### PR TITLE
Enable sync on empty localstorage, force sync, sync on both load and reconnect.

### DIFF
--- a/client/js/options.js
+++ b/client/js/options.js
@@ -49,11 +49,16 @@ const noSync = ["syncSettings"];
 const alwaysSync = [];
 
 // Process usersettings from localstorage.
-let userSettings = JSON.parse(storage.get("settings")) || {};
+let userSettings = JSON.parse(storage.get("settings")) || false;
 
-for (const key in settings) {
-	if (userSettings[key] !== undefined) {
-		settings[key] = userSettings[key];
+if (!userSettings) {
+	// Enable sync by default if there are no user defined settings.
+	settings.syncSettings = true;
+} else {
+	for (const key in settings) {
+		if (userSettings[key] !== undefined) {
+			settings[key] = userSettings[key];
+		}
 	}
 }
 

--- a/client/js/options.js
+++ b/client/js/options.js
@@ -319,5 +319,5 @@ function initialize() {
 	// Local init is done, let's sync
 	// We always ask for synced settings even if it is disabled.
 	// Settings can be mandatory to sync and it is used to determine sync base state.
-	socket.emit("settings:get");
+	socket.emit("setting:get");
 }

--- a/client/js/options.js
+++ b/client/js/options.js
@@ -312,7 +312,7 @@ function initialize() {
 		}
 	});
 
-	$settings.on("click", "#forceSync", () => {
+	$settings.find("#forceSync").on("click", () => {
 		syncAllSettings(true);
 	});
 

--- a/client/js/socket-events/configuration.js
+++ b/client/js/socket-events/configuration.js
@@ -8,6 +8,8 @@ const webpush = require("../webpush");
 
 socket.on("configuration", function(data) {
 	if (options.initialized) {
+		// Likely a reconnect, request sync for possibly missed settings.
+		socket.emit("setting:get");
 		return;
 	}
 

--- a/client/js/socket-events/setting.js
+++ b/client/js/socket-events/setting.js
@@ -19,7 +19,7 @@ socket.on("setting:new", function(data) {
 
 socket.on("setting:all", function(settings) {
 	if (Object.keys(settings).length === 0) {
-		options.noServerSettings();
+		options.syncAllSettings();
 	} else {
 		for (const name in settings) {
 			evaluateSetting(name, settings[name]);

--- a/client/views/windows/settings.tpl
+++ b/client/views/windows/settings.tpl
@@ -28,6 +28,10 @@
 			</label>
 			<p class="sync-warning-override"><strong>Warning</strong> Checking this box will override the settings of this client with those stored on the server.</p>
 			<p class="sync-warning-base"><strong>Warning</strong> No settings have been synced before. Enabling this will sync all settings of this client as the base for other clients.</p>
+			<label class="opt force-sync-button">
+				<button type="button" class="btn" id="forceSync">Force sync settings</button><br>
+				This will override any settings already synced to the server.
+			</label>
 		</div>
 		{{/unless}}
 		<div class="col-sm-12">


### PR DESCRIPTION
This fixes #2278

Turns out that I forgot to change `settings:get` to `setting:get` so settings never got synced on startup. Also made it so that the client will now sync settings when reconnecting. 

This also implements #2279 with the force sync button as discussed in that issue.
