### PR TITLE
Change ctrl/command up/down to alt/option up/down to align with other apps

### DIFF
--- a/client/js/keybinds.js
+++ b/client/js/keybinds.js
@@ -37,8 +37,8 @@ Mousetrap.bind([
 });
 
 Mousetrap.bind([
-	"mod+up",
-	"mod+down",
+	"alt+up",
+	"alt+down",
 ], function(e, keys) {
 	const channels = sidebar.find(".chan");
 	const index = channels.index(channels.filter(".active"));

--- a/client/views/windows/help.tpl
+++ b/client/views/windows/help.tpl
@@ -49,7 +49,7 @@
 
 	<div class="help-item">
 		<div class="subject">
-			<kbd class="key-all">Ctrl</kbd><kbd class="key-apple">⌘</kbd> + <kbd>↑</kbd> / <kbd>↓</kbd>
+			<kbd class="key-all">Alt</kbd><kbd class="key-apple">⌥</kbd> + <kbd>↑</kbd> / <kbd>↓</kbd>
 		</div>
 		<div class="description">
 			<p>Switch to the previous/next window in the channel list.</p>


### PR DESCRIPTION
In my investigation, Slack, Facebook messenger, and discord all use alt instead of ctrl for moving up and down channels. I think it would be good to align ourselves as it can be confusing when moving between apps.

If we agree to do this, we can either go nuclear and just change it. Or we can keep ctrl as well as alt for a while, and then remove it, or we can keep them both indefinitely.

Thoughts?