### PR TITLE
Add 'op' and 'voice' user context menu items

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -279,6 +279,8 @@ kbd {
 .context-menu-list::before { content: "\f03a"; /* http://fontawesome.io/icon/list/ */ }
 .context-menu-action-whois::before { content: "\f05a"; /* http://fontawesome.io/icon/info-circle/  */ }
 .context-menu-action-kick::before { content: "\f05e"; /* http://fontawesome.io/icon/ban/ */ }
+.context-menu-action-op::before { content: "\f1fa"; /* http://fontawesome.io/icon/at/ */ }
+.context-menu-action-voice::before { content: "\f067"; /* http://fontawesome.io/icon/plus/ */ }
 .context-menu-network::before { content: "\f233"; /* https://fontawesome.com/icons/server?style=solid */ }
 
 #sidebar .not-secure-icon::before {
@@ -1952,7 +1954,7 @@ part/quit messages where we don't load previews (adds a blank line otherwise) */
 	list-style: none;
 	margin: 0;
 	padding: 0;
-	min-width: 160px;
+	min-width: 180px;
 	font-size: 14px;
 	background-color: #fff;
 	box-shadow: 0 3px 12px rgba(0, 0, 0, 0.15);

--- a/client/js/contextMenuFactory.js
+++ b/client/js/contextMenuFactory.js
@@ -125,6 +125,82 @@ function addKickItem() {
 	});
 }
 
+function addOpItem() {
+	function op(itemData) {
+		socket.emit("input", {
+			target: $("#chat").data("id"),
+			text: "/op " + itemData,
+		});
+	}
+
+	addContextMenuItem({
+		check: (target) =>
+			utils.hasRoleInChannel(target.closest(".chan"), ["op"]) &&
+			!utils.hasRoleInChannel(target.closest(".chan"), ["op"], target.data("name")),
+		className: "action-op",
+		displayName: "Give operator (+o)",
+		data: (target) => target.data("name"),
+		callback: op,
+	});
+}
+
+function addDeopItem() {
+	function deop(itemData) {
+		socket.emit("input", {
+			target: $("#chat").data("id"),
+			text: "/deop " + itemData,
+		});
+	}
+
+	addContextMenuItem({
+		check: (target) =>
+			utils.hasRoleInChannel(target.closest(".chan"), ["op"]) &&
+			utils.hasRoleInChannel(target.closest(".chan"), ["op"], target.data("name")),
+		className: "action-op",
+		displayName: "Revoke operator (-o)",
+		data: (target) => target.data("name"),
+		callback: deop,
+	});
+}
+
+function addVoiceItem() {
+	function voice(itemData) {
+		socket.emit("input", {
+			target: $("#chat").data("id"),
+			text: "/voice " + itemData,
+		});
+	}
+
+	addContextMenuItem({
+		check: (target) =>
+			utils.hasRoleInChannel(target.closest(".chan"), ["op"]) &&
+			!utils.hasRoleInChannel(target.closest(".chan"), ["voice"], target.data("name")),
+		className: "action-voice",
+		displayName: "Give voice (+v)",
+		data: (target) => target.data("name"),
+		callback: voice,
+	});
+}
+
+function addDevoiceItem() {
+	function devoice(itemData) {
+		socket.emit("input", {
+			target: $("#chat").data("id"),
+			text: "/devoice " + itemData,
+		});
+	}
+
+	addContextMenuItem({
+		check: (target) =>
+			utils.hasRoleInChannel(target.closest(".chan"), ["op"]) &&
+			utils.hasRoleInChannel(target.closest(".chan"), ["voice"], target.data("name")),
+		className: "action-voice",
+		displayName: "Revoke voice (-v)",
+		data: (target) => target.data("name"),
+		callback: devoice,
+	});
+}
+
 function addFocusItem() {
 	function focusChan(itemData) {
 		$(`.networks .chan[data-target="${itemData}"]`).click();
@@ -206,6 +282,10 @@ function addDefaultItems() {
 	addWhoisItem();
 	addQueryItem();
 	addKickItem();
+	addOpItem();
+	addDeopItem();
+	addVoiceItem();
+	addDevoiceItem();
 	addFocusItem();
 	addChannelListItem();
 	addBanListItem();

--- a/client/js/utils.js
+++ b/client/js/utils.js
@@ -42,16 +42,16 @@ function resetHeight(element) {
 	element.style.height = element.style.minHeight;
 }
 
-// Given a channel element will determine if the lounge user is one of the supplied roles.
-function hasRoleInChannel(channel, roles) {
+// Given a channel element will determine if the lounge user or a given nick is one of the supplied roles.
+function hasRoleInChannel(channel, roles, nick) {
 	if (!channel || !roles) {
 		return false;
 	}
 
 	const channelID = channel.data("id");
 	const network = $("#sidebar .network").has(`.chan[data-id="${channelID}"]`);
-	const ownNick = network.data("nick");
-	const user = channel.find(`.names-original .user[data-name="${escape(ownNick)}"]`).first();
+	const target = nick || network.data("nick");
+	const user = channel.find(`.names-original .user[data-name="${escape(target)}"]`).first();
 	return user.parent().is("." + roles.join(", ."));
 }
 


### PR DESCRIPTION
As a first step to adding more commands to the context menu, this adds the probably most common modes +o (op) and +v (voice) when you have +o (similar to the kick entry).

![image](https://user-images.githubusercontent.com/2070503/38746167-06067888-3f47-11e8-9039-f63d9cca6787.png)

If the target is op, it shows "Revoke op (-o)", same for voice. All these only appear when you're op yourself.

I discussed with @McInkay and @xPaw and we concluded that in the future, 

> what we ideally want is entries on the context menu for each of the ones in PREFIX (with the name from the handlebars plugin) up to your own priviledge, except voice gets none

and also

> 17:18:44 <+McInkay> I'd be ok with the first version being "show op and voice if you are an op" and nothing else

So here goes. 

Also fixes #1081.