### PR TITLE
Network-first service worker caches

### DIFF
--- a/client/css/bootstrap.css
+++ b/client/css/bootstrap.css
@@ -44,7 +44,7 @@ audio:not([controls]) {
 }
 [hidden],
 template {
-  display: none;
+  display: none !important;
 }
 a {
   background: transparent;

--- a/client/js/loading-error-handlers.js
+++ b/client/js/loading-error-handlers.js
@@ -60,4 +60,9 @@
 	};
 
 	window.addEventListener("error", window.g_LoungeErrorHandler);
+
+	// Trigger early service worker registration
+	if ("serviceWorker" in navigator) {
+		navigator.serviceWorker.register("service-worker.js");
+	}
 })();

--- a/client/js/socket-events/configuration.js
+++ b/client/js/socket-events/configuration.js
@@ -8,6 +8,18 @@ const webpush = require("../webpush");
 const connect = $("#connect");
 const utils = require("../utils");
 
+window.addEventListener("beforeinstallprompt", (installPromptEvent) => {
+	$("#webapp-install-button")
+		.on("click", function() {
+			if (installPromptEvent && installPromptEvent.prompt) {
+				installPromptEvent.prompt();
+			}
+
+			$(this).prop("hidden", true);
+		})
+		.prop("hidden", false);
+});
+
 socket.on("configuration", function(data) {
 	if (options.initialized) {
 		// Likely a reconnect, request sync for possibly missed settings.

--- a/client/service-worker.js
+++ b/client/service-worker.js
@@ -2,6 +2,61 @@
 /* global clients */
 "use strict";
 
+const excludedPathsFromCache = /^(?:socket\.io|storage|uploads|cdn-cgi)\//;
+
+self.addEventListener("install", function() {
+	self.skipWaiting();
+});
+
+self.addEventListener("activate", function(event) {
+	event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener("fetch", function(event) {
+	if (event.request.method !== "GET") {
+		return;
+	}
+
+	const url = event.request.url;
+	const scope = self.registration.scope;
+
+	// Skip cross-origin requests
+	if (!url.startsWith(scope)) {
+		return;
+	}
+
+	const path = url.substring(scope.length);
+
+	// Skip ignored paths
+	if (excludedPathsFromCache.test(path)) {
+		return;
+	}
+
+	const uri = new URL(url);
+	uri.hash = "";
+	uri.search = "";
+
+	event.respondWith(networkOrCache(uri));
+});
+
+function networkOrCache(uri) {
+	return caches.open("thelounge").then(function(cache) {
+		return fetch(uri)
+			.then(function(response) {
+				if (response.ok) {
+					return cache.put(uri, response.clone()).then(function() {
+						return response;
+					});
+				}
+			})
+			.catch(function() {
+				return cache.match(uri).then(function(matching) {
+					return matching || Promise.reject("request-not-in-cache");
+				});
+			});
+	});
+}
+
 self.addEventListener("message", function(event) {
 	showNotification(event, event.data);
 });

--- a/client/service-worker.js
+++ b/client/service-worker.js
@@ -41,7 +41,8 @@ self.addEventListener("fetch", function(event) {
 
 function networkOrCache(uri) {
 	return caches.open("thelounge").then(function(cache) {
-		return fetch(uri)
+		// Despite the "no-cache" name, it is a conditional request if proper headers are set
+		return fetch(uri, {cache: "no-cache"})
 			.then(function(response) {
 				if (response.ok) {
 					return cache.put(uri, response.clone()).then(function() {

--- a/client/views/windows/settings.tpl
+++ b/client/views/windows/settings.tpl
@@ -15,6 +15,8 @@
 
 	<div class="row">
 		<div class="col-sm-12">
+			<h2>Native app</h2>
+			<button type="button" class="btn" id="webapp-install-button" hidden>Add The Lounge to Home screen</button>
 			<button type="button" class="btn" id="make-default-client">Open irc:// URLs with The Lounge</button>
 		</div>
 

--- a/src/server.js
+++ b/src/server.js
@@ -39,15 +39,17 @@ module.exports = function() {
 (Node.js ${colors.green(process.versions.node)} on ${colors.green(process.platform)} ${process.arch})`);
 	log.info(`Configuration file: ${colors.green(Helper.getConfigPath())}`);
 
+	const staticOptions = {
+		redirect: false,
+		maxAge: 86400 * 1000,
+	};
+
 	const app = express()
 		.disable("x-powered-by")
 		.use(allRequests)
 		.use(index)
-		.use(express.static("public"))
-		.use("/storage/", express.static(Helper.getStoragePath(), {
-			redirect: false,
-			maxAge: 86400 * 1000,
-		}));
+		.use(express.static(path.join(__dirname, "..", "public"), staticOptions))
+		.use("/storage/", express.static(Helper.getStoragePath(), staticOptions));
 
 	// This route serves *installed themes only*. Local themes are served directly
 	// from the `public/themes/` folder as static assets, without entering this


### PR DESCRIPTION
This adds offline "support". The Lounge itself won't connect or show messages, but at least it will render the loading screen and will keep trying to connect to the server.

This is also required for "add to home" in Chrome 68, as they changed the rules.

And finally this allows generating a proper PWA apk on Android, as Chrome considers it a proper PWA app now.

- [x] Fixes #2432
- [x] Don't handle or cache link preview media.
- [x] I think hashes and GET params need to be stripped from index file request.
- [x] Make a button in settings to prompt installing the app.
- [x] Fix trying to fetch cross-origin resources (like mp4)

@sinz163 for review