### PR TITLE
Always hide horizontal overflow in chat

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -1041,6 +1041,7 @@ kbd {
 
 #chat .chat {
 	overflow: auto;
+	overflow-x: hidden;
 	display: flex;
 	flex-grow: 1;
 	flex-direction: column;


### PR DESCRIPTION
Resizing the window temporarily shows non-scrollable scrollbar for some reason in Chrome, but then clicking anything recalculates (?) and it disappears.