### PR TITLE
Move .nyc_output folder out of root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,5 @@ yarn-debug.log*
 yarn-error.log*
 package-lock.json
 
-.nyc_output/
 coverage/
 public/

--- a/test/.nycrc-mocha
+++ b/test/.nycrc-mocha
@@ -1,5 +1,6 @@
 {
   "all": true,
+  "temp-directory": "./node_modules/.cache/nyc_output",
   "exclude": [
     "webpack.config*.js"
   ],

--- a/test/.nycrc-mocha-webpack
+++ b/test/.nycrc-mocha-webpack
@@ -1,5 +1,6 @@
 {
   "all": true,
+  "temp-directory": "./node_modules/.cache/nyc_output",
   "include": [
     "client/"
   ],

--- a/test/.nycrc-report
+++ b/test/.nycrc-report
@@ -1,4 +1,5 @@
 {
+  "temp-directory": "./node_modules/.cache/nyc_output",
   "reporter": [
     "lcov",
     "text-summary"


### PR DESCRIPTION
`nyc` already uses `node_modules/.cache/nyc` folder, so I don't know why they don't also put this temp output folder there too.