### PR TITLE
Fix/Improve some nick fallbacks

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -140,7 +140,7 @@ Client.prototype.find = function(channelId) {
 
 Client.prototype.connect = function(args) {
 	const client = this;
-	const nick = args.nick || "lounge-user";
+	const nick = args.nick || "thelounge";
 	let webirc = null;
 	let channels = [];
 

--- a/src/plugins/irc-events/error.js
+++ b/src/plugins/irc-events/error.js
@@ -39,7 +39,7 @@ module.exports = function(irc, network) {
 		lobby.pushMessage(client, msg, true);
 
 		if (irc.connection.registered === false) {
-			const random = (data.nick || irc.user.nick) + Math.floor(10 + (Math.random() * 89));
+			const random = (data.nick || irc.user.nick) + Math.floor(Math.random() * 10);
 			irc.changeNick(random);
 		}
 
@@ -59,8 +59,7 @@ module.exports = function(irc, network) {
 		lobby.pushMessage(client, msg, true);
 
 		if (irc.connection.registered === false) {
-			const random = "i" + Math.random().toString(36).substr(2, 10); // 'i' so it never begins with a number
-			irc.changeNick(random);
+			irc.changeNick("thelounge" + Math.floor(Math.random() * 100));
 		}
 
 		client.emit("nick", {


### PR DESCRIPTION
- Rename a forgotten `lounge-user`
- Generate nick fallbacks when already in use by appending 0-9 instead of 10-98 (?!).
- Generate nick fallbacks when invalid similarly to our config default instead of random string. This is to make it less confusing when fallback gets used.