### PR TITLE
Don't render mode in usernames on userlist

### DIFF
--- a/client/js/render.js
+++ b/client/js/render.js
@@ -172,6 +172,7 @@ function renderChannelUsers(data) {
 		.find(".search")
 		.prop("placeholder", nicks.length + " " + (nicks.length === 1 ? "user" : "users"));
 
+	data.users.forEach((user) => user.dontRenderMode = true);
 	users
 		.data("nicks", nicks)
 		.find(".names-original")

--- a/client/views/user_name.tpl
+++ b/client/views/user_name.tpl
@@ -1,1 +1,1 @@
-<span role="button" class="user {{colorClass nick}}" data-name="{{nick}}">{{mode}}{{nick}}</span>
+<span role="button" class="user {{colorClass nick}}" data-name="{{nick}}">{{#unless dontRenderMode}}{{mode}}{{/unless}}{{nick}}</span>


### PR DESCRIPTION
I'd really like to explore methods of removing IRC-specific jargon out of the UI. I'm almost tempted to also remove modes from the message list. 

I'm sure this will get pushback, but thoughts?

<img src="https://sr.ht/5-pv.png" height="300" width="300"></img>