### PR TITLE
Restore whitespace between caret and More/Less text in previews

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -1428,7 +1428,7 @@ kbd {
 }
 
 #chat .toggle-content .more::after {
-	content: attr(aria-label);
+	content: " " attr(aria-label);
 }
 
 #chat .toggle-content .more-caret {


### PR DESCRIPTION
Supersedes #2511. Follow-up of #2498.

This is kind of a cheap trick compared to using padding or such, but I do like the separation with an actual whitespace 🤷‍♂️ Thoughts?

I haven't seen any other place yet where removal of whitespace is breaking margins, but let me know if you did.