### PR TITLE
Remove header border on non-chat windows and reduce top margin a bit more

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -180,7 +180,7 @@ kbd {
 }
 
 .container {
-	margin: 20px auto;
+	margin-bottom: 20px;
 	max-width: 480px;
 	touch-action: pan-y;
 }
@@ -877,13 +877,16 @@ kbd {
 }
 
 #windows .header {
-	border-bottom: 1px solid #e7e7e7;
 	line-height: 48px;
 	height: 48px;
 	padding: 0 6px;
 	display: flex;
 	flex-shrink: 0;
 	overflow: hidden;
+}
+
+#windows #chat .header {
+	border-bottom: 1px solid #e7e7e7;
 }
 
 #windows .header .title {
@@ -2207,10 +2210,6 @@ part/quit messages where we don't load previews (adds a blank line otherwise) */
 		opacity: 0;
 	}
 
-	.container {
-		margin-top: 60px !important;
-	}
-
 	#sidebar button,
 	#sidebar .chan,
 	#sidebar .empty,
@@ -2312,7 +2311,7 @@ part/quit messages where we don't load previews (adds a blank line otherwise) */
 
 @media (max-width: 479px) {
 	.container {
-		margin: 10px 0 !important;
+		margin: 0;
 	}
 
 	#sign-in .btn {

--- a/client/css/style.css
+++ b/client/css/style.css
@@ -470,7 +470,13 @@ kbd {
 	width: 36px;
 }
 
+/* Channel list button stays fixed when scrolling... */
 #viewport .lt {
+	position: fixed;
+}
+
+/* ... Except on chat windows, relative to include the notification dot */
+#viewport #chat .lt {
 	position: relative;
 }
 
@@ -2284,6 +2290,11 @@ part/quit messages where we don't load previews (adds a blank line otherwise) */
 	#viewport .lt,
 	#viewport .channel .rt {
 		display: flex;
+	}
+
+	/* On mobile display, channel list button stays at the top */
+	#viewport .lt {
+		position: relative;
 	}
 
 	#chat .userlist {

--- a/client/themes/morning.css
+++ b/client/themes/morning.css
@@ -32,7 +32,7 @@ body {
 
 /* Borders */
 #chat .content,
-#windows .header,
+#windows #chat .header,
 #chat .user-mode::before,
 #chat .userlist {
 	border-color: #2a323d;


### PR DESCRIPTION
Follow-up of #2321.
Extracted from #2315.

Before | After
--- | ---
<img width="1066" alt="screen shot 2018-04-17 at 23 26 42" src="https://user-images.githubusercontent.com/113730/38899032-ff035d5a-4296-11e8-8a03-a40e0c24175d.png"> | <img width="1069" alt="screen shot 2018-04-17 at 23 25 46" src="https://user-images.githubusercontent.com/113730/38899044-03e77aae-4297-11e8-8347-b3c1a5a60dcd.png">
<img width="205" alt="screen shot 2018-04-17 at 23 28 53" src="https://user-images.githubusercontent.com/113730/38899517-61fc3a52-4298-11e8-84c7-6ae06e6bdfbb.png"> | <img width="203" alt="screen shot 2018-04-17 at 23 37 26" src="https://user-images.githubusercontent.com/113730/38899518-621c874e-4298-11e8-9ff8-32487bebad27.png">
