### PR TITLE
Improve readability and styling of shortcut keys in the Help section

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -80,7 +80,6 @@ button {
 }
 
 code,
-kbd,
 pre,
 .irc-monospace,
 textarea#user-specified-css-input {
@@ -89,7 +88,7 @@ textarea#user-specified-css-input {
 
 code,
 .irc-monospace {
-	font-size: 12px;
+	font-size: 13px;
 	padding: 2px 4px;
 	color: #e74c3c;
 	background-color: #f9f2f4;
@@ -111,16 +110,19 @@ pre {
 
 kbd {
 	display: inline-block;
-	font-size: 11px;
-	line-height: 10px;
-	padding: 3px 5px;
-	color: #555;
-	vertical-align: middle;
-	background-color: #fcfcfc;
-	border: solid 1px #ccc;
-	border-bottom-color: #bbb;
-	border-radius: 3px;
-	box-shadow: inset 0 -1px 0 #bbb;
+	font-family: inherit;
+	line-height: 1em;
+	min-width: 28px; /* Ensure 1-char keys have the same width */
+	margin: 0 1px;
+	padding: 4px 6px;
+	color: #444;
+	text-align: center;
+	text-shadow: 0 1px 0 #fff;
+	background-color: white;
+	background-image: linear-gradient(180deg, rgba(0, 0, 0, 0.05), transparent);
+	border: 1px solid #bbb;
+	border-radius: 4px;
+	box-shadow: 0 2px 0 #bbb, inset 0 1px 1px #fff, inset 0 -1px 3px #ccc;
 }
 
 .btn {

--- a/client/themes/morning.css
+++ b/client/themes/morning.css
@@ -213,6 +213,15 @@ code,
 	color: #f3f3f3;
 }
 
+kbd {
+	color: #eee;
+	text-shadow: 0 -1px 0 #000;
+	border-color: #000;
+	background-color: #333;
+	background-image: linear-gradient(rgba(0, 0, 0, 0.25), transparent);
+	box-shadow: 0 2px 0 #000, inset 0 1px 1px #777, inset 0 -1px 3px #222;
+}
+
 /* Embeds */
 #chat .toggle-content {
 	background: #242a33;

--- a/client/themes/zenburn.css
+++ b/client/themes/zenburn.css
@@ -239,6 +239,15 @@ code,
 	color: #dcdccc;
 }
 
+kbd {
+	color: #eee;
+	text-shadow: 0 -1px 0 #000;
+	border-color: #000;
+	background-color: #333;
+	background-image: linear-gradient(rgba(0, 0, 0, 0.25), transparent);
+	box-shadow: 0 2px 0 #000, inset 0 1px 1px #777, inset 0 -1px 3px #222;
+}
+
 /* Previews */
 
 #chat .toggle-content {

--- a/client/views/windows/help.tpl
+++ b/client/views/windows/help.tpl
@@ -49,25 +49,48 @@
 
 	<div class="help-item">
 		<div class="subject">
-			<kbd class="key-all">Alt</kbd><kbd class="key-apple">⌥</kbd> + <kbd>Shift</kbd> + <kbd>↑</kbd> / <kbd>↓</kbd>
+			<span class="key-all"><kbd>Alt</kbd> <kbd>Shift</kbd> <kbd>↓</kbd></span>
+			<span class="key-apple"><kbd>⌥</kbd> <kbd>⇧</kbd> <kbd>↓</kbd></span>
 		</div>
 		<div class="description">
-			<p>Switch to the previous/next lobby in the channel list.</p>
+			<p>Switch to the next lobby in the channel list.</p>
 		</div>
 	</div>
 
 	<div class="help-item">
 		<div class="subject">
-			<kbd class="key-all">Alt</kbd><kbd class="key-apple">⌥</kbd> + <kbd>↑</kbd> / <kbd>↓</kbd>
+			<span class="key-all"><kbd>Alt</kbd> <kbd>Shift</kbd> <kbd>↑</kbd></span>
+			<span class="key-apple"><kbd>⌥</kbd> <kbd>⇧</kbd> <kbd>↑</kbd></span>
 		</div>
 		<div class="description">
-			<p>Switch to the previous/next window in the channel list.</p>
+			<p>Switch to the previous lobby in the channel list.</p>
 		</div>
 	</div>
 
 	<div class="help-item">
 		<div class="subject">
-			<kbd class="key-all">Ctrl</kbd><kbd class="key-apple">⌘</kbd> + <kbd>K</kbd>
+			<span class="key-all"><kbd>Alt</kbd> <kbd>↓</kbd></span>
+			<span class="key-apple"><kbd>⌥</kbd> <kbd>↓</kbd></span>
+		</div>
+		<div class="description">
+			<p>Switch to the next window in the channel list.</p>
+		</div>
+	</div>
+
+	<div class="help-item">
+		<div class="subject">
+			<span class="key-all"><kbd>Alt</kbd> <kbd>↑</kbd></span>
+			<span class="key-apple"><kbd>⌥</kbd> <kbd>↑</kbd></span>
+		</div>
+		<div class="description">
+			<p>Switch to the previous window in the channel list.</p>
+		</div>
+	</div>
+
+	<div class="help-item">
+		<div class="subject">
+			<span class="key-all"><kbd>Ctrl</kbd> <kbd>K</kbd></span>
+			<span class="key-apple"><kbd>⌘</kbd> <kbd>K</kbd></span>
 		</div>
 		<div class="description">
 			<p>
@@ -90,52 +113,58 @@
 
 	<div class="help-item">
 		<div class="subject">
-			<kbd class="key-all">Ctrl</kbd><kbd class="key-apple">⌘</kbd> + <kbd>B</kbd>
+			<span class="key-all"><kbd>Ctrl</kbd> <kbd>B</kbd></span>
+			<span class="key-apple"><kbd>⌘</kbd> <kbd>B</kbd></span>
 		</div>
 		<div class="description">
-			<p>Mark all text typed after this shortcut as bold.</p>
+			<p>Mark all text typed after this shortcut as <span class="irc-bold">bold</span>.</p>
 		</div>
 	</div>
 
 	<div class="help-item">
 		<div class="subject">
-			<kbd class="key-all">Ctrl</kbd><kbd class="key-apple">⌘</kbd> + <kbd>U</kbd>
+			<span class="key-all"><kbd>Ctrl</kbd> <kbd>U</kbd></span>
+			<span class="key-apple"><kbd>⌘</kbd> <kbd>U</kbd></span>
 		</div>
 		<div class="description">
-			<p>Mark all text typed after this shortcut as underlined.</p>
+			<p>Mark all text typed after this shortcut as <span class="irc-underline">underlined</span>.</p>
 		</div>
 	</div>
 
 	<div class="help-item">
 		<div class="subject">
-			<kbd class="key-all">Ctrl</kbd><kbd class="key-apple">⌘</kbd> + <kbd>I</kbd>
+			<span class="key-all"><kbd>Ctrl</kbd> <kbd>I</kbd></span>
+			<span class="key-apple"><kbd>⌘</kbd> <kbd>I</kbd></span>
 		</div>
 		<div class="description">
-			<p>Mark all text typed after this shortcut as italics.</p>
+			<p>Mark all text typed after this shortcut as <span class="irc-italic">italics</span>.</p>
 		</div>
 	</div>
 
 	<div class="help-item">
 		<div class="subject">
-			<kbd class="key-all">Ctrl</kbd><kbd class="key-apple">⌘</kbd> + <kbd>S</kbd>
+			<span class="key-all"><kbd>Ctrl</kbd> <kbd>S</kbd></span>
+			<span class="key-apple"><kbd>⌘</kbd> <kbd>S</kbd></span>
 		</div>
 		<div class="description">
-			<p>Mark all text typed after this shortcut as struck through.</p>
+			<p>Mark all text typed after this shortcut as <span class="irc-strikethrough">struck through</span>.</p>
 		</div>
 	</div>
 
 	<div class="help-item">
 		<div class="subject">
-			<kbd class="key-all">Ctrl</kbd><kbd class="key-apple">⌘</kbd> + <kbd>M</kbd>
+			<span class="key-all"><kbd>Ctrl</kbd> <kbd>M</kbd></span>
+			<span class="key-apple"><kbd>⌘</kbd> <kbd>M</kbd></span>
 		</div>
 		<div class="description">
-			<p>Mark all text typed after this shortcut as monospaced.</p>
+			<p>Mark all text typed after this shortcut as <span class="irc-monospace">monospaced</span>.</p>
 		</div>
 	</div>
 
 	<div class="help-item">
 		<div class="subject">
-			<kbd class="key-all">Ctrl</kbd><kbd class="key-apple">⌘</kbd> + <kbd>O</kbd>
+			<span class="key-all"><kbd>Ctrl</kbd> <kbd>O</kbd></span>
+			<span class="key-apple"><kbd>⌘</kbd> <kbd>O</kbd></span>
 		</div>
 		<div class="description">
 			<p>


### PR DESCRIPTION
For example, on macOS, shortcuts are displayed such as "⌘C" while on Windows they would be displayed as "Ctrl+C":

<img height="250" alt="screen shot 2018-03-13 at 19 24 09" src="https://user-images.githubusercontent.com/113730/37380297-6db4f4ba-270e-11e8-859d-44efe2f9bd56.png"> <img height="250" src="https://user-images.githubusercontent.com/113730/37380364-bb1c7034-270e-11e8-8113-7121bab5b322.png">


Also on Mac these characters in key boxes are reaaally tiny, so I went simpler as I figured simple trumps fancy here (and imo that wasn't really pretty either but that's subjective).

Before | After
--- | ---
<img width="598" alt="screen shot 2018-03-13 at 22 21 12" src="https://user-images.githubusercontent.com/113730/37380238-1b49d574-270e-11e8-897a-bd180525e404.png"> | <img width="605" alt="screen shot 2018-03-13 at 22 19 18" src="https://user-images.githubusercontent.com/113730/37380235-1b21d8e4-270e-11e8-8207-6725a7b8cb29.png">
<img width="594" alt="screen shot 2018-03-13 at 22 20 02" src="https://user-images.githubusercontent.com/113730/37380237-1b3ce8e6-270e-11e8-9a35-16ce3e7a2388.png"> | <img width="593" alt="screen shot 2018-03-13 at 22 19 39" src="https://user-images.githubusercontent.com/113730/37380236-1b30207a-270e-11e8-9a28-37c0502f587c.png">

Thoughts?

_I know that this PR is going to conflict with #2206, which should go first, so @ESWAT won't have to deal with conflicts ;)_
