### PR TITLE
Channel leave button tooltip to correspond with right click context menu

### DIFF
--- a/client/views/chan.tpl
+++ b/client/views/chan.tpl
@@ -15,8 +15,8 @@
 	{{/equal}}
 	<span class="badge{{#if highlight}} highlight{{/if}}">{{#if unread}}{{roundBadgeNumber unread}}{{/if}}</span>
 	{{#notEqual type "lobby"}}
-		<span class="close-tooltip tooltipped tooltipped-w" aria-label="Close">
-			<button class="close" aria-label="Close"></button>
+		<span class="close-tooltip tooltipped tooltipped-w" aria-label="Leave">
+			<button class="close" aria-label="Leave"></button>
 		</span>
 	{{/notEqual}}
 	<span class="name" title="{{name}}">{{name}}</span>


### PR DESCRIPTION
Currently X button tooltip for channels says "Close", while right click context menu says "Leave". It sounds more normal to leave a channel, and therefor updating the X button tooltip to say leave as well. This makes it more consistent.

![capture](https://user-images.githubusercontent.com/11909212/36637059-0efa92fa-19d4-11e8-89d7-af1e380811a2.PNG)

Thanks to @MaxLeiter on IRC for the help to make this PR.