### PR TITLE
Mark sqlite3 as an optional dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,13 +58,15 @@
     "semver": "5.5.0",
     "socket.io": "2.1.1",
     "spdy": "3.4.7",
-    "sqlite3": "4.0.0",
     "thelounge-ldapjs-non-maintained-fork": "1.0.2",
     "tlds": "1.203.1",
     "ua-parser-js": "0.7.18",
     "uuid": "3.2.1",
     "web-push": "3.3.1",
     "yarn": "1.7.0"
+  },
+  "optionalDependencies": {
+    "sqlite3": "4.0.0"
   },
   "devDependencies": {
     "@fortawesome/fontawesome-free": "5.1.0-11",


### PR DESCRIPTION
Reminder: `optionalDependencies` simply means the install will not fail if that dependency fails to install, not that it will not get installed by default. We currently handle the case in code when sqlite3 is not working properly (follow-up of #2391).

See https://docs.npmjs.com/files/package.json#optionaldependencies