### PR TITLE
Fix default ecdh curve for better compatibility

### DIFF
--- a/src/plugins/irc-events/link.js
+++ b/src/plugins/irc-events/link.js
@@ -11,6 +11,16 @@ const storage = require("../storage");
 
 process.setMaxListeners(0);
 
+// Fix ECDH curve client compatibility in Node v8/v9
+// This is fixed in Node 10, but The Lounge supports LTS versions
+// https://github.com/nodejs/node/issues/16196
+// https://github.com/nodejs/node/pull/16853
+const tls = require("tls");
+
+if (tls.DEFAULT_ECDH_CURVE === "prime256v1") {
+	tls.DEFAULT_ECDH_CURVE = "auto";
+}
+
 module.exports = function(client, chan, msg) {
 	if (!Helper.config.prefetch) {
 		return;


### PR DESCRIPTION
https://github.com/nodejs/node/issues/16196
https://github.com/nodejs/node/pull/16853

This isn't exactly a problem with The Lounge, but as we support LTS versions, we increase compatibility by including a fix for these Node versions.