### PR TITLE
Insert channel/user into channel list at alphabetically sorted point, not just the end

### DIFF
--- a/client/js/socket-events/join.js
+++ b/client/js/socket-events/join.js
@@ -10,11 +10,12 @@ const sidebar = $("#sidebar");
 socket.on("join", function(data) {
 	const id = data.network;
 	const network = sidebar.find(`#network-${id}`);
-	network.append(
-		templates.chan({
-			channels: [data.chan],
-		})
-	);
+	const channels = network.children();
+	const position = $(channels[data.index || channels.length - 1]); // Put channel in correct position, or the end if we don't have one
+	const sidebarEntry = templates.chan({
+		channels: [data.chan],
+	});
+	$(sidebarEntry).insertAfter(position);
 	chat.append(
 		templates.chat({
 			channels: [data.chan],

--- a/src/models/network.js
+++ b/src/models/network.js
@@ -128,6 +128,28 @@ Network.prototype.getNetworkStatus = function() {
 	return status;
 };
 
+Network.prototype.addChannel = function(newChan) {
+	let index = this.channels.length; // Default to putting as the last item in the array
+
+	// Don't sort special channels in amongst channels/users.
+	if (newChan.type === Chan.Type.CHANNEL || newChan.type === Chan.Type.QUERY) {
+		// We start at 1 so we don't test against the lobby
+		for (let i = 1; i < this.channels.length; i++) {
+			const compareChan = this.channels[i];
+
+			// Negative if the new chan is alphabetically before the next chan in the list, positive if after
+			if (newChan.name.localeCompare(compareChan.name, {sensitivity: "base"}) <= 0
+				|| (compareChan.type !== Chan.Type.CHANNEL && compareChan.type !== Chan.Type.QUERY)) {
+				index = i;
+				break;
+			}
+		}
+	}
+
+	this.channels.splice(index, 0, newChan);
+	return index;
+};
+
 Network.prototype.export = function() {
 	const network = _.pick(this, [
 		"uuid",

--- a/src/plugins/inputs/query.js
+++ b/src/plugins/inputs/query.js
@@ -47,11 +47,12 @@ exports.input = function(network, chan, cmd, args) {
 		type: Chan.Type.QUERY,
 		name: target,
 	});
-	network.channels.push(newChan);
+
 	this.emit("join", {
 		network: network.id,
 		chan: newChan.getFilteredClone(true),
 		shouldOpen: true,
+		index: network.addChannel(newChan),
 	});
 	this.save();
 	newChan.loadMessages(this, network);

--- a/src/plugins/irc-events/banlist.js
+++ b/src/plugins/irc-events/banlist.js
@@ -37,10 +37,10 @@ module.exports = function(irc, network) {
 				type: Chan.Type.SPECIAL,
 				name: chanName,
 			});
-			network.channels.push(chan);
 			client.emit("join", {
 				network: network.id,
 				chan: chan.getFilteredClone(true),
+				index: network.addChannel(chan),
 			});
 		}
 

--- a/src/plugins/irc-events/join.js
+++ b/src/plugins/irc-events/join.js
@@ -15,12 +15,13 @@ module.exports = function(irc, network) {
 				name: data.channel,
 				state: Chan.State.JOINED,
 			});
-			network.channels.push(chan);
-			client.save();
+
 			client.emit("join", {
 				network: network.id,
 				chan: chan.getFilteredClone(true),
+				index: network.addChannel(chan),
 			});
+			client.save();
 
 			chan.loadMessages(client, network);
 

--- a/src/plugins/irc-events/list.js
+++ b/src/plugins/irc-events/list.js
@@ -46,10 +46,11 @@ module.exports = function(irc, network) {
 				type: Chan.Type.SPECIAL,
 				name: "Channel List",
 			});
-			network.channels.push(chan);
+
 			client.emit("join", {
 				network: network.id,
 				chan: chan.getFilteredClone(true),
+				index: network.addChannel(chan),
 			});
 		}
 

--- a/src/plugins/irc-events/message.js
+++ b/src/plugins/irc-events/message.js
@@ -67,11 +67,13 @@ module.exports = function(irc, network) {
 						type: Chan.Type.QUERY,
 						name: target,
 					});
-					network.channels.push(chan);
+
 					client.emit("join", {
 						network: network.id,
 						chan: chan.getFilteredClone(true),
+						index: network.addChannel(chan),
 					});
+					client.save();
 					chan.loadMessages(client, network);
 				}
 			}

--- a/src/plugins/irc-events/whois.js
+++ b/src/plugins/irc-events/whois.js
@@ -13,13 +13,15 @@ module.exports = function(irc, network) {
 				type: Chan.Type.QUERY,
 				name: data.nick,
 			});
-			network.channels.push(chan);
+
 			client.emit("join", {
 				shouldOpen: true,
 				network: network.id,
 				chan: chan.getFilteredClone(true),
+				index: network.addChannel(chan),
 			});
 			chan.loadMessages(client, network);
+			client.save();
 		}
 
 		let msg;


### PR DESCRIPTION
Fixes #53

This has 1 issue in that if the user has sorted channels in a differnet way, then it won't work, and it'll be sorted in the first position that it is alphabetically below. But realistically, we don't want to re-sort all the user's chans, because that'll remove the point of having user sorting. And I don't think there's a better way to do this, personally.