### PR TITLE
Change wsEngine to "ws"

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -141,6 +141,7 @@ module.exports = function() {
 		}
 
 		const sockets = io(server, {
+			wsEngine: "ws",
 			serveClient: false,
 			transports: Helper.config.transports,
 		});


### PR DESCRIPTION
uWS causes major delays - https://github.com/socketio/socket.io/issues/3100

They also reverted the default in engine.io - https://github.com/socketio/engine.io/commit/b1fa020675d905905b6f07d0a6b5acff775c4be5