### PR TITLE
Scroll to joined/activated channel

### DIFF
--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -375,6 +375,7 @@ $(function() {
 				utils.toggleNotificationMarkers(false);
 			}
 
+			utils.scrollIntoViewNicely(self[0]);
 			slideoutMenu.toggle(false);
 		}
 

--- a/client/js/userlist.js
+++ b/client/js/userlist.js
@@ -5,6 +5,7 @@ const fuzzy = require("fuzzy");
 const Mousetrap = require("mousetrap");
 
 const templates = require("../views");
+const utils = require("./utils");
 
 const chat = $("#chat");
 
@@ -93,7 +94,7 @@ exports.handleKeybinds = function(input) {
 		}
 
 		// Adjust scroll when active item is outside of the visible area
-		userlist.find(".user.active")[0].scrollIntoView(false);
+		utils.scrollIntoViewNicely(userlist.find(".user.active")[0]);
 	});
 
 	// When pressing Enter, open the context menu (emit a click) on the active

--- a/client/js/utils.js
+++ b/client/js/utils.js
@@ -14,6 +14,7 @@ module.exports = {
 	lastMessageId,
 	confirmExit,
 	forceFocus,
+	scrollIntoViewNicely,
 	hasRoleInChannel,
 	move,
 	resetHeight,
@@ -56,6 +57,13 @@ function hasRoleInChannel(channel, roles) {
 // This can only be called from another interactive event (e.g. button click)
 function forceFocus() {
 	input.trigger("click").trigger("focus");
+}
+
+// Reusable scrollIntoView parameters for channel list / user list
+function scrollIntoViewNicely(el) {
+	// Ideally this would use behavior: "smooth", but that does not consistently work in e.g. Chrome
+	// https://github.com/iamdustan/smoothscroll/issues/28#issuecomment-364061459
+	el.scrollIntoView({block: "nearest", inline: "nearest"});
 }
 
 function collapse() {


### PR DESCRIPTION
~~WIP because I'm not entirely happy with it, but it does technically function. I need to port this into my production instance for a day or two, because my local TL install isn't behaving right for some reason.~~

I'm using the object option to keep the scrolling down the minimum necessary (`'nearest'`). What @xPaw suggested in #2062, `scrollIntoView(false)`, always aligns the element to the bottom of the viewport, which looks kind of wonky if the target channel is actually above the viewport (it scrolls a long way for no particularly good reason, IMO).

`behavior: 'auto'` as used in this WIP seems to prefer instant scrolling, even on desktop, which doesn't look great. Before this gets merged, I'd like to make that `behavior: 'smooth'` instead, ~~unless there are UX or performance considerations I should know about.~~ but unfortunately it doesn't work consistently and correctly across all browsers. E.g. Chrome 64 appears to just not scroll if given `smooth`.

PR to close #2062 once complete.

Edit: No idea why local `npm test` didn't catch the quotes, but I'll fix that too in the next branch update.