### PR TITLE
Increase test timeout on CI

### DIFF
--- a/test/server.js
+++ b/test/server.js
@@ -6,7 +6,9 @@ const request = require("request");
 const io = require("socket.io-client");
 
 describe("Server", function() {
-	this.timeout(5000);
+	// Travis is having issues with slow workers and thus tests timeout
+	this.timeout(process.env.CI ? 25000 : 5000);
+
 	let server;
 	let originalLogInfo;
 


### PR DESCRIPTION
Travis is really having some issues with very slow builds (there's plenty of issues on their tracker), tests never fail on AppVeyor.