### PR TITLE
Allow editing networks via UI

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -417,6 +417,7 @@ kbd {
 	margin-right: 9px;
 }
 
+.context-menu-edit::before,
 #set-nick::before {
 	content: "\f303"; /* https://fontawesome.com/icons/pencil-alt?style=solid */
 }

--- a/client/js/contextMenuFactory.js
+++ b/client/js/contextMenuFactory.js
@@ -153,6 +153,21 @@ function addFocusItem() {
 	});
 }
 
+function addEditNetworkItem() {
+	function edit(itemData) {
+		socket.emit("network:get", itemData);
+		$('button[data-target="#connect"]').trigger("click");
+	}
+
+	addContextMenuItem({
+		check: (target) => target.hasClass("lobby"),
+		className: "edit",
+		displayName: "Edit this network…",
+		data: (target) => target.closest(".network").data("uuid"),
+		callback: edit,
+	});
+}
+
 function addChannelListItem() {
 	function list(itemData) {
 		socket.emit("input", {
@@ -207,6 +222,7 @@ function addDefaultItems() {
 	addQueryItem();
 	addKickItem();
 	addFocusItem();
+	addEditNetworkItem();
 	addChannelListItem();
 	addBanListItem();
 	addJoinItem();

--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -18,7 +18,6 @@ const utils = require("./utils");
 require("./webpush");
 require("./keybinds");
 require("./clipboard");
-const Changelog = require("./socket-events/changelog");
 const contextMenuFactory = require("./contextMenuFactory");
 const contextMenuContainer = $("#context-menu-container");
 
@@ -320,15 +319,6 @@ $(function() {
 		if (chan.data("needsNamesRefresh") === true) {
 			chan.data("needsNamesRefresh", false);
 			socket.emit("names", {target: self.data("id")});
-		}
-
-		if (target === "#settings") {
-			$("#session-list").html("<p>Loading…</p>");
-			socket.emit("sessions:get");
-		}
-
-		if (target === "#help" || target === "#changelog") {
-			Changelog.requestIfNeeded();
 		}
 
 		// Pushes states to history web API when clicking elements with a data-target attribute.

--- a/client/js/socket-events/changelog.js
+++ b/client/js/socket-events/changelog.js
@@ -4,10 +4,6 @@ const $ = require("jquery");
 const socket = require("../socket");
 const templates = require("../../views");
 
-module.exports = {
-	requestIfNeeded,
-};
-
 // Requests version information if it hasn't been retrieved before (or if it has
 // been removed from the page, i.e. when clicking on "Check now". Displays a
 // loading state until received.
@@ -53,6 +49,8 @@ socket.on("changelog", function(data) {
 		);
 	}
 });
+
+$("#help, #changelog").on("show", requestIfNeeded);
 
 // When clicking the "Check now" button, remove current checker information and
 // request a new one. Loading will be displayed in the meantime.

--- a/client/js/socket-events/network.js
+++ b/client/js/socket-events/network.js
@@ -3,6 +3,7 @@
 const $ = require("jquery");
 const socket = require("../socket");
 const render = require("../render");
+const templates = require("../../views");
 const sidebar = $("#sidebar");
 
 socket.on("network", function(data) {
@@ -26,4 +27,18 @@ socket.on("network:status", function(data) {
 		.find("#network-" + data.network)
 		.toggleClass("not-connected", !data.connected)
 		.toggleClass("not-secure", !data.secure);
+});
+
+socket.on("network:info", function(data) {
+	$("#connect")
+		.html(templates.windows.connect(data))
+		.find("form").on("submit", function() {
+			const uuid = $(this).find("input[name=uuid]").val();
+			const newName = $(this).find("#connect\\:name").val();
+
+			sidebar.find(`.network[data-uuid="${uuid}"] .chan.lobby .name`)
+				.attr("title", newName)
+				.text(newName)
+				.click();
+		});
 });

--- a/client/views/windows/connect.tpl
+++ b/client/views/windows/connect.tpl
@@ -1,20 +1,26 @@
 <div class="header">
 	<button class="lt" aria-label="Toggle channel list"></button>
 </div>
-<form class="container" method="post" action="" data-event="conn">
+<form class="container" method="post" action="" data-event="{{#if defaults.uuid}}network:edit{{else}}network:new{{/if}}">
 	<div class="row">
 		<div class="col-sm-12">
 			<h1 class="title">
-				{{#if public}}The Lounge - {{/if}}
-				Connect
-				{{#unless displayNetwork}}
-					{{#if lockNetwork}}
-					to {{defaults.name}}
-					{{/if}}
-				{{/unless}}
+				{{#if defaults.uuid}}
+					<input type="hidden" name="uuid" value="{{defaults.uuid}}">
+
+					Edit {{defaults.name}}
+				{{else}}
+					{{#if public}}The Lounge - {{/if}}
+					Connect
+					{{#unless displayNetwork}}
+						{{#if lockNetwork}}
+						to {{defaults.name}}
+						{{/if}}
+					{{/unless}}
+				{{/if}}
 			</h1>
 		</div>
-		{{#if displayNetwork}}
+	{{#if displayNetwork}}
 		<div>
 			<div class="col-sm-12">
 				<h2>Network settings</h2>
@@ -29,7 +35,7 @@
 				<label for="connect:host">Server</label>
 			</div>
 			<div class="col-sm-6 col-xs-8">
-				<input class="input" id="connect:host" name="host" value="{{defaults.host}}" aria-label="Server address" {{#if lockNetwork}}disabled{{/if}}>
+				<input class="input" id="connect:host" name="host" value="{{defaults.host}}" aria-label="Server address" required {{#if lockNetwork}}disabled{{/if}}>
 			</div>
 			<div class="col-sm-3 col-xs-4">
 				<div class="port">
@@ -51,7 +57,7 @@
 			</div>
 			<div class="clearfix"></div>
 		</div>
-		{{/if}}
+	{{/if}}
 		<div class="col-sm-12">
 			<h2>User preferences</h2>
 		</div>
@@ -59,16 +65,16 @@
 			<label for="connect:nick">Nick</label>
 		</div>
 		<div class="col-sm-9">
-			<input class="input nick" id="connect:nick" name="nick" value="{{defaults.nick}}">
+			<input class="input nick" id="connect:nick" name="nick" value="{{defaults.nick}}" required>
 		</div>
-		{{#unless useHexIp}}
+	{{#unless useHexIp}}
 		<div class="col-sm-3">
 			<label for="connect:username">Username</label>
 		</div>
 		<div class="col-sm-9">
 			<input class="input username" id="connect:username" name="username" value="{{defaults.username}}">
 		</div>
-		{{/unless}}
+	{{/unless}}
 		<div class="col-sm-3">
 			<label for="connect:password">Password</label>
 		</div>
@@ -81,6 +87,18 @@
 		<div class="col-sm-9">
 			<input class="input" id="connect:realname" name="realname" value="{{defaults.realname}}">
 		</div>
+	{{#if defaults.uuid}}
+		<div class="col-sm-3">
+			<label for="connect:commands">Commands</label>
+		</div>
+		<div class="col-sm-9">
+			<textarea class="input" id="connect:commands" name="commands" placeholder="One raw command per line, each command will be executed on new connection">{{~#each defaults.commands~}}{{~this}}
+{{/each~}}</textarea>
+		</div>
+		<div class="col-sm-9 col-sm-offset-3">
+			<button type="submit" class="btn">Save</button>
+		</div>
+	{{else}}
 		<div class="col-sm-3">
 			<label for="connect:channels">Channels</label>
 		</div>
@@ -90,5 +108,6 @@
 		<div class="col-sm-9 col-sm-offset-3">
 			<button type="submit" class="btn">Connect</button>
 		</div>
+	{{/if}}
 	</div>
 </form>

--- a/src/helper.js
+++ b/src/helper.js
@@ -31,6 +31,7 @@ const Helper = {
 	getGitCommit,
 	ip2hex,
 	mergeConfig,
+	getDefaultNick,
 
 	password: {
 		hash: passwordHash,
@@ -189,6 +190,14 @@ function passwordHash(password) {
 
 function passwordCompare(password, expected) {
 	return bcrypt.compare(password, expected);
+}
+
+function getDefaultNick() {
+	if (!this.config.defaults.nick) {
+		return "thelounge";
+	}
+
+	return this.config.defaults.nick.replace(/%/g, () => Math.floor(Math.random() * 10));
 }
 
 function mergeConfig(oldConfig, newConfig) {

--- a/src/models/network.js
+++ b/src/models/network.js
@@ -63,7 +63,7 @@ function Network(attr) {
 }
 
 Network.prototype.validate = function(client) {
-	this.setNick(String(this.nick || "thelounge").replace(" ", "_"));
+	this.setNick(String(this.nick || Helper.getDefaultNick()).replace(" ", "_"));
 
 	if (!this.username) {
 		this.username = this.nick.replace(/[^a-zA-Z0-9]/g, "");

--- a/src/plugins/irc-events/error.js
+++ b/src/plugins/irc-events/error.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const Msg = require("../../models/msg");
+const Helper = require("../../helper");
 
 module.exports = function(irc, network) {
 	const client = this;
@@ -59,7 +60,7 @@ module.exports = function(irc, network) {
 		lobby.pushMessage(client, msg, true);
 
 		if (irc.connection.registered === false) {
-			irc.changeNick("thelounge" + Math.floor(Math.random() * 100));
+			irc.changeNick(Helper.getDefaultNick());
 		}
 
 		client.emit("nick", {

--- a/src/server.js
+++ b/src/server.js
@@ -301,7 +301,7 @@ function initializeClient(socket, client, token, lastMessage) {
 		}
 	});
 
-	socket.on("conn", (data) => {
+	socket.on("network:new", (data) => {
 		if (typeof data === "object") {
 			// prevent people from overriding webirc settings
 			data.ip = null;

--- a/src/server.js
+++ b/src/server.js
@@ -599,7 +599,7 @@ function getClientConfiguration(network) {
 		config.gitCommit = Helper.getGitCommit();
 		config.themes = themes.getAll();
 		config.defaultTheme = Helper.config.theme;
-		config.defaults.nick = config.defaults.nick.replace(/%/g, () => Math.floor(Math.random() * 10));
+		config.defaults.nick = Helper.getDefaultNick();
 	}
 
 	return config;

--- a/test/models/network.js
+++ b/test/models/network.js
@@ -51,6 +51,8 @@ describe("Network", function() {
 		});
 
 		it("validate should set correct defaults", function() {
+			Helper.config.defaults.nick = "";
+
 			const network = new Network({
 				host: "localhost",
 			});

--- a/test/server.js
+++ b/test/server.js
@@ -88,7 +88,7 @@ describe("Server", function() {
 
 		it("should create network", (done) => {
 			client.on("init", () => {
-				client.emit("conn", {
+				client.emit("network:new", {
 					username: "test-user",
 					realname: "The Lounge Test",
 					nick: "test-user",


### PR DESCRIPTION
Some of the network code moved, and the editing code had to be done in such a way to apply same restrictions as adding a new connection. So this needs a lot of testing.

- [x] Fixes #179
- [x] Fixes #1161 (and practically #584, but the UI only exists when editing, not connecting, which is fine by me)
- [x] Update lobby name in UI if changed
- [x] Send `/nick` if nick changes
- [x] Update IRC object with new configuration
- [x] Look if `irc.user` variables need update (e.g. nick while disconnected)
- [x] Default nick to config default instead of hardcoded string