### PR TITLE
Make CTCP requests/responses increase unread counter

### DIFF
--- a/src/plugins/irc-events/ctcp.js
+++ b/src/plugins/irc-events/ctcp.js
@@ -33,7 +33,7 @@ module.exports = function(irc, network) {
 			from: chan.getUser(data.nick),
 			ctcpMessage: data.message,
 		});
-		chan.pushMessage(client, msg);
+		chan.pushMessage(client, msg, true);
 	});
 
 	// Limit requests to a rate of one per second max
@@ -52,6 +52,6 @@ module.exports = function(irc, network) {
 			hostmask: data.ident + "@" + data.hostname,
 			ctcpMessage: data.message,
 		});
-		lobby.pushMessage(client, msg);
+		lobby.pushMessage(client, msg, true);
 	}, 1000, {trailing: false}));
 };


### PR DESCRIPTION
Incoming CTCP requests go to the lobby; incoming CTCP replies go to the lobby or, if there's an open query window for the source, into that.

In all of these cases, they do not increase the respective unread counter, so you will not notice them coming in.

This PR changes that.