### PR TITLE
Fix word boundary in the custom highlights regex not matching unicode

### DIFF
--- a/client/js/options.js
+++ b/client/js/options.js
@@ -146,7 +146,7 @@ function applySetting(name, value) {
 		});
 
 		if (highlightsTokens && highlightsTokens.length) {
-			module.exports.highlightsRE = new RegExp("\\b(?:" + highlightsTokens.join("|") + ")\\b", "i");
+			module.exports.highlightsRE = new RegExp(`(?:^| |\t)(?:${highlightsTokens.join("|")})(?:\t| |$)`, "i");
 		} else {
 			module.exports.highlightsRE = null;
 		}


### PR DESCRIPTION
Fixes #1939