### PR TITLE
Select lobby of network when collapsing network

### DIFF
--- a/client/js/render.js
+++ b/client/js/render.js
@@ -308,6 +308,10 @@ function loadMoreHistory(entries) {
 sidebar.on("click", ".collapse-network", (e) => {
 	const collapseButton = $(e.target);
 
+	if (collapseButton.closest(".network").find(".active").length > 0) {
+		collapseButton.closest(".lobby").click();
+	}
+
 	collapseButton.closest(".network").toggleClass("collapsed");
 
 	if (collapseButton.attr("aria-expanded") === "true") {


### PR DESCRIPTION
Fixes #2224 

- [x] Only select lobby if we are on a channel in that network, don't switch network