### PR TITLE
Add auto-prepend behaviour for unprefixed channel names

### DIFF
--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -585,7 +585,19 @@ $(function() {
 			// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...in#Iterating_over_own_properties_only
 			for (let key in params) {
 				if (params.hasOwnProperty(key)) {
-					const value = params[key];
+					let value = params[key];
+
+					if (key === "join") {
+						const channels = value.split(",");
+						value = channels.map((c) => {
+							if (c.match(/^\w/)) {
+								return "#" + c;
+							}
+
+							return c;
+						}).join(",");
+					}
+
 					// \W searches for non-word characters
 					key = key.replace(/\W/g, "");
 


### PR DESCRIPTION
This change adds behaviour to automatically prefix channel names passed in via the "?join=x,y,z" query string/search parameter which do not appear to include an appropriate channel symbol. For example, `channel` becomes `#channel` but `#channel` and `~channel` are left alone.

**Known limitation:** Unicode characters at the start of the channel name will not be considered to match `/^\w/`. These will not be auto-prefixed.

If this is not the correct place to implement this functionality, please let me know where it would be better suited.