### PR TITLE
Fix `yarn coverage` script on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "homepage": "https://thelounge.chat/",
   "scripts": {
     "build": "webpack",
-    "coverage": "rm -rf .nyc_output/ && run-s test:{client,server} && nyc --nycrc-path=test/.nycrc-report report",
+    "coverage": "run-s test:{client,server} && nyc --nycrc-path=test/.nycrc-report report",
     "dev": "run-p watch start",
     "lint:css": "stylelint --color \"client/**/*.css\"",
     "lint:js": "eslint . --report-unused-disable-directives --color",

--- a/test/.nycrc-mocha-webpack
+++ b/test/.nycrc-mocha-webpack
@@ -6,6 +6,5 @@
   "reporter": [
     "json",
     "text-summary"
-  ],
-  "clean": false
+  ]
 }


### PR DESCRIPTION
Fixes #2250.

This is less than ideal because it's slightly fragile, but I don't care much as this is an internal tool that we don't use that much (well, I do, but we don't use it past running the command), and long-term I'd rather ditch this command entirely and have both reports correctly built, so it doesn't have to be perfect now, just run.