### PR TITLE
Fix merge() in parser not filling unstyled text correctly

### DIFF
--- a/client/js/libs/handlebars/ircmessageparser/merge.js
+++ b/client/js/libs/handlebars/ircmessageparser/merge.js
@@ -25,13 +25,9 @@ function sortParts(a, b) {
 // "o", and the second resulting part will contain "b" and "ar". "o" and "b"
 // fragments will contain duplicate styling attributes.
 function merge(textParts, styleFragments, cleanText) {
-	// Every section of the original text that has not been captured in a "part"
-	// is filled with "text" parts, dummy objects with start/end but no extra
-	// metadata.
-	const allParts = textParts
-		.sort(sortParts) // Sort all parts identified based on their position in the original text
-		.concat(fill(textParts, cleanText))
-		.sort(sortParts) // Sort them again after filling in unstyled text
+	// Remove overlapping parts
+	textParts = textParts
+		.sort(sortParts)
 		.reduce((prev, curr) => {
 			const intersection = prev.some((p) => anyIntersection(p, curr));
 
@@ -41,6 +37,13 @@ function merge(textParts, styleFragments, cleanText) {
 
 			return prev.concat([curr]);
 		}, []);
+
+	// Every section of the original text that has not been captured in a "part"
+	// is filled with "text" parts, dummy objects with start/end but no extra
+	// metadata.
+	const allParts = textParts
+		.concat(fill(textParts, cleanText))
+		.sort(sortParts); // Sort all parts identified based on their position in the original text
 
 	// Distribute the style fragments within the text parts
 	return allParts.map((textPart) => {

--- a/test/client/js/libs/handlebars/ircmessageparser/merge.js
+++ b/test/client/js/libs/handlebars/ircmessageparser/merge.js
@@ -60,4 +60,67 @@ describe("merge", () => {
 
 		expect(actual).to.deep.equal(expected);
 	});
+
+	it("should not drop clean text", () => {
+		const textParts = [{
+			start: 0,
+			end: 52,
+			link: "https://github.com/xPaw/PHP-Source-Query/runs/175079",
+		}];
+		const styleFragments = [{
+			bold: false,
+			textColor: undefined,
+			bgColor: undefined,
+			hexColor: undefined,
+			hexBgColor: undefined,
+			italic: false,
+			underline: false,
+			strikethrough: false,
+			monospace: false,
+			text: "https://github.com/xPaw/PHP-Source-Query/runs/175079 here's some text",
+			start: 0,
+			end: 69,
+		}];
+
+		const expected = [{
+			link: "https://github.com/xPaw/PHP-Source-Query/runs/175079",
+			start: 0,
+			end: 52,
+			fragments: [{
+				bold: false,
+				textColor: undefined,
+				bgColor: undefined,
+				hexColor: undefined,
+				hexBgColor: undefined,
+				italic: false,
+				underline: false,
+				strikethrough: false,
+				monospace: false,
+				text: "https://github.com/xPaw/PHP-Source-Query/runs/175079",
+				start: 0,
+				end: 52,
+			}],
+		}, {
+			start: 52,
+			end: 69,
+			fragments: [{
+				bold: false,
+				textColor: undefined,
+				bgColor: undefined,
+				hexColor: undefined,
+				hexBgColor: undefined,
+				italic: false,
+				underline: false,
+				strikethrough: false,
+				monospace: false,
+				text: " here's some text",
+				start: 52,
+				end: 69,
+			}],
+		}];
+
+		const actual = merge(textParts, styleFragments, styleFragments.map((fragment) => fragment.text).join(""));
+
+		expect(actual).to.deep.equal(expected);
+	});
 });


### PR DESCRIPTION
Broken by 162b80183992ffcd5fcf42b00ae638c9afaf1f8e because `fill` needed sorted `textParts`.