### PR TITLE
Replace "." character with random digit in nick param

### DIFF
--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -414,6 +414,10 @@ $(function() {
 				params.join = params.channels;
 			}
 
+			if ("nick" in params) {
+				params.nick = params.nick.replace(/\./g, () => "" + Math.floor(Math.random() * Math.floor(10)));
+			}
+
 			// Possible parameters:  name, host, port, password, tls, nick, username, realname, join
 			// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...in#Iterating_over_own_properties_only
 			for (let key in params) {


### PR DESCRIPTION
Feature parity: iris (https://github.com/atheme-legacy/iris/commit/c747578046dcf9925a4353c7cf9740c51367a7f0)

Use-case: Support channels, ensuring minimal chance of nick collision.