### PR TITLE
Remove `contain` as it's causing rendering issues

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -1041,7 +1041,6 @@ kbd {
 	display: flex;
 	flex-grow: 1;
 	overflow: hidden;
-	contain: strict;
 }
 
 #chat .chat {


### PR DESCRIPTION
Specifically `content: paint` is causing rendering issues in Chrome. This was added in one of the flexbox refactors.

We should revisit this property though, https://developers.google.com/web/updates/2016/06/css-containment