### PR TITLE
Replace current highlight with a highlight on entire message

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -1174,11 +1174,20 @@ kbd {
 }
 
 #chat .error,
-#chat .error .from,
-#chat .channel .highlight .from,
-#chat .channel .highlight .text,
-#chat .channel .highlight .user {
-	color: #f00;
+#chat .error .from {
+	color: #e74c3c;
+}
+
+#chat .channel .message.highlight {
+	background-color: rgba(231, 76, 60, 0.5);
+}
+
+#chat .channel .message.highlight .from {
+	border-right: 1px solid rgba(231, 76, 60, 0.5);
+}
+
+#chat .channel .message.highlight .from::after {
+	background: transparent;
 }
 
 #chat .toggle-button.opened, /* Thumbnail toggle */
@@ -2243,6 +2252,13 @@ part/quit messages where we don't load previews (adds a blank line otherwise) */
 		padding: 5px 10px;
 	}
 
+	#chat .channel .message.highlight {
+		margin-left: -10px;
+		margin-right: -10px;
+		padding-left: 10px;
+		padding-right: 10px;
+	}
+
 	#chat .msg {
 		display: block;
 		padding: 2px 0;
@@ -2250,6 +2266,7 @@ part/quit messages where we don't load previews (adds a blank line otherwise) */
 
 	#chat .time,
 	#chat .from,
+	#chat .channel .message.highlight .from,
 	#chat .content {
 		border: 0;
 		display: inline;

--- a/client/themes/morning.css
+++ b/client/themes/morning.css
@@ -166,11 +166,16 @@ body {
 }
 
 #chat .error,
-#chat .error .from,
-#chat .channel .highlight,
-#chat .channel .highlight .from,
-#chat .channel .highlight .text {
+#chat .error .from {
 	color: #f92772;
+}
+
+#chat .channel .message.highlight {
+	background-color: #f9277280;
+}
+
+#chat .channel .message.highlight .from {
+	border-right: 1px solid  #f9277280;
 }
 
 #chat .unhandled .from {

--- a/client/themes/zenburn.css
+++ b/client/themes/zenburn.css
@@ -192,11 +192,16 @@ body {
 }
 
 #chat .error,
-#chat .error .from,
-#chat .channel .highlight,
-#chat .channel .highlight .from,
-#chat .channel .highlight .text {
+#chat .error .from {
 	color: #bc6c4c;
+}
+
+#chat .channel .message.highlight {
+	background-color: #bc6c4c80;
+}
+
+#chat .channel .message.highlight .from {
+	border-right: 1px solid  #bc6c4c80;
 }
 
 #chat .unhandled .from {


### PR DESCRIPTION
This is an alternative attempt at #1846.
So far I prefer the other result, but that's a personal preference. Also it seems like there will be more color-related issues with this way of doing so, which does not bode well with accessibility.

Browser | Mobile
--- | ---
<img width="1152" alt="screen shot 2017-12-16 at 17 54 44" src="https://user-images.githubusercontent.com/113730/34075116-befa0b1c-e28a-11e7-9d27-ac9b8f6ec9b0.png"> | <img width="495" alt="screen shot 2017-12-16 at 17 54 59" src="https://user-images.githubusercontent.com/113730/34075118-c20c6296-e28a-11e7-899b-9ee29824d484.png">

At the moment the fading-out gradient for long nick is broken with this. I'll try to fix it if that's what we go with.