### PR TITLE
Fix channel and ban lists in context menu not working

### DIFF
--- a/client/js/contextMenuFactory.js
+++ b/client/js/contextMenuFactory.js
@@ -247,7 +247,7 @@ function addEditNetworkItem() {
 function addChannelListItem() {
 	function list(itemData) {
 		socket.emit("input", {
-			target: itemData,
+			target: parseInt(itemData, 10),
 			text: "/list",
 		});
 	}
@@ -264,7 +264,7 @@ function addChannelListItem() {
 function addBanListItem() {
 	function banlist(itemData) {
 		socket.emit("input", {
-			target: itemData,
+			target: parseInt(itemData, 10),
 			text: "/banlist",
 		});
 	}


### PR DESCRIPTION
Fixes #2400.

Broken by #2398 because it no longer uses jquery magic to automatically assume the data type and server wants an actual number.