### PR TITLE
Remove ability to change date format and timezone

### DIFF
--- a/defaults/config.js
+++ b/defaults/config.js
@@ -162,33 +162,6 @@ module.exports = {
 	messageStorage: ["sqlite", "text"],
 
 	//
-	// Log settings
-	//
-	// Logging has to be enabled per user. If enabled, logs will be stored in
-	// the 'logs/<user>/<network>/' folder.
-	//
-	// @type     object
-	// @default  {}
-	//
-	logs: {
-		//
-		// Timestamp format
-		//
-		// @type     string
-		// @default  "YYYY-MM-DD HH:mm:ss"
-		//
-		format: "YYYY-MM-DD HH:mm:ss",
-
-		//
-		// Timezone
-		//
-		// @type     string
-		// @default  "UTC+00:00"
-		//
-		timezone: "UTC+00:00",
-	},
-
-	//
 	// Maximum number of history lines per channel
 	//
 	// Defines the maximum number of history lines that will be kept in

--- a/src/helper.js
+++ b/src/helper.js
@@ -8,6 +8,7 @@ const fs = require("fs");
 const net = require("net");
 const bcrypt = require("bcryptjs");
 const colors = require("chalk");
+const moment = require("moment");
 
 let homePath;
 let configPath;
@@ -30,6 +31,7 @@ const Helper = {
 	setHome,
 	getVersion,
 	getGitCommit,
+	getHumanDate,
 	ip2hex,
 	mergeConfig,
 	getDefaultNick,
@@ -203,6 +205,10 @@ function passwordHash(password) {
 
 function passwordCompare(password, expected) {
 	return bcrypt.compare(password, expected);
+}
+
+function getHumanDate() {
+	return moment().format("YYYY-MM-DD HH:mm:ss");
 }
 
 function getDefaultNick() {

--- a/src/log.js
+++ b/src/log.js
@@ -1,16 +1,11 @@
 "use strict";
 
 const colors = require("chalk");
-const moment = require("moment");
 const read = require("read");
 const Helper = require("./helper");
 
 function timestamp() {
-	const format = Helper.config.logs.format || "YYYY-MM-DD HH:mm:ss";
-	const tz = Helper.config.logs.timezone || "UTC+00:00";
-	const time = moment().utcOffset(tz).format(format);
-
-	return colors.dim(time);
+	return colors.dim(Helper.getHumanDate());
 }
 
 module.exports = {

--- a/src/plugins/messageStorage/text.js
+++ b/src/plugins/messageStorage/text.js
@@ -3,7 +3,6 @@
 const fs = require("fs");
 const fsextra = require("fs-extra");
 const path = require("path");
-const moment = require("moment");
 const filenamify = require("filenamify");
 const Helper = require("../../helper");
 
@@ -40,11 +39,7 @@ class TextFileMessageStorage {
 			return;
 		}
 
-		const format = Helper.config.logs.format || "YYYY-MM-DD HH:mm:ss";
-		const tz = Helper.config.logs.timezone || "UTC+00:00";
-
-		const time = moment(msg.time).utcOffset(tz).format(format);
-		let line = `[${time}] `;
+		let line = `[${Helper.getHumanDate()}] `;
 
 		if (msg.type === "message") {
 			// Format:

--- a/test/src/helperTest.js
+++ b/test/src/helperTest.js
@@ -2,6 +2,7 @@
 
 const expect = require("chai").expect;
 const os = require("os");
+const moment = require("moment");
 const Helper = require("../../src/helper");
 
 describe("Helper", function() {
@@ -51,5 +52,9 @@ describe("Helper", function() {
 		it("should include a valid semver version", function() {
 			expect(version).to.match(/v[0-9]+\.[0-9]+\.[0-9]+/);
 		});
+	});
+
+	describe("#getHumanDate()", function() {
+		expect(Helper.getHumanDate()).to.equal(moment().format("YYYY-MM-DD HH:mm:ss"));
 	});
 });


### PR DESCRIPTION
Timezones were discussed in #1486. Removing it from config means the timezone of the server will be used.

Being able to change date format in logs makes little sence when you can't format anything else in the log.