### PR TITLE
Fix order in oidentd file

### DIFF
--- a/src/identification.js
+++ b/src/identification.js
@@ -91,9 +91,9 @@ class Identification {
 
 		this.connections.forEach((connection) => {
 			file += `to ${connection.socket.remoteAddress}`
-				+ ` lport ${connection.socket.localPort}`
-				+ ` from ${connection.socket.localAddress}`
 				+ ` fport ${connection.socket.remotePort}`
+				+ ` from ${connection.socket.localAddress}`
+				+ ` lport ${connection.socket.localPort}`
 				+ ` { reply "${connection.user}" }\n`;
 		});
 


### PR DESCRIPTION
oident'd parser expects exact order and the man page is written incorrectly.

Confirmed bug in https://github.com/janikrabe/oidentd/pull/13


@ronilaukkarinen If you are still around, can you test if this finally fixes the issues you had? Possibly fixes #754