### PR TITLE
Remove `mailto:` part of security email address

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,4 +6,4 @@
   manner.
 - On IRC, send a private message to any voiced user on our Freenode channel,
   `#thelounge`.
-- By email, send us your report at <mailto:security@thelounge.chat>.
+- By email, send us your report at <security@thelounge.chat>.


### PR DESCRIPTION
This actually displays `send us your report at mailto:security@thelounge.chat.`. Also, it's optional and Markdown renderer adds it when rendering to a `<a>` link.