### PR TITLE
Add prefix to channels from connect window

### DIFF
--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -361,14 +361,13 @@ $(function() {
 					let value = params[key];
 
 					if (key === "join") {
-						const channels = value.split(",");
-						value = channels.map((c) => {
-							if (c.match(/^\w/)) {
-								return "#" + c;
+						value = value.split(",").map((chan) => {
+							if (!chan.match(/^[#&!+]/)) {
+								return `#${chan}`;
 							}
 
-							return c;
-						}).join(",");
+							return chan;
+						}).join(", ");
 					}
 
 					// \W searches for non-word characters

--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -4,7 +4,6 @@
 require("jquery-ui/ui/widgets/sortable");
 const $ = require("jquery");
 const moment = require("moment");
-const URI = require("urijs");
 
 // our libraries
 require("./libs/jquery/stickyscroll");
@@ -345,48 +344,6 @@ $(function() {
 		data: (target) => target.attr("data-target"),
 		callback: (itemData) => closeChan($(`.networks .chan[data-target="${itemData}"]`)),
 	});
-
-	if ($(document.body).hasClass("public") && (window.location.hash === "#connect" || window.location.hash === "")) {
-		$("#connect").one("show", function() {
-			const params = URI(document.location.search).search(true);
-
-			if ("channels" in params) {
-				params.join = params.channels;
-			}
-
-			// Possible parameters:  name, host, port, password, tls, nick, username, realname, join
-			// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...in#Iterating_over_own_properties_only
-			for (let key in params) {
-				if (params.hasOwnProperty(key)) {
-					let value = params[key];
-
-					if (key === "join") {
-						value = value.split(",").map((chan) => {
-							if (!chan.match(/^[#&!+]/)) {
-								return `#${chan}`;
-							}
-
-							return chan;
-						}).join(", ");
-					}
-
-					// \W searches for non-word characters
-					key = key.replace(/\W/g, "");
-
-					const element = $("#connect input[name='" + key + "']");
-
-					// if the element exists, it isn't disabled, and it isn't hidden
-					if (element.length > 0 && !element.is(":disabled") && !element.is(":hidden")) {
-						if (element.is(":checkbox")) {
-							element.prop("checked", (value === "1" || value === "true") ? true : false);
-						} else {
-							element.val(value);
-						}
-					}
-				}
-			}
-		});
-	}
 
 	$(document).on("visibilitychange focus click", () => {
 		if (sidebar.find(".highlight").length === 0) {

--- a/client/js/socket-events/configuration.js
+++ b/client/js/socket-events/configuration.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const $ = require("jquery");
+const URI = require("urijs");
 const socket = require("../socket");
 const templates = require("../../views");
 const options = require("../options");
@@ -84,4 +85,38 @@ socket.on("configuration", function(data) {
 				$(this).data("lastvalue", nick);
 			});
 	});
+
+	if ($(document.body).hasClass("public")) {
+		const params = URI(document.location.search).search(true);
+
+		for (let key in params) {
+			// Support `channels` as a compatibility alias with other clients
+			if (key === "channels") {
+				key = "join";
+			}
+
+			if (!data.defaults.hasOwnProperty(key)) {
+				continue;
+			}
+
+			let value = params[key];
+
+			if (key === "join") {
+				value = value.split(",").map((chan) => {
+					if (!chan.match(/^[#&!+]/)) {
+						return `#${chan}`;
+					}
+
+					return chan;
+				}).join(", ");
+			}
+
+			// Override server provided defaults with parameters passed in the URL if they match the data type
+			switch (typeof data.defaults[key]) {
+			case "boolean": data.defaults[key] = value === "1" || value === "true"; break;
+			case "number": data.defaults[key] = Number(value); break;
+			case "string": data.defaults[key] = String(value); break;
+			}
+		}
+	}
 });

--- a/client/js/socket-events/init.js
+++ b/client/js/socket-events/init.js
@@ -23,10 +23,6 @@ socket.on("init", function(data) {
 
 	if (data.networks.length === 0) {
 		sidebar.find(".empty").show();
-
-		$("#footer").find(".connect").trigger("click", {
-			pushState: false,
-		});
 	} else {
 		render.renderNetworks(data);
 	}

--- a/src/client.js
+++ b/src/client.js
@@ -177,7 +177,11 @@ Client.prototype.connect = function(args) {
 		channels = args.join
 			.replace(/,/g, " ")
 			.split(/\s+/g)
-			.map(function(chan) {
+			.map((chan) => {
+				if (!chan.match(/^[#&!+]/)) {
+					chan = `#${chan}`;
+				}
+
 				return client.createChannel({
 					name: chan,
 				});


### PR DESCRIPTION
Fixes #2327.
Fixes #2424.

I changed the regex to known chan types because stuff like `[test]` wouldn't match otherwise.

Also fixed 2 other bugs:
- Fix connect window opening twice in public mode
- Override server provided defaults with parameters passed in the URL if they match the data type (this is currently broken on master)