### PR TITLE
Add custom focus outlines for inputs and green buttons

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -100,10 +100,6 @@ h3 {
 	margin: 0;
 }
 
-input {
-	outline: 0;
-}
-
 button {
 	border: none;
 	background: none;
@@ -172,7 +168,7 @@ kbd {
 	margin-bottom: 10px;
 	padding: 9px 17px;
 	text-transform: uppercase;
-	transition: background 0.2s, border-color 0.2s, color 0.2s;
+	transition: background 0.2s, border-color 0.2s, color 0.2s, box-shadow 0.2s;
 	word-spacing: 3px;
 	cursor: pointer; /* This is useful for `<button>` elements */
 }
@@ -189,8 +185,14 @@ kbd {
 	opacity: 1;
 }
 
+.input:focus,
+.btn:active,
+.btn:focus {
+	outline: 0;
+	box-shadow: 0 0 0 3px rgba(132, 206, 136, 0.5);
+}
+
 .btn:active {
-	box-shadow: none;
 	opacity: 0.8;
 }
 
@@ -877,9 +879,8 @@ background on hover (unless active) */
 	font-size: 14px;
 	margin: 2px 0;
 	margin-bottom: 10px;
-	outline: 0;
 	padding: 0 10px;
-	transition: border-color 0.2s;
+	transition: border-color 0.2s, box-shadow 0.2s;
 	width: 100%;
 	height: 35px;
 	line-height: 35px;
@@ -891,7 +892,7 @@ background on hover (unless active) */
 
 .input:not(:disabled):hover,
 .input:not(:disabled):focus {
-	border-color: #79838c;
+	border-color: #84ce88;
 }
 
 #user-specified-css-input {
@@ -2103,7 +2104,7 @@ part/quit messages where we don't load previews (adds a blank line otherwise) */
 #chat .userlist .user.active {
 	background-color: #f6f6f6;
 	transition: none;
-	outline: 0; /* TODO: Handle focus outlines in PR #1873 */
+	outline: 0;
 }
 
 .context-menu-item::before,


### PR DESCRIPTION
Ref https://github.com/thelounge/lounge/issues/1872

We were automatically silencing outlines for all buttons and inputs, even though we really meant `.btn`s and `.input`s where we had some custom UI on hover only. I have added an outline on focus on those specifically, not on everything.

This is clearly not perfect, but I think it's much better. I prioritized on things that get focus naturally, like form inputs, but did not apply this to all keyboard-navigable elements (like font-icon buttons). The most important aspect of it is that now we do not remove outlines by default on elements, so tabbing through font-icon buttons, if not super pretty, is at least visible.

⚠️ It looks ugly on themes at the moment, test on `Example`. If that seems okay to you, I'll apply the changes to the themes.

<img width="501" alt="screen shot 2017-12-21 at 19 12 53" src="https://user-images.githubusercontent.com/113730/34280219-554d8e20-e684-11e7-9115-9170ce724eb7.png">
<img width="490" alt="screen shot 2017-12-21 at 19 13 03" src="https://user-images.githubusercontent.com/113730/34280220-557f0f72-e684-11e7-8de1-052c890c6001.png">
<img width="482" alt="screen shot 2017-12-21 at 19 13 10" src="https://user-images.githubusercontent.com/113730/34280221-55b8f19c-e684-11e7-8fed-fa4296a8974e.png">

### TODO

- [ ] Built-in themes
- [ ] Icon buttons (any ideas?)