### PR TITLE
naive fix for false nick highlighting

### DIFF
--- a/src/plugins/irc-events/message.js
+++ b/src/plugins/irc-events/message.js
@@ -110,8 +110,9 @@ module.exports = function(irc, network) {
 		}
 
 		let match;
+		const boundaryRegExp = /\b(.*)\b/g;
 
-		while ((match = nickRegExp.exec(data.message))) {
+		while ((match = boundaryRegExp.exec(data.message))) {
 			if (chan.findUser(match[1])) {
 				msg.users.push(match[1]);
 			}


### PR DESCRIPTION
addresses #2008 to fix highlighting users after `'`. does not account for unicode characters since the `\w` escape in current js regex only looks for ascii letters. 

after a small bit of preliminary research, it looks like solving this would require choosing a unicode range, adding common diacritic characters to the regex, or using an external lib for unicode regex (such as [xregexp](http://xregexp.com)).

let's discuss how to solve the unicode issue.