### PR TITLE
Ensure HTML minifying does not incorrectly remove some whitespaces

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -71,6 +71,7 @@ const config = {
 				}, {
 					loader: "html-minifier-loader",
 					options: {
+						conservativeCollapse: true,
 						ignoreCustomFragments: [
 							/{{[\s\S]*?}}/,
 						],


### PR DESCRIPTION
#2498 was a bit too strict in what it removed. I noticed at least one instance where it removed a whitespace too strictly:

Before #2498 | After #2498
--- | ---
<img width="62" alt="screen shot 2018-06-04 at 01 06 01" src="https://user-images.githubusercontent.com/113730/40899299-3cc12326-6794-11e8-9b64-0aef4d0abbd5.png"> | <img width="57" alt="screen shot 2018-06-04 at 01 06 12" src="https://user-images.githubusercontent.com/113730/40899300-3cce9bc8-6794-11e8-9358-68c5e70bf8a6.png">

My guess is that these sneaky "whitespaces as margins" can be found in multiple places in the app. I'd rather not break those silently for now.

This PR fixes that by ensuring the last whitespace to be kept.
Note that `preserveLineBreaks: true` achieves the same fix, not sure if it is actually better but I assumed not (see https://github.com/kangax/html-minifier#options-quick-reference).