### PR TITLE
Exclude Node v9.9 from Travis build, for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 node_js:
-- 9 # Current stable
+# TODO: Node 9.9.0 has a bug with path normalization. Switch back to `9`
+#       https://github.com/nodejs/node/commit/a0adf56 is released.
+- 9.8 # Current stable
 - 8 # Active LTS until April 2019
 - 6 # Active LTS until April 2018
 


### PR DESCRIPTION
Node 9.9.0 breaks one of our tests, and it's getting really noisy in the CI status checks. **Revert this once the next version of Node with a fix gets released.**

References:

- https://github.com/nodejs/node/issues/19519
- https://github.com/nodejs/node/pull/19520
- https://github.com/nodejs/node/commit/a0adf56855f59a301d9a1f69b4267ced4fd4cf03

I hesitated to mark node v9 as [`allow_failures`](https://docs.travis-ci.com/user/customizing-the-build/#Rows-that-are-Allowed-to-Fail), but figured we'd still want to successfully test against some Node v9 version, and having both v9.8 + v9.9-failures-allowed was overkill.