### PR TITLE
Fix server side rendering for href of initial theme

### DIFF
--- a/client/index.html.tpl
+++ b/client/index.html.tpl
@@ -10,7 +10,7 @@
 	<link rel="stylesheet" href="css/bootstrap.css">
 	<link rel="stylesheet" href="css/primer-tooltips.css">
 	<link rel="stylesheet" href="css/style.css">
-	<link id="theme" rel="stylesheet" href="themes/<%- theme %>.css" data-server-theme="<%- theme %>">
+	<link id="theme" rel="stylesheet" href="<%- theme %>" data-server-theme="<%- theme %>">
 	<% _.forEach(stylesheets, function(css) { %>
 		<link rel="stylesheet" href="packages/<%- css %>">
 	<% }); %>


### PR DESCRIPTION
The index.html template renders the initial theme's href incorrectly, making the browser try to load `/themes/themes/example.css.css`. 
This is because the `theme` variable already includes the `/themes/` prefix and `.css` suffix, which the template then adds again.