### PR TITLE
Rework how unread marker is moved when status messages are hidden

### DIFF
--- a/client/js/socket-events/msg.js
+++ b/client/js/socket-events/msg.js
@@ -70,12 +70,25 @@ function processReceivedMessage(data) {
 
 	notifyMessage(targetId, channel, data);
 
-	const lastVisible = container.find("div:visible").last();
+	let shouldMoveMarker = data.msg.self;
 
-	if (data.msg.self
-		|| lastVisible.hasClass("unread-marker")
-		|| (lastVisible.hasClass("date-marker")
-		&& lastVisible.prev().hasClass("unread-marker"))) {
+	if (!shouldMoveMarker) {
+		const lastChild = container.children().last();
+
+		// If last element is hidden (e.g. hidden status messages) check the element before it.
+		// If it's unread marker or date marker, then move unread marker to the bottom
+		// so that it isn't displayed as the last element in chat.
+		// display properly is checked instead of using `:hidden` selector because it doesn't work in non-active channels.
+		if (lastChild.css("display") === "none") {
+			const prevChild = lastChild.prev();
+
+			shouldMoveMarker =
+				prevChild.hasClass("unread-marker") ||
+				(prevChild.hasClass("date-marker") && prevChild.prev().hasClass("unread-marker"));
+		}
+	}
+
+	if (shouldMoveMarker) {
 		container
 			.find(".unread-marker")
 			.data("unread-id", 0)


### PR DESCRIPTION
Fixes #2214.

This should be more performant as it only gets last children instead of filtering by `:visible`. We basically no longer need to iterate as status messages are contained within a single `condensed` container.