### PR TITLE
Set caching on shields.io badges in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,19 +25,19 @@
 	<br>
 	<a href="https://yarn.pm/thelounge"><img
 		alt="npm version"
-		src="https://img.shields.io/npm/v/thelounge.svg?style=flat-square"></a>
+		src="https://img.shields.io/npm/v/thelounge.svg?style=flat-square&maxAge=3600"></a>
 	<a href="https://travis-ci.org/thelounge/thelounge"><img
 		alt="Travis CI Build Status"
-		src="https://img.shields.io/travis/thelounge/thelounge/master.svg?label=linux&style=flat-square"></a>
+		src="https://img.shields.io/travis/thelounge/thelounge/master.svg?label=linux&style=flat-square&maxAge=60"></a>
 	<a href="https://ci.appveyor.com/project/astorije/lounge/branch/master"><img
 		alt="AppVeyor Build Status"
-		src="https://img.shields.io/appveyor/ci/astorije/lounge/master.svg?label=windows&style=flat-square"></a>
+		src="https://img.shields.io/appveyor/ci/astorije/lounge/master.svg?label=windows&style=flat-square&maxAge=60"></a>
 	<a href="https://david-dm.org/thelounge/thelounge"><img
 		alt="Dependencies Status"
-		src="https://img.shields.io/david/thelounge/thelounge.svg?style=flat-square"></a>
+		src="https://img.shields.io/david/thelounge/thelounge.svg?style=flat-square&maxAge=3600"></a>
 	<a href="https://npm-stat.com/charts.html?package=thelounge&from=2016-02-12"><img
 		alt="Total downloads on npm"
-		src="https://img.shields.io/npm/dt/thelounge.svg?colorB=007dc7&style=flat-square"></a>
+		src="https://img.shields.io/npm/dt/thelounge.svg?colorB=007dc7&style=flat-square&maxAge=3600"></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
By default it's `no-cache` which causes them to fail to load frequently in the readme, this should help fix that.