### PR TITLE
Add 'User information' (whois) support to the sidebar context menu

### DIFF
--- a/client/js/contextMenuFactory.js
+++ b/client/js/contextMenuFactory.js
@@ -75,10 +75,10 @@ function addWhoisItem() {
 	});
 
 	addContextMenuItem({
-		check: (target) => target.hasClass("user"),
+		check: (target) => target.hasClass("user") || target.hasClass("query"),
 		className: "action-whois",
 		displayName: "User information",
-		data: (target) => target.attr("data-name"),
+		data: (target) => target.attr("data-name") || target.attr("aria-label"),
 		callback: whois,
 	});
 }
@@ -385,6 +385,7 @@ function addIgnoreListItem() {
 }
 
 function addDefaultItems() {
+	addFocusItem();
 	addWhoisItem();
 	addQueryItem();
 	addKickItem();
@@ -392,7 +393,6 @@ function addDefaultItems() {
 	addDeopItem();
 	addVoiceItem();
 	addDevoiceItem();
-	addFocusItem();
 	addEditNetworkItem();
 	addJoinItem();
 	addChannelListItem();


### PR DESCRIPTION
When right-clicking a user in the sidebar, show 'User information' as a possible option in the context menu. Before this the only way to show user information via a context menu was to click on the username in an open channel/chat window.

![context_menu_whois](https://user-images.githubusercontent.com/619802/41821226-6292eec8-77ab-11e8-841b-57e07011ea68.png)
