### PR TITLE
Undo webpack sorting, it made network always locked

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -74,8 +74,6 @@ const config = {
 						ignoreCustomFragments: [
 							/{{[\s\S]*?}}/,
 						],
-						sortAttributes: true,
-						sortClassName: true,
 					},
 				}],
 			},


### PR DESCRIPTION
The result of troubleshooting with @xPaw on IRC when I couldn't get a new instance working properly on c0ff2fe2 (the merge of #2498).