### PR TITLE
Point download badge to npm-stat instead of npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 	<a href="https://david-dm.org/thelounge/thelounge"><img
 		alt="Dependencies Status"
 		src="https://img.shields.io/david/thelounge/thelounge.svg?style=flat-square"></a>
-	<a href="https://www.npmjs.org/package/thelounge"><img
+	<a href="https://npm-stat.com/charts.html?package=thelounge&from=2016-02-12"><img
 		alt="Total downloads on npm"
 		src="https://img.shields.io/npm/dt/thelounge.svg?colorB=007dc7&style=flat-square"></a>
 </p>


### PR DESCRIPTION
Follow-up of #2003.
12 February 2016 is the release date of v1.0.0: https://github.com/thelounge/lounge/releases/tag/v1.0.0
Without this date, npm-stat shows 1y reports by default.

(Note that there is currently a bug with shields.io total download report, but that's irrelevant here: https://github.com/badges/shields/issues/1278)