### PR TITLE
Fix nicks with special characters being colored incorrectly in messages

### DIFF
--- a/client/js/libs/handlebars/parse.js
+++ b/client/js/libs/handlebars/parse.js
@@ -122,7 +122,7 @@ module.exports = function parse(text, users) {
 			return `<span class="emoji" role="img" aria-label="Emoji: ${emojiMap[textPart.emoji]}" title="${emojiMap[textPart.emoji]}">${fragments}</span>`;
 		} else if (textPart.nick) {
 			const nick = Handlebars.Utils.escapeExpression(textPart.nick);
-			return `<span role="button" class="user ${colorClass(nick)}" data-name="${nick}">${fragments}</span>`;
+			return `<span role="button" class="user ${colorClass(textPart.nick)}" data-name="${nick}">${fragments}</span>`;
 		}
 
 		return fragments;


### PR DESCRIPTION
Fixes #2362. It was hashing based on the encoded version.

@MiniDigger please test.