### PR TITLE
Add `upgrade` CLI command for themes and packages

### DIFF
--- a/src/command-line/index.js
+++ b/src/command-line/index.js
@@ -48,6 +48,7 @@ if (!Helper.config.public && !Helper.config.ldap.enable) {
 
 require("./install");
 require("./uninstall");
+require("./upgrade");
 
 // `parse` expects to be passed `process.argv`, but we need to remove to give it
 // a version of `argv` that does not contain options already parsed by

--- a/src/command-line/upgrade.js
+++ b/src/command-line/upgrade.js
@@ -1,0 +1,66 @@
+"use strict";
+
+const colors = require("chalk");
+const program = require("commander");
+const Helper = require("../helper");
+const Utils = require("./utils");
+
+program
+	.command("upgrade [packages...]")
+	.description("Upgrade installed themes and packages to their latest versions.")
+	.on("--help", Utils.extraHelp)
+	.action(function(packages) {
+		const fs = require("fs");
+		const path = require("path");
+
+		// Get paths to the location of packages directory
+		const packagesPath = Helper.getPackagesPath();
+		const packagesConfig = path.join(packagesPath, "package.json");
+		const packagesList = JSON.parse(fs.readFileSync(packagesConfig)).dependencies;
+		const argsList = [
+			"upgrade",
+			"--latest",
+			"--json",
+			"--production",
+			"--ignore-scripts",
+			"--non-interactive",
+			"--cwd",
+			packagesPath,
+		];
+
+		let count = 0;
+
+		// Check if the configuration file exists
+		if (!fs.existsSync(packagesConfig)) {
+			log.warn("There are no packages installed.");
+			return;
+		}
+
+		// If a package names are supplied, check they exist
+		if (packages.length) {
+			log.info("Upgrading the following packages:");
+			packages.forEach((p) => {
+				log.info(`- ${colors.green(p)}`);
+
+				if (packagesList.hasOwnProperty(p)) {
+					argsList.splice(1, 0, p);
+					count++;
+				} else {
+					log.error(`${colors.green(p)} is not installed.`);
+				}
+			});
+		} else {
+			log.info("Upgrading all packages...");
+		}
+
+		if (count === 0 && packages.length) {
+			log.warn("There are not any packages to upgrade.");
+			return;
+		}
+
+		return Utils.executeYarnCommand(...argsList).then(() => {
+			log.info("Package(s) have been successfully upgraded.");
+		}).catch((code) => {
+			throw `Failed to upgrade package(s). Exit code ${code}`;
+		});
+	});


### PR DESCRIPTION
> I apologise if I was supposed to create an issue but I'd already made it by the time I had seen that in the contributing guidelines.

Earlier on today I needed to update some of my themes and I thought it was quite a long winded way to do `thelounge install thelounge-theme-mytheme` for each theme I wanted to update, so I made a `thelounge update` command which updates all of the themes installed.

I've tested it when themes need to be updated, when themes are already up to date and when there are no themes (and no packages folder) and it seems to work fine.