### PR TITLE
Remove setMaxListeners

### DIFF
--- a/src/plugins/irc-events/link.js
+++ b/src/plugins/irc-events/link.js
@@ -9,8 +9,6 @@ const cleanIrcMessage = require("../../../client/js/libs/handlebars/ircmessagepa
 const findLinks = require("../../../client/js/libs/handlebars/ircmessageparser/findLinks");
 const storage = require("../storage");
 
-process.setMaxListeners(0);
-
 // Fix ECDH curve client compatibility in Node v8/v9
 // This is fixed in Node 10, but The Lounge supports LTS versions
 // https://github.com/nodejs/node/issues/16196


### PR DESCRIPTION
Reverts 2cee0ea6ef5ee51de0190332f976934b55bbc8e4 as this no longer causes the EventEmitter warning due to `maxRedirects` being set to 5 on our end. We shouldn't be blindly hiding these warnings for the entire process.

Ref: https://github.com/request/request/issues/311#issuecomment-153507416