### PR TITLE
Update Travis and Renovate configs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,9 @@ cache: yarn
 before_script:
   - NODE_ENV=$BUILD_ENV yarn build
 
+install:
+  - yarn --frozen-lockfile
+
 notifications:
   email:
     on_success: never

--- a/renovate.json
+++ b/renovate.json
@@ -8,5 +8,6 @@
   "labels": [
     "Type: Dependencies"
   ],
+  "rebaseStalePrs": true,
   "statusCheckVerify": true
 }


### PR DESCRIPTION
As the lockfile no longer updates on travis (we had to do it with greenkeeper), we can make use of `--frozen-lockfile` (we already use it on appveyor).

Also enabled `rebaseStalePrs` in renovate to keep rebasing open dependency PRs onto master.