### PR TITLE
Let user know someone is making a CTCP request against their nick

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -236,6 +236,7 @@ kbd {
 #chat .topic .from::before,
 #chat .mode .from::before,
 #chat .ctcp .from::before,
+#chat .ctcp_request .from::before,
 #chat .whois .from::before,
 #chat .nick .from::before,
 #chat .action .from::before,
@@ -351,7 +352,8 @@ kbd {
 	color: #2ecc40;
 }
 
-#chat .ctcp .from::before {
+#chat .ctcp .from::before,
+#chat .ctcp_request .from::before {
 	content: "\f0f6"; /* http://fontawesome.io/icon/file-text-o/ */
 }
 

--- a/client/views/actions/ctcp_request.tpl
+++ b/client/views/actions/ctcp_request.tpl
@@ -1,2 +1,3 @@
 {{> ../user_name from}}
+sent a <abbr title="Client-to-client_protocol">CTCP</abbr> request:
 <span class="ctcp-message">{{{parse ctcpMessage}}}</span>

--- a/src/models/msg.js
+++ b/src/models/msg.js
@@ -62,6 +62,7 @@ Msg.Type = {
 	PART: "part",
 	QUIT: "quit",
 	CTCP: "ctcp",
+	CTCP_REQUEST: "ctcp_request",
 	CHGHOST: "chghost",
 	TOPIC: "topic",
 	TOPIC_SET_BY: "topic_set_by",

--- a/src/plugins/irc-events/ctcp.js
+++ b/src/plugins/irc-events/ctcp.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const _ = require("lodash");
 const Helper = require("../../helper");
 const Msg = require("../../models/msg");
 const User = require("../../models/user");
@@ -35,7 +36,8 @@ module.exports = function(irc, network) {
 		chan.pushMessage(client, msg);
 	});
 
-	irc.on("ctcp request", (data) => {
+	// Limit requests to a rate of one per second max
+	irc.on("ctcp request", _.throttle((data) => {
 		const response = ctcpResponses[data.type];
 
 		if (response) {
@@ -51,5 +53,5 @@ module.exports = function(irc, network) {
 			ctcpMessage: data.message,
 		});
 		lobby.pushMessage(client, msg);
-	});
+	}, 1000, {trailing: false}));
 };


### PR DESCRIPTION
I'm still wrapping my head around CTCP so I may have overlooked some aspect of this.

<img width="521" alt="screen shot 2018-01-02 at 00 29 35" src="https://user-images.githubusercontent.com/113730/34474937-0e6e351c-ef54-11e7-9fe3-3344ed5028d0.png">

This screenshot is the result of a user CTCPing themselves, which is rather uninteresting, but this obviously also works when someone else makes a request about them.