### PR TITLE
Add asterisk in front of nick in action lines

### DIFF
--- a/client/js/clipboard.js
+++ b/client/js/clipboard.js
@@ -22,6 +22,10 @@ function copyMessages() {
 			el.text(`<${el.text()}>`);
 		});
 
+	$(documentFragment)
+		.find(".content > .user")
+		.prepend("* ");
+
 	div.id = "js-copy-hack";
 	div.appendChild(documentFragment);
 	chat.appendChild(div);


### PR DESCRIPTION
fixes #2486

This adds a `*` in front of the sender nickname on copy pasting actions.

Tests:
![image](https://user-images.githubusercontent.com/2070503/40783631-58db063e-64e3-11e8-99f5-20e65123e94a.png)
