### PR TITLE
Remove unintentionally included lodash in client build

### DIFF
--- a/client/js/condensed.js
+++ b/client/js/condensed.js
@@ -1,6 +1,5 @@
 "use strict";
 
-const _ = require("lodash");
 const constants = require("./constants");
 const templates = require("../views");
 
@@ -22,8 +21,8 @@ function getStoredTypes(condensed) {
 function updateText(condensed, addedTypes) {
 	const obj = getStoredTypes(condensed);
 
-	_.forOwn(addedTypes, (count, type) => {
-		obj[type] += count;
+	Object.keys(addedTypes).map((type) => {
+		obj[type] += addedTypes[type];
 		condensed.data(type, obj[type]);
 	});
 


### PR DESCRIPTION
lodash is *huge*, we don't want to include it for no reason.