### PR TITLE
Specify parseInt base in respondToIdent

### DIFF
--- a/src/identification.js
+++ b/src/identification.js
@@ -47,8 +47,8 @@ class Identification {
 	respondToIdent(socket, data) {
 		data = data.toString().split(",");
 
-		const lport = parseInt(data[0]);
-		const fport = parseInt(data[1]);
+		const lport = parseInt(data[0], 10) || 0;
+		const fport = parseInt(data[1], 10) || 0;
 
 		if (lport < 1 || fport < 1 || lport > 65535 || fport > 65535) {
 			return;


### PR DESCRIPTION
Just a minor issue to fix identd replying to malformed requests (when ports parse to NaN).