### PR TITLE
Replace current red-text highlight with a full background-color highlight

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -19,6 +19,10 @@
 
 	/* Color of the unread message marker, text and separator */
 	--unread-marker-color: rgba(231, 76, 60, 0.5);
+
+	/* Background and left-border color of highlight messages */
+	--highlight-bg-color: #efe8dc;
+	--highlight-border-color: #b08c4f;
 }
 
 /* Samsung Internet <7.0 and Microsoft Edge support (yes, both of them use webkit prefix) */
@@ -1175,7 +1179,7 @@ background on hover (unless active) */
 }
 
 #chat .time {
-	color: #ddd;
+	color: #999;
 	padding-left: 10px;
 	width: 55px;
 }
@@ -1365,11 +1369,23 @@ background on hover (unless active) */
 }
 
 #chat .error,
-#chat .error .from,
-#chat .channel .highlight .from,
-#chat .channel .highlight .text,
-#chat .channel .highlight .user {
-	color: #f00;
+#chat .error .from {
+	color: #e74c3c;
+}
+
+#chat .channel .message.highlight {
+	background-color: var(--highlight-bg-color);
+	border-left: 5px solid var(--highlight-border-color);
+}
+
+#chat .channel .message.highlight .time {
+	padding-left: 5px;
+	width: 50px;
+	color: #696969;
+}
+
+#chat .channel .message.highlight .content {
+	border-left: 1px solid var(--highlight-bg-color);
 }
 
 #chat .toggle-content.opened .more-caret, /* Expand/Collapse link previews */
@@ -2429,12 +2445,12 @@ part/quit messages where we don't load previews (adds a blank line otherwise) */
 
 	#chat .messages {
 		display: block;
-		padding: 5px 10px;
+		padding: 5px 0;
 	}
 
 	#chat .msg {
 		display: block;
-		padding: 2px 0;
+		padding: 2px 10px;
 	}
 
 	#chat .time,
@@ -2445,14 +2461,13 @@ part/quit messages where we don't load previews (adds a blank line otherwise) */
 		padding: 0;
 	}
 
+	#chat .channel .message.highlight .time {
+		padding-left: 0;
+	}
+
 	#chat .condensed-summary .time,
 	#chat .condensed-summary .from {
 		display: none;
-	}
-
-	#chat .date-marker,
-	#chat .unread-marker {
-		margin: 0;
 	}
 
 	#help .help-item .subject {

--- a/client/themes/morning.css
+++ b/client/themes/morning.css
@@ -6,6 +6,12 @@
 	--window-bg-color: #303e4a;
 	--date-marker-color: #97ea70;
 	--unread-marker-color: #f92772;
+	--highlight-bg-color: #4d4332;
+	--highlight-border-color: #b08c4f;
+}
+
+#chat .channel .message.highlight .time {
+	color: white;
 }
 
 #windows .logo {
@@ -121,10 +127,7 @@
 }
 
 #chat .error,
-#chat .error .from,
-#chat .channel .highlight,
-#chat .channel .highlight .from,
-#chat .channel .highlight .text {
+#chat .error .from {
 	color: #f92772;
 }
 
@@ -136,6 +139,7 @@
 	color: #b7c5d1;
 }
 
+#chat .time,
 #chat .condensed .content,
 #chat .away .content,
 #chat .back .content,


### PR DESCRIPTION
~⚠️ **This PR is currently set after my branch at #2315 so _Do Not Merge_ until that other PR makes it in, but making it its own PR to facilitate the review.**~
*All good now.*

---

Supersedes #1847 and #1846.

Inspired by @xPaw's approach at https://github.com/thelounge/thelounge/pull/1847#issuecomment-381578238.
I am using colors given by https://color.adobe.com/ to match our main color to match it with our actual "new" blue.

**Default theme:**

<img width="1101" alt="screen shot 2018-06-04 at 00 37 44" src="https://user-images.githubusercontent.com/113730/40898835-a6a16a56-6791-11e8-8463-8e10e825f8ac.png">

**Morning theme:**

<img width="1099" alt="screen shot 2018-06-04 at 00 44 08" src="https://user-images.githubusercontent.com/113730/40898836-a6add03e-6791-11e8-8110-6844742d5cc8.png">