### PR TITLE
Don't mark your nick changes as self in each channel

### DIFF
--- a/src/plugins/irc-events/nick.js
+++ b/src/plugins/irc-events/nick.js
@@ -36,7 +36,6 @@ module.exports = function(irc, network) {
 				from: user,
 				type: Msg.Type.NICK,
 				new_nick: data.new_nick,
-				self: self,
 			});
 			chan.pushMessage(client, msg);
 


### PR DESCRIPTION
This accomplishes two things:

- Don't reset unread counters in all the channels
- Allows your nick changes to be condensed in all the channels (`You're now known as` is still shown in the lobby channel, so there's no reason to duplicate that info in every single channel)