### PR TITLE
Quick-fix tooltips not being loaded by Webpack

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -1,6 +1,5 @@
 @import "fontawesome.css";
 @import "bootstrap.css";
-@import "../../node_modules/primer-tooltips/build/build.css";
 
 :root {
 	/* Links and link-looking buttons */

--- a/client/index.html.tpl
+++ b/client/index.html.tpl
@@ -7,6 +7,8 @@
 
 	<link rel="preload" as="script" href="js/bundle.vendor.js">
 	<link rel="preload" as="script" href="js/bundle.js">
+
+	<link rel="stylesheet" href="css/primer-tooltips.css">
 	<link rel="stylesheet" href="css/style.css">
 	<link id="theme" rel="stylesheet" href="themes/<%- theme %>.css" data-server-theme="<%- theme %>">
 	<% _.forEach(stylesheets, function(css) { %>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -114,6 +114,10 @@ const config = {
 				from: "./client/themes/*",
 				to: "themes/[name].[ext]",
 			},
+			{
+				from: "./node_modules/primer-tooltips/build/build.css",
+				to: "css/primer-tooltips.[ext]",
+			},
 		]),
 		// socket.io uses debug, we don't need it
 		new webpack.NormalModuleReplacementPlugin(/debug/, path.resolve(__dirname, "scripts/noop.js")),


### PR DESCRIPTION
Fixes #2353.

I tried so many ways to get it right, with `~primer-tooltips/build/build.css`, with `url()`, with `css-loader`'s `options.alias`, etc. etc. etc., nothing worked.