### PR TITLE
Fix undefined channel when updating title

### DIFF
--- a/client/js/utils.js
+++ b/client/js/utils.js
@@ -104,7 +104,7 @@ function updateTitle() {
 	let title = $(document.body).data("app-name");
 	const chanTitle = $("#sidebar").find(".chan.active").attr("aria-label");
 
-	if (chanTitle.length > 0) {
+	if (chanTitle && chanTitle.length > 0) {
 		title = `${chanTitle} — ${title}`;
 	}
 


### PR DESCRIPTION
Appears as warning in console if there are no channels.