### PR TITLE
Target more modern browsers in babel

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -46,7 +46,10 @@ const config = {
 						presets: [
 							["env", {
 								targets: {
-									browsers: "last 2 versions",
+									browsers: [
+										"last 1 year",
+										"firefox esr",
+									],
 								},
 							}],
 						],


### PR DESCRIPTION
Reason being is that `last 2 versions` is a really poor descriptor and will forever target things like IE 10 and 11, even though Lounge doesn't work there even after transpiling (due to functions string.endsWith being used).

Use modern targets means we can actually transpile less code and end up with smaller final bundle size. This means arrow functions and rest parameters are left as-is.

The target I changed to seems rather reasonable, but might require some tweaking: http://browserl.ist/?q=last+1+year%2C+firefox+esr

References:
https://jamie.build/last-2-versions
http://browserl.ist/?q=last+2+versions
