### PR TITLE
Sync on both load and reconnect

### DIFF
--- a/client/js/options.js
+++ b/client/js/options.js
@@ -303,5 +303,5 @@ function initialize() {
 	// Local init is done, let's sync
 	// We always ask for synced settings even if it is disabled.
 	// Settings can be mandatory to sync and it is used to determine sync base state.
-	socket.emit("settings:get");
+	socket.emit("setting:get");
 }

--- a/client/js/socket-events/configuration.js
+++ b/client/js/socket-events/configuration.js
@@ -8,6 +8,8 @@ const webpush = require("../webpush");
 
 socket.on("configuration", function(data) {
 	if (options.initialized) {
+		// Likely a reconnect, request sync for possibly missed settings.
+		socket.emit("setting:get");
 		return;
 	}
 


### PR DESCRIPTION
Fixes #2278

Turns out that I forgot to change `settings:get` to `setting:get` so settings never got synced on startup. Also made it so that the client will now sync settings when reconnecting. 