### PR TITLE
Add lockUsername config option

### DIFF
--- a/client/views/windows/connect.tpl
+++ b/client/views/windows/connect.tpl
@@ -66,7 +66,11 @@
 			<label for="connect:username">Username</label>
 		</div>
 		<div class="col-sm-9">
-			<input class="input username" id="connect:username" name="username" value="{{defaults.username}}">
+			{{#if lockUsername}}
+				<input class="input username" name="username" disabled value="{{lockUsername}}">
+        	{{else}}
+        		<input class="input username" id="connect:username" name="username" value="{{defaults.username}}">
+        	{{/if}}
 		</div>
 		{{/unless}}
 		<div class="col-sm-3">

--- a/defaults/config.js
+++ b/defaults/config.js
@@ -119,6 +119,17 @@ module.exports = {
 	lockNetwork: false,
 
 	//
+	// Lock username
+	//
+	// If enabled, users will be forced to connect with
+	// the specified username.
+	//
+	// @type     string
+	// @default  null
+	//
+	lockUsername: null,
+
+	//
 	// Hex IP
 	//
 	// If enabled, clients' username will be set to their IP encoded has hex.

--- a/src/client.js
+++ b/src/client.js
@@ -247,12 +247,18 @@ Client.prototype.connect = function(args) {
 		}
 	}
 
+	let resolvedUsername = Helper.config.useHexIp ? Helper.ip2hex(args.ip) : network.username;
+
+	if (Helper.config.lockUsername !== null) {
+		resolvedUsername = Helper.config.lockUsername;
+	}
+
 	network.irc = new ircFramework.Client({
 		version: false, // We handle it ourselves
 		host: network.host,
 		port: network.port,
 		nick: nick,
-		username: Helper.config.useHexIp ? Helper.ip2hex(args.ip) : network.username,
+		username: resolvedUsername,
 		gecos: network.realname,
 		password: network.password,
 		tls: network.tls,

--- a/src/server.js
+++ b/src/server.js
@@ -545,6 +545,7 @@ function getClientConfiguration() {
 	const config = _.pick(Helper.config, [
 		"public",
 		"lockNetwork",
+		"lockUsername",
 		"displayNetwork",
 		"useHexIp",
 		"themes",


### PR DESCRIPTION
Allows network administrators to force specific usernames (intended for use in public mode).

Feature parity: iris.conf ident_string

May be preferable to hide the username field entirely?