### PR TITLE
Prevent "undefined" OS version in session list

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -316,7 +316,11 @@ Client.prototype.updateSession = function(token, ip, request) {
 	}
 
 	if (agent.os.name) {
-		friendlyAgent += ` on ${agent.os.name} ${agent.os.version}`;
+		friendlyAgent += ` on ${agent.os.name}`;
+
+		if (agent.os.version) {
+			friendlyAgent += ` ${agent.os.version}`;
+		}
 	}
 
 	client.config.sessions[token] = _.assign(client.config.sessions[token], {


### PR DESCRIPTION
Noticed this in my session list after spinning up a new Ubuntu machine & logging in to The Lounge from it. Here's a quick little PR to make the ugly `undefined` go away.