### PR TITLE
Wrap join-form with lobby info

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -585,6 +585,13 @@ kbd {
 	font-size: 15px;
 	font-weight: bold;
 	padding-left: 0;
+	flex-direction: column;
+}
+
+#sidebar .lobby-row {
+	display: flex;
+	flex-direction: row;
+	width: 100%;
 }
 
 #sidebar .lobby-wrap {
@@ -724,7 +731,7 @@ kbd {
 	transform: rotate(45deg) translateZ(0);
 }
 
-#sidebar .network .lobby:nth-last-child(2) .collapse-network {
+#sidebar .network .lobby:last-child .collapse-network {
 	/* Hide collapse button if there are no channels/queries */
 	width: 0;
 	overflow: hidden;
@@ -1033,7 +1040,7 @@ kbd {
   */
 #sidebar .join-form {
 	display: none;
-	padding: 0 18px 8px;
+	padding: 8px 0 0 14px;
 }
 
 #sidebar .join-form .input {
@@ -1042,6 +1049,7 @@ kbd {
 	margin-right: auto;
 	margin-top: 5px;
 	margin-bottom: 5px;
+	font-weight: normal;
 }
 
 #sidebar .join-form .btn {

--- a/client/views/chan.tpl
+++ b/client/views/chan.tpl
@@ -9,22 +9,25 @@
 	aria-selected="false"
 >
 	{{#equal type "lobby"}}
-		<button class="collapse-network" aria-label="Collapse" aria-controls="network-{{id}}" aria-expanded="true">
-			<span class="collapse-network-icon"></span>
-		</button>
-		<div class="lobby-wrap">
-			<span class="name" title="{{name}}">{{name}}</span>
-			<span class="not-secure-tooltip tooltipped tooltipped-w" aria-label="Insecure connection">
-				<span class="not-secure-icon"></span>
+		<div class="lobby-row">
+			<button class="collapse-network" aria-label="Collapse" aria-controls="network-{{id}}" aria-expanded="true">
+				<span class="collapse-network-icon"></span>
+			</button>
+			<div class="lobby-wrap">
+				<span class="name" title="{{name}}">{{name}}</span>
+				<span class="not-secure-tooltip tooltipped tooltipped-w" aria-label="Insecure connection">
+					<span class="not-secure-icon"></span>
+				</span>
+				<span class="not-connected-tooltip tooltipped tooltipped-w" aria-label="Disconnected">
+					<span class="not-connected-icon"></span>
+				</span>
+				<span class="badge{{#if highlight}} highlight{{/if}}">{{#if unread}}{{roundBadgeNumber unread}}{{/if}}</span>
+			</div>
+			<span class="add-channel-tooltip tooltipped tooltipped-w tooltipped-no-touch" aria-label="Join a channel…" data-alt-label="Cancel">
+				<button class="add-channel" aria-label="Join a channel…" data-id="{{id}}"></button>
 			</span>
-			<span class="not-connected-tooltip tooltipped tooltipped-w" aria-label="Disconnected">
-				<span class="not-connected-icon"></span>
-			</span>
-			<span class="badge{{#if highlight}} highlight{{/if}}">{{#if unread}}{{roundBadgeNumber unread}}{{/if}}</span>
 		</div>
-		<span class="add-channel-tooltip tooltipped tooltipped-w tooltipped-no-touch" aria-label="Join a channel…" data-alt-label="Cancel">
-			<button class="add-channel" aria-label="Join a channel…" data-id="{{id}}"></button>
-		</span>
+		{{> join_channel}}
 	{{/equal}}
 	{{#notEqual type "lobby"}}
 		<span class="name" title="{{name}}">{{name}}</span>
@@ -34,7 +37,4 @@
 		</span>
 	{{/notEqual}}
 </div>
-{{#equal type "lobby"}}
-	{{> join_channel}}
-{{/equal}}
 {{/each}}


### PR DESCRIPTION
Fixes #2218.

However I noticed a weird bug with both Chrome and Firefox where moving the `.join-form` in a container with flexbox set its form font to bold… so I explicitly reset `font-weight: normal` there.

