### PR TITLE
Add ?channels=x,y,z alias for ?join=x,y,z

### DIFF
--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -581,6 +581,10 @@ $(function() {
 		$("#connect").one("show", function() {
 			const params = URI(document.location.search).search(true);
 
+			if ("channels" in params) {
+				params.join = params.channels;
+			}
+
 			// Possible parameters:  name, host, port, password, tls, nick, username, realname, join
 			// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...in#Iterating_over_own_properties_only
 			for (let key in params) {


### PR DESCRIPTION
For backwards compat. with Iris and other systems.

`?join=%23foo,%23bar` and `?channels=%23foo,%23bar` are treated as equivalent with this patch.