### PR TITLE
Revert "Scroll to joined/activated channel"

### DIFF
--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -373,7 +373,6 @@ $(function() {
 				utils.toggleNotificationMarkers(false);
 			}
 
-			utils.scrollIntoViewNicely(self[0]);
 			slideoutMenu.toggle(false);
 		}
 

--- a/client/js/userlist.js
+++ b/client/js/userlist.js
@@ -5,7 +5,6 @@ const fuzzy = require("fuzzy");
 const Mousetrap = require("mousetrap");
 
 const templates = require("../views");
-const utils = require("./utils");
 
 const chat = $("#chat");
 
@@ -94,7 +93,7 @@ exports.handleKeybinds = function(input) {
 		}
 
 		// Adjust scroll when active item is outside of the visible area
-		utils.scrollIntoViewNicely(userlist.find(".user.active")[0]);
+		userlist.find(".user.active")[0].scrollIntoView(false);
 	});
 
 	// When pressing Enter, open the context menu (emit a click) on the active

--- a/client/js/utils.js
+++ b/client/js/utils.js
@@ -15,7 +15,6 @@ module.exports = {
 	lastMessageId,
 	confirmExit,
 	forceFocus,
-	scrollIntoViewNicely,
 	hasRoleInChannel,
 	move,
 	resetHeight,
@@ -58,13 +57,6 @@ function hasRoleInChannel(channel, roles) {
 // This can only be called from another interactive event (e.g. button click)
 function forceFocus() {
 	input.trigger("click").trigger("focus");
-}
-
-// Reusable scrollIntoView parameters for channel list / user list
-function scrollIntoViewNicely(el) {
-	// Ideally this would use behavior: "smooth", but that does not consistently work in e.g. Chrome
-	// https://github.com/iamdustan/smoothscroll/issues/28#issuecomment-364061459
-	el.scrollIntoView({block: "nearest", inline: "nearest"});
 }
 
 function collapse() {


### PR DESCRIPTION
Reverts #2166

Since merging, this has caused too many issues due to inconsistent browser support (#2233, for example).

I'm working on a more brute-force approach that doesn't use this flaky API. Until that's done, I'd argue that removing the functionality is better than the current state.