### PR TITLE
Make channel list slideout trigger when starting dragging on the left half of the screen.

### DIFF
--- a/client/js/libs/slideout.js
+++ b/client/js/libs/slideout.js
@@ -31,7 +31,7 @@ module.exports = function slideoutMenu(viewport, menu) {
 
 		menuWidth = parseFloat(window.getComputedStyle(menu).width);
 
-		if ((!menuIsOpen && touch.screenX < 50) || (menuIsOpen && touch.screenX > menuWidth)) {
+		if (!menuIsOpen || (menuIsOpen && touch.screenX > menuWidth)) {
 			touchStartPos = touch;
 			touchCurPos = touch;
 			touchStartTime = Date.now();


### PR DESCRIPTION
This makes it easier to drag the channel list out on e.g. iOS, whereas the current approach often results in the Safari previous page gesture.