### PR TITLE
Optional syncing of client settings. 

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -223,6 +223,7 @@ kbd {
 #chat .title::before,
 #footer .icon,
 #chat .count::before,
+#settings .extra-experimental,
 #settings .extra-help,
 #settings #play::before,
 #form #submit::before,
@@ -399,6 +400,10 @@ kbd {
 	right: 18px;
 	font-size: 14px;
 	line-height: 50px;
+}
+
+#settings .extra-experimental::before {
+	content: "\f0c3"; /* https://fontawesome.com/icons/flask?style=solid */
 }
 
 #settings .extra-help::before {
@@ -1565,6 +1570,10 @@ part/quit messages where we don't load previews (adds a blank line otherwise) */
 	margin-top: 30px;
 }
 
+#settings .sync-warning-base {
+	display: none;
+}
+
 #settings .opt {
 	display: block;
 	padding: 5px 0 5px 1px;
@@ -1574,15 +1583,21 @@ part/quit messages where we don't load previews (adds a blank line otherwise) */
 	margin-right: 6px;
 }
 
+#settings .extra-experimental {
+	color: #84ce88;
+}
+
 #settings .extra-help,
 #settings #play {
 	color: #7f8c8d;
 }
 
+#settings .extra-experimental,
 #settings .extra-help {
 	cursor: help;
 }
 
+#settings .extra-experimental,
 #settings h2 .extra-help {
 	font-size: 0.8em;
 }

--- a/client/js/autocompletion.js
+++ b/client/js/autocompletion.js
@@ -10,16 +10,16 @@ const constants = require("./constants");
 
 const input = $("#input");
 let textcomplete;
+let enabled = false;
 
 module.exports = {
 	enable: enableAutocomplete,
 	disable: () => {
-		input.off("input.tabcomplete");
-		Mousetrap(input.get(0)).off("tab", "keydown");
-
-		if (textcomplete) {
+		if (enabled) {
+			input.off("input.tabcomplete");
+			Mousetrap(input.get(0)).off("tab", "keydown");
 			textcomplete.destroy();
-			textcomplete = null;
+			enabled = false;
 		}
 	},
 };
@@ -63,7 +63,7 @@ const nicksStrategy = {
 	},
 	replace([, original], position = 1) {
 		// If no postfix specified, return autocompleted nick as-is
-		if (!options.nickPostfix) {
+		if (!options.settings.nickPostfix) {
 			return original;
 		}
 
@@ -73,7 +73,7 @@ const nicksStrategy = {
 		}
 
 		// If nick is first in the input, append specified postfix
-		return original + options.nickPostfix;
+		return original + options.settings.nickPostfix;
 	},
 	index: 1,
 };
@@ -169,6 +169,7 @@ const backgroundColorStrategy = {
 };
 
 function enableAutocomplete() {
+	enabled = true;
 	let tabCount = 0;
 	let lastMatch = "";
 	let currentMatches = [];

--- a/client/js/libs/handlebars/tz.js
+++ b/client/js/libs/handlebars/tz.js
@@ -5,6 +5,6 @@ const constants = require("../../constants");
 
 module.exports = function(time) {
 	const options = require("../../options");
-	const format = options.showSeconds ? constants.timeFormats.msgWithSeconds : constants.timeFormats.msgDefault;
+	const format = options.settings.showSeconds ? constants.timeFormats.msgWithSeconds : constants.timeFormats.msgDefault;
 	return moment(time).format(format);
 };

--- a/client/js/socket-events/configuration.js
+++ b/client/js/socket-events/configuration.js
@@ -7,7 +7,7 @@ const options = require("../options");
 const webpush = require("../webpush");
 
 socket.on("configuration", function(data) {
-	if (!options.initialize) {
+	if (options.initialized) {
 		return;
 	}
 

--- a/client/js/socket-events/index.js
+++ b/client/js/socket-events/index.js
@@ -20,3 +20,4 @@ require("./sign_out");
 require("./sessions_list");
 require("./configuration");
 require("./changelog");
+require("./setting");

--- a/client/js/socket-events/msg.js
+++ b/client/js/socket-events/msg.js
@@ -124,9 +124,9 @@ function notifyMessage(targetId, channel, msg) {
 
 	const button = sidebar.find(".chan[data-id='" + targetId + "']");
 
-	if (msg.highlight || (options.notifyAllMessages && msg.type === "message")) {
+	if (msg.highlight || (options.settings.notifyAllMessages && msg.type === "message")) {
 		if (!document.hasFocus() || !channel.hasClass("active")) {
-			if (options.notification) {
+			if (options.settings.notification) {
 				try {
 					pop.play();
 				} catch (exception) {
@@ -136,7 +136,7 @@ function notifyMessage(targetId, channel, msg) {
 
 			utils.toggleNotificationMarkers(true);
 
-			if (options.desktopNotifications && Notification.permission === "granted") {
+			if (options.settings.desktopNotifications && ("Notification" in window) && Notification.permission === "granted") {
 				let title;
 				let body;
 

--- a/client/js/socket-events/setting.js
+++ b/client/js/socket-events/setting.js
@@ -1,0 +1,28 @@
+"use strict";
+
+const socket = require("../socket");
+const options = require("../options");
+
+function evaluateSetting(name, value) {
+	if (options.settings.syncSettings && options.settings[name] !== value && !options.noSync.includes(name)) {
+		options.processSetting(name, value, true);
+	} else if (options.alwaysSync.includes(name)) {
+		options.processSetting(name, value, true);
+	}
+}
+
+socket.on("setting:new", function(data) {
+	const name = data.name;
+	const value = data.value;
+	evaluateSetting(name, value);
+});
+
+socket.on("setting:all", function(settings) {
+	if (Object.keys(settings).length === 0) {
+		options.noServerSettings();
+	} else {
+		for (const name in settings) {
+			evaluateSetting(name, settings[name]);
+		}
+	}
+});

--- a/client/js/sorting.js
+++ b/client/js/sorting.js
@@ -30,7 +30,7 @@ module.exports = function() {
 				}
 			);
 
-			options.ignoreSortSync = true;
+			options.settings.ignoreSortSync = true;
 		},
 	});
 	sidebar.find(".network").sortable({
@@ -58,7 +58,7 @@ module.exports = function() {
 				}
 			);
 
-			options.ignoreSortSync = true;
+			options.settings.ignoreSortSync = true;
 		},
 	});
 };

--- a/client/views/windows/settings.tpl
+++ b/client/views/windows/settings.tpl
@@ -5,6 +5,22 @@
 	<h1 class="title">Settings</h1>
 
 	<div class="row">
+		{{#unless public}}
+		<div class="col-sm-12">
+			<h2>
+				Settings synchronisation
+				<span class="tooltipped tooltipped-n tooltipped-no-delay" aria-label="Note: This is an experimental feature and may change in future releases.">
+					<button class="extra-experimental" aria-label="Note: This is an experimental feature and may change in future releases."></button>
+				</span>
+			</h2>
+			<label class="opt">
+				<input type="checkbox" name="syncSettings">
+				Synchronize settings with other clients.
+			</label>
+			<p class="sync-warning-override"><strong>Warning</strong> Checking this box will override the settings of this client with those stored on the server.</p>
+			<p class="sync-warning-base"><strong>Warning</strong> No settings have been synced before. Enabling this will sync all settings of this client as the base for other clients.</p>
+		</div>
+		{{/unless}}
 		<div class="col-sm-12">
 			<h2>Messages</h2>
 		</div>

--- a/src/clientManager.js
+++ b/src/clientManager.js
@@ -116,6 +116,7 @@ ClientManager.prototype.addUser = function(name, password, enableLog) {
 		awayMessage: "",
 		networks: [],
 		sessions: {},
+		clientSettings: {},
 	};
 
 	try {

--- a/src/server.js
+++ b/src/server.js
@@ -441,6 +441,44 @@ function initializeClient(socket, client, token, lastMessage) {
 
 	socket.on("sessions:get", sendSessionList);
 
+	if (!Helper.config.public) {
+		socket.on("setting:set", (newSetting) => {
+			if (!newSetting || typeof newSetting !== "object") {
+				return;
+			}
+
+			// Older user configs will not have the clientSettings property.
+			if (!client.config.hasOwnProperty("clientSettings")) {
+				client.config.clientSettings = {};
+			}
+
+			// We do not need to do write operations and emit events if nothing changed.
+			if (client.config.clientSettings[newSetting.name] !== newSetting.value) {
+				client.config.clientSettings[newSetting.name] = newSetting.value;
+
+				// Pass the setting to all clients.
+				client.emit("setting:new", {
+					name: newSetting.name,
+					value: newSetting.value,
+				});
+
+				client.manager.updateUser(client.name, {
+					clientSettings: client.config.clientSettings,
+				});
+			}
+		});
+
+		socket.on("setting:get", () => {
+			if (!client.config.hasOwnProperty("clientSettings")) {
+				socket.emit("setting:all", {});
+				return;
+			}
+
+			const clientSettings = client.config.clientSettings;
+			socket.emit("setting:all", clientSettings);
+		});
+	}
+
 	socket.on("sign-out", (tokenToSignOut) => {
 		// If no token provided, sign same client out
 		if (!tokenToSignOut) {


### PR DESCRIPTION
This provides syncing as detailed in #1825. Some demonstrations

- [General behavior of syncing and unchecking the box.](http://creesch.com/dump/vid/vid_5a3432fc0f6dc.mp4)
- [Enabling sync for the very first time](https://www.creesch.com/dump/vid/vid_5a3692e0339c4.mp4)

## Note on always syncing some settings. 

This PR includes the ability to make some settings mandatory to sync regardless of syncing in general being on or not. This works fine, however I didn't include any settings as migration is a consideration. The ability was requested in relation to custom highlights, not working for people with push enabled.  So when people have no push enabled then it isn't broken to them.  Meaning that it is likely that some people have explicitly set it differently in different clients, which means that a migration strategy is needed. 

Because the goal of this PR is to implement syncing in general first I decided to not turn mandatory sync yet. I left the ability in as the goal of this PR is to have a basis to work on from here on out. 

## options.js refactoring 
In addition this PR also reworks `client/js/options.js` to be more reliable, easier to understand and generally more robust. Functionality that was all randomly called on has been divided in separate functions: 

- Initialization 
- Processing 
- Saving 
- Applying 

Meaning that settings are now actually only saved and applied when things actually change. Before it could easily happen that when nothing was actually changed in settings there still would be multiple write actions and attempts at applying settings to the client where it was not needed. 

It also changes the `module.exports` object to separate user settings from other information and functions, potentially preventing outside modules from accidentally overwriting settings. 


Making options.js robust enough to be able to handle synced settings was the biggest part of the work that needed to be done. 