### PR TITLE
Fix "rendering..." getting stuck on first connection

### DIFF
--- a/client/js/socket-events/init.js
+++ b/client/js/socket-events/init.js
@@ -30,11 +30,11 @@ socket.on("init", function(data) {
 		render.renderNetworks(data);
 	}
 
-	if (lastMessageId > -1) {
-		$("#connection-error").removeClass("shown");
-		$(".show-more-button, #input").prop("disabled", false);
-		$("#submit").show();
-	} else {
+	$("#connection-error").removeClass("shown");
+	$(".show-more-button, #input").prop("disabled", false);
+	$("#submit").show();
+
+	if (lastMessageId < 0) {
 		if (data.token) {
 			storage.set("token", data.token);
 		}


### PR DESCRIPTION
The bug is quite simple, if on the first socket connection it fails, disconnect handler will display the red banner and disable input and when the connection finally succeeds they do not get removed because that code didn't run on the first init (assumption was that it's a clean state).