### PR TITLE
Fix Alt+Up/Down cycling through channels of collapsed networks

### DIFF
--- a/client/js/keybinds.js
+++ b/client/js/keybinds.js
@@ -41,7 +41,7 @@ Mousetrap.bind([
 	"alt+up",
 	"alt+down",
 ], function(e, keys) {
-	const channels = sidebar.find(".chan");
+	const channels = sidebar.find(".chan").not(".network.collapsed :not(.lobby)");
 	const index = channels.index(channels.filter(".active"));
 	const direction = keys.split("+").pop();
 	let target;


### PR DESCRIPTION
This Fixes #2200.
It now filters channels inside a collapsed network when cycling through channels.