### PR TITLE
Set channel state to joined when channel already exists

### DIFF
--- a/src/plugins/irc-events/join.js
+++ b/src/plugins/irc-events/join.js
@@ -24,6 +24,8 @@ module.exports = function(irc, network) {
 
 			// Request channels' modes
 			network.irc.raw("MODE", chan.name);
+		} else if (data.nick === irc.user.nick) {
+			chan.state = Chan.State.JOINED;
 		}
 
 		const user = new User({nick: data.nick});


### PR DESCRIPTION
Fixes #2141
Fixes #2103

Channel objects can be created before `join` event which causes them to never get `JOINED` state. If joined state is not, `part` is never sent for that channel whenever user tries to leave it.

This can be reproduced by joining a channel in connect window (e.g. `#thelounge-spam` in demo).