### PR TITLE
Revert "Allow scaling the page"

### DIFF
--- a/client/index.html.tpl
+++ b/client/index.html.tpl
@@ -3,7 +3,7 @@
 	<head>
 
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<meta name="viewport" content="width=device-width, user-scalable=no">
 
 	<link rel="preload" as="script" href="js/bundle.vendor.js">
 	<link rel="preload" as="script" href="js/bundle.js">


### PR DESCRIPTION
Reverts thelounge/thelounge#1910
Fixes https://github.com/thelounge/thelounge/issues/2120

It's pretty unfortunate that we have to do this, but on iOS this is not going well at all.
I'm open to trying other settings if anyone wants to help, but I think first step is to revert to go back to an OK state, and then we can iterate.