### PR TITLE
Add keybinds for cycling through networks/lobbies

### DIFF
--- a/client/js/keybinds.js
+++ b/client/js/keybinds.js
@@ -59,6 +59,38 @@ Mousetrap.bind([
 });
 
 Mousetrap.bind([
+	"alt+shift+up",
+	"alt+shift+down",
+], function(e, keys) {
+	const lobbies = sidebar.find(".lobby");
+	const direction = keys.split("+").pop();
+	let index = lobbies.index(lobbies.filter(".active"));
+	let target;
+
+	switch (direction) {
+	case "up":
+		if (index < 0) {
+			target = lobbies.index(sidebar.find(".channel").filter(".active").siblings(".lobby")[0]);
+		} else {
+			target = (lobbies.length + (index - 1 + lobbies.length)) % lobbies.length;
+		}
+
+		break;
+
+	case "down":
+		if (index < 0) {
+			index = lobbies.index(sidebar.find(".channel").filter(".active").siblings(".lobby")[0]);
+		}
+
+		target = (lobbies.length + (index + 1 + lobbies.length)) % lobbies.length;
+
+		break;
+	}
+
+	lobbies.eq(target).click();
+});
+
+Mousetrap.bind([
 	"escape",
 ], function() {
 	contextMenuContainer.hide();

--- a/client/views/windows/help.tpl
+++ b/client/views/windows/help.tpl
@@ -49,6 +49,15 @@
 
 	<div class="help-item">
 		<div class="subject">
+			<kbd class="key-all">Alt</kbd><kbd class="key-apple">⌥</kbd> + <kbd>Shift</kbd> + <kbd>↑</kbd> / <kbd>↓</kbd>
+		</div>
+		<div class="description">
+			<p>Switch to the previous/next lobby in the channel list.</p>
+		</div>
+	</div>
+
+	<div class="help-item">
+		<div class="subject">
 			<kbd class="key-all">Alt</kbd><kbd class="key-apple">⌥</kbd> + <kbd>↑</kbd> / <kbd>↓</kbd>
 		</div>
 		<div class="description">


### PR DESCRIPTION
Closes #2203. I just used the shortcuts suggested [in this comment](https://github.com/thelounge/thelounge/issues/2203#issuecomment-372371916) for cycling between lobbies.