### PR TITLE
apply antialiased font-smoothing on body

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -31,6 +31,8 @@ body {
 	-moz-user-select: none;
 	-ms-user-select: none;
 	user-select: none;
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
 	cursor: default;
 	touch-action: none;
 
@@ -253,8 +255,6 @@ kbd {
 #sidebar .collapse-network-icon::before {
 	font: normal normal normal 14px/1 FontAwesome;
 	font-size: inherit; /* Can't have font-size inherit on line above, so need to override */
-	-webkit-font-smoothing: antialiased;
-	-moz-osx-font-smoothing: grayscale;
 }
 
 #viewport .lt::before { content: "\f0c9"; /* http://fontawesome.io/icon/bars/ */ }


### PR DESCRIPTION
Difference in Safari (make sure you view in 1:1 scale):

![screenshot 2018-05-14 at 17 54 21](https://user-images.githubusercontent.com/6705160/40138771-f84aef64-594d-11e8-9b1e-7524c89b4572.png)
![screenshot 2018-05-14 at 17 54 40](https://user-images.githubusercontent.com/6705160/40138772-f8660bf0-594d-11e8-80f7-5a8d7ff36cde.png)

I have just tested this in macOS Safari, opened PR to set the ball rolling

How it looks like in `master` now: https://streamable.com/omf67