### PR TITLE
Bring back line-height on messages

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -887,6 +887,7 @@ kbd {
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
+	font-size: 14px;
 }
 
 #windows .window .header {
@@ -972,10 +973,10 @@ kbd {
 }
 
 #windows #form .input,
-#windows .header .topic,
 .messages .msg,
 .sidebar {
 	font-size: 14px;
+	line-height: 1.4;
 }
 
 #windows #chat .header {


### PR DESCRIPTION
Was removed in c051b705375c838d189d3dec7aa74c80794bb356, but this affected line height on mobile view due to increased font size