### PR TITLE
Replace the all-red highlighted messages with a dot marker

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -1026,6 +1026,22 @@ kbd {
 	position: relative;
 }
 
+#chat .channel .message.highlight::before {
+	display: inline-block;
+	content: " ";
+	background: #e74c3c;
+	height: 16px;
+	min-width: 16px;
+	border-radius: 8px;
+	margin-top: 5px;
+	margin-left: 10px;
+	margin-right: -5px;
+}
+
+#chat .channel .message.highlight .from {
+	width: 113px; /* 134px original - 5px margin - 16px highlight dot width */
+}
+
 #chat .content {
 	flex: 1 1 auto;
 	min-width: 0;
@@ -1174,11 +1190,8 @@ kbd {
 }
 
 #chat .error,
-#chat .error .from,
-#chat .channel .highlight .from,
-#chat .channel .highlight .text,
-#chat .channel .highlight .user {
-	color: #f00;
+#chat .error .from {
+	color: #e74c3c;
 }
 
 #chat .toggle-button.opened, /* Thumbnail toggle */
@@ -2241,6 +2254,12 @@ part/quit messages where we don't load previews (adds a blank line otherwise) */
 	#chat .messages {
 		display: block;
 		padding: 5px 10px;
+	}
+
+	#chat .channel .message.highlight::before {
+		margin: 0;
+		height: 12px;
+		min-width: 12px;
 	}
 
 	#chat .msg {


### PR DESCRIPTION
This re-uses the shape and color of the notification dot.

Browser | Mobile
--- | ---
<img width="416" alt="screen shot 2017-12-16 at 17 16 04" src="https://user-images.githubusercontent.com/113730/34074792-eec6acb6-e284-11e7-957d-dcde36f7b7c2.png"> | <img width="288" alt="screen shot 2017-12-16 at 17 16 18" src="https://user-images.githubusercontent.com/113730/34074793-eed1ec70-e284-11e7-8b7b-409875b1b033.png">

This can definitely use some CSS tweaking.
What do people think?

Marking as v3 if it makes it because it's sufficiently disrupting...