### PR TITLE
Reset highlights on self messages; update title when other client opens a channel

### DIFF
--- a/client/js/socket-events/msg.js
+++ b/client/js/socket-events/msg.js
@@ -97,7 +97,12 @@ function processReceivedMessage(data) {
 
 	// Clear unread/highlight counter if self-message
 	if (data.msg.self) {
-		sidebarTarget.find(".badge").removeClass("highlight").empty();
+		sidebarTarget.find(".badge")
+			.attr("data-highlight", 0)
+			.removeClass("highlight")
+			.empty();
+
+		utils.updateTitle();
 	}
 
 	let messageLimit = 0;
@@ -211,12 +216,12 @@ function notifyMessage(targetId, channel, msg) {
 		return;
 	}
 
-	const badge = button.find(".badge").html(helpers_roundBadgeNumber(serverUnread));
+	const badge = button.find(".badge")
+		.attr("data-highlight", serverHighlight)
+		.html(helpers_roundBadgeNumber(serverUnread));
 
 	if (msg.highlight) {
-		badge
-			.attr("data-highlight", serverHighlight)
-			.addClass("highlight");
+		badge.addClass("highlight");
 
 		utils.updateTitle();
 	}

--- a/client/js/socket-events/open.js
+++ b/client/js/socket-events/open.js
@@ -2,6 +2,7 @@
 
 const $ = require("jquery");
 const socket = require("../socket");
+const utils = require("../utils");
 
 // Sync unread badge and marker when other clients open a channel
 socket.on("open", function(id) {
@@ -21,6 +22,8 @@ socket.on("open", function(id) {
 		.attr("data-highlight", 0)
 		.removeClass("highlight")
 		.empty();
+
+	utils.updateTitle();
 
 	// Move unread marker to the bottom
 	channel


### PR DESCRIPTION
- Fixes title not updating when another client opens a channel and resets highlights
- Fixes highlights not resetting when you receive your own message (sent from another client)