### PR TITLE
Always correctly trigger sticky scroll on .chat container

### DIFF
--- a/client/js/render.js
+++ b/client/js/render.js
@@ -217,7 +217,7 @@ function renderNetworks(data, singleNetwork) {
 						container.find(".show-more").addClass("show");
 					}
 
-					container.trigger("keepToBottom");
+					container.parent().trigger("keepToBottom");
 				}
 			} else {
 				newChannels.push(channel);

--- a/client/js/renderPreview.js
+++ b/client/js/renderPreview.js
@@ -55,7 +55,7 @@ function appendPreview(preview, msg, template) {
 		return;
 	}
 
-	const container = msg.closest(".messages");
+	const container = msg.closest(".chat");
 	const channelId = container.closest(".chan").data("id") || -1;
 	const activeChannelId = chat.find(".chan.active").data("id") || -2;
 

--- a/client/js/socket-events/msg.js
+++ b/client/js/socket-events/msg.js
@@ -48,6 +48,7 @@ function processReceivedMessage(data) {
 		}
 	}
 
+	const scrollContainer = channel.find(".chat");
 	const container = channel.find(".messages");
 	const activeChannelId = chat.find(".chan.active").data("id");
 
@@ -64,7 +65,7 @@ function processReceivedMessage(data) {
 	);
 
 	if (activeChannelId === targetId) {
-		container.trigger("keepToBottom");
+		scrollContainer.trigger("keepToBottom");
 	}
 
 	notifyMessage(targetId, channel, data);
@@ -91,7 +92,7 @@ function processReceivedMessage(data) {
 	if (activeChannelId !== targetId) {
 		// If message arrives in non active channel, keep only 100 messages
 		messageLimit = 100;
-	} else if (container.isScrollBottom()) {
+	} else if (scrollContainer.isScrollBottom()) {
 		// If message arrives in active channel, keep 500 messages if scroll is currently at the bottom
 		messageLimit = 500;
 	}


### PR DESCRIPTION
`.chat` has the overflow on it, and not `.messages` so stuff like scrollTop only works on `.chat`