### PR TITLE
Warn about old config folder

### DIFF
--- a/src/command-line/index.js
+++ b/src/command-line/index.js
@@ -35,6 +35,8 @@ if (!fs.existsSync(path.join(
 
 Helper.setHome(process.env.THELOUNGE_HOME || Utils.defaultHome());
 
+Utils.checkOldHome();
+
 // Merge config key-values passed as CLI options into the main config
 _.merge(Helper.config, program.config);
 

--- a/src/command-line/utils.js
+++ b/src/command-line/utils.js
@@ -20,6 +20,23 @@ class Utils {
 		].forEach((e) => log.raw(e));
 	}
 
+	// TODO: Remove in a couple of releases
+	static checkOldHome() {
+		const currentHome = Helper.getHomePath();
+		const oldHome = currentHome.replace(/\.thelounge$/, ".lounge");
+
+		if (currentHome === oldHome || !fs.existsSync(oldHome)) {
+			return;
+		}
+
+		console.log(); // eslint-disable-line no-console
+		log.warn(`Folder ${colors.bold.red(oldHome)} still exists.`);
+		log.warn(`In v3, we renamed the default configuration folder to ${colors.bold.green(".thelounge")} for consistency.`);
+		log.warn(`You might want to rename the folder from ${colors.bold.red(".lounge")} to ${colors.bold.green(".thelounge")} to keep existing configuration.`);
+		log.warn("Make sure to look at the release notes to see other breaking changes.");
+		console.log(); // eslint-disable-line no-console
+	}
+
 	static defaultHome() {
 		if (home) {
 			return home;


### PR DESCRIPTION
We didn't warn about the folder rename in 2.x releases.