### PR TITLE
Allow generating random numbers in nick on page load

### DIFF
--- a/defaults/config.js
+++ b/defaults/config.js
@@ -240,17 +240,17 @@ module.exports = {
 		// For example, Guest%%% will become Guest123 on page load.
 		//
 		// @type     string
-		// @default  "lounge-user"
+		// @default  "thelounge%%"
 		//
-		nick: "lounge-user",
+		nick: "thelounge%%",
 
 		//
 		// Username
 		//
 		// @type     string
-		// @default  "lounge-user"
+		// @default  "thelounge"
 		//
-		username: "lounge-user",
+		username: "thelounge",
 
 		//
 		// Real Name

--- a/defaults/config.js
+++ b/defaults/config.js
@@ -236,6 +236,9 @@ module.exports = {
 		//
 		// Nick
 		//
+		// Percent sign (%) will be replaced into a random number from 0 to 9.
+		// For example, Guest%%% will become Guest123 on page load.
+		//
 		// @type     string
 		// @default  "lounge-user"
 		//

--- a/src/server.js
+++ b/src/server.js
@@ -521,7 +521,7 @@ function getClientConfiguration() {
 	config.themes = themes.getAll();
 
 	if (config.displayNetwork) {
-		config.defaults = Helper.config.defaults;
+		config.defaults = _.clone(Helper.config.defaults);
 	} else {
 		// Only send defaults that are visible on the client
 		config.defaults = _.pick(Helper.config.defaults, [
@@ -532,6 +532,8 @@ function getClientConfiguration() {
 			"join",
 		]);
 	}
+
+	config.defaults.nick = config.defaults.nick.replace(/%/g, () => Math.floor(Math.random() * 10));
 
 	return config;
 }


### PR DESCRIPTION
Very useful in public mode. No need to rely on `nick in use` to generate random.