### PR TITLE
Fix highlights when seconds are shown in timestamps

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -1385,6 +1385,10 @@ background on hover (unless active) */
 	color: #696969;
 }
 
+#chat.show-seconds .channel .message.highlight .time {
+	width: 70px;
+}
+
 #chat .channel .message.highlight .content {
 	border-left: 1px solid var(--highlight-bg-color);
 }


### PR DESCRIPTION
Follow-up of #2526.

Before | After
--- | ---
<img width="364" alt="screen shot 2018-06-23 at 14 58 30" src="https://user-images.githubusercontent.com/113730/41812719-f148effc-76f5-11e8-9c9c-ffeab25b812a.png"> | <img width="371" alt="screen shot 2018-06-23 at 14 57 35" src="https://user-images.githubusercontent.com/113730/41812720-f1565be2-76f5-11e8-9421-01ad9c64d062.png">
