### PR TITLE
Conversation layout for the main chat window

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -250,7 +250,6 @@ kbd {
 #chat .mode .from::before,
 #chat .ctcp .from::before,
 #chat .ctcp_request .from::before,
-#chat .whois .from::before,
 #chat .nick .from::before,
 #chat .action .from::before,
 #chat .toggle-button::after,
@@ -368,11 +367,6 @@ kbd {
 #chat .ctcp .from::before,
 #chat .ctcp_request .from::before {
 	content: "\f15c"; /* https://fontawesome.com/icons/file-alt?style=solid */
-}
-
-#chat .whois .from::before {
-	content: "\f007"; /* http://fontawesome.io/icon/user/ */
-	color: #2ecc40;
 }
 
 #chat .nick .from::before {
@@ -1008,7 +1002,7 @@ background on hover (unless active) */
 }
 
 #chat.condensed-status-messages .condensed-summary {
-	display: flex;
+	display: inline-flex;
 }
 
 #chat .condensed-summary .content:hover {
@@ -1021,10 +1015,6 @@ background on hover (unless active) */
 
 #chat.condensed-status-messages .condensed.closed .msg {
 	display: none;
-}
-
-#chat .condensed-summary .time {
-	visibility: hidden;
 }
 
 #windows #form,
@@ -1107,9 +1097,13 @@ background on hover (unless active) */
 #chat .msg {
 	word-wrap: break-word;
 	word-break: break-word; /* Webkit-specific */
-	display: flex;
-	align-items: flex-start;
 	position: relative;
+	padding-top: 4px;
+	padding-bottom: 4px;
+}
+
+#chat .same-sender {
+	margin-top: -8px;
 }
 
 #chat .unread-marker {
@@ -1168,44 +1162,43 @@ background on hover (unless active) */
 	padding: 0 10px;
 }
 
-#chat .time,
-#chat .from,
-#chat .content {
-	padding: 3px 0;
-	flex: 0 0 auto;
-}
-
 #chat .time {
 	color: #999;
-	padding-left: 10px;
-	width: 55px;
-}
-
-#chat.show-seconds .time {
-	width: 75px;
+	font-size: 0.75em;
 }
 
 #chat .from {
 	color: #b1c3ce;
-	padding-right: 10px;
-	text-align: right;
-	width: 134px;
-	overflow: hidden;
-	white-space: nowrap;
 	position: relative;
+	font-size: 0.85em;
 }
 
-#chat .same-sender .from {
-	visibility: hidden;
+#chat .message .from,
+#chat .notice .from {
+	padding-left: 10px;
+	padding-right: 5px;
+}
+
+#chat .same-sender .from,
+#chat .same-sender .time {
+	display: none;
 }
 
 #chat .content {
 	flex: 1 1 auto;
 	min-width: 0;
-	padding-left: 10px;
-	padding-right: 6px;
-	border-left: 1px solid #f6f6f6;
+	padding: 0 10px;
 	overflow: hidden; /* Prevents Zalgo text to expand beyond messages */
+}
+
+#chat .messages > .msg:not(.message):not(.notice):not(.motd) {
+	padding-left: 10px;
+	padding-right: 10px;
+	text-align: center;
+}
+
+#chat .msg:not(.message):not(.notice):not(.motd) .content {
+	padding-left: 0;
 }
 
 #chat .special .time,
@@ -1339,6 +1332,12 @@ background on hover (unless active) */
 	display: none !important;
 }
 
+#chat .message:not([data-from]) .from,
+#chat .message:not([data-from]) .time,
+#chat .motd .time {
+	display: none;
+}
+
 #chat .condensed .content,
 #chat .away .content,
 #chat .back .content,
@@ -1379,8 +1378,12 @@ background on hover (unless active) */
 	border-left: 5px solid var(--highlight-border-color);
 }
 
-#chat .channel .message.highlight .time {
+#chat .channel .message.highlight .from,
+#chat .channel .message.highlight .content {
 	padding-left: 5px;
+}
+
+#chat .channel .message.highlight .time {
 	width: 50px;
 	color: #696969;
 }
@@ -1409,6 +1412,10 @@ background on hover (unless active) */
 	overflow: hidden;
 	box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
 	contain: content; /* This fixes a display bug where border-radius stopped working on image link hover */
+}
+
+#chat .toggle-content:last-child {
+	margin-bottom: 3px;
 }
 
 /* This applies to images of preview-type-image and thumbnails of preview-type-link */
@@ -1812,21 +1819,31 @@ part/quit messages where we don't load previews (adds a blank line otherwise) */
 	display: inline-block;
 }
 
-.whois {
+#chat .whois .from,
+#chat .whois .time {
+	display: none;
+}
+
+#chat .whois .content {
+	padding: 0;
+}
+
+#chat .whois-details {
 	display: -ms-grid; /* Edge 15- */
 	display: grid;
 	-ms-grid-template-columns: max-content auto;
 	grid-template-columns: max-content auto;
 	margin: 0;
+	text-align: left;
 }
 
-.whois dt {
+#chat .whois-details dt {
 	-ms-grid-column-start: 1;
 	grid-column-start: 1;
-	margin-right: 20px;
+	margin-right: 10px;
 }
 
-.whois dd {
+#chat .whois-details dd {
 	-ms-grid-column-start: 2;
 	grid-column-start: 2;
 }
@@ -2295,15 +2312,6 @@ part/quit messages where we don't load previews (adds a blank line otherwise) */
 	font-size: 12px;
 }
 
-@media (min-width: 480px) {
-	/* Fade out for long usernames */
-	#chat .from {
-		padding-left: 10px;
-		-webkit-mask-image: linear-gradient(to left, transparent, black 10px);
-		mask-image: linear-gradient(to left, transparent, black 10px);
-	}
-}
-
 @media (max-width: 768px) {
 	/**
 	  * TODO Replace this with `@media (hover: hover)` when Firefox supports it
@@ -2470,13 +2478,34 @@ part/quit messages where we don't load previews (adds a blank line otherwise) */
 		padding-left: 0;
 	}
 
-	#chat .same-sender .from {
-		display: none;
-	}
-
 	#chat .condensed-summary .time,
 	#chat .condensed-summary .from {
 		display: none;
+	}
+
+	/* The following makes keys and values of the whois definition list appear on
+	the same line for small screens */
+
+	#chat .whois-details {
+		display: block;
+	}
+
+	#chat .whois-details dt,
+	#chat .whois-details dd {
+		display: inline;
+	}
+
+	#chat .whois-details dt {
+		margin-right: 0;
+	}
+
+	#chat .whois-details dt::after {
+		content: ' ';
+	}
+
+	#chat .whois-details dd::after {
+		content: '';
+		display: block;
 	}
 
 	#help .help-item .subject {

--- a/client/css/style.css
+++ b/client/css/style.css
@@ -1195,6 +1195,10 @@ background on hover (unless active) */
 	position: relative;
 }
 
+#chat .same-sender .from {
+	visibility: hidden;
+}
+
 #chat .content {
 	flex: 1 1 auto;
 	min-width: 0;
@@ -2464,6 +2468,10 @@ part/quit messages where we don't load previews (adds a blank line otherwise) */
 
 	#chat .channel .message.highlight .time {
 		padding-left: 0;
+	}
+
+	#chat .same-sender .from {
+		display: none;
 	}
 
 	#chat .condensed-summary .time,

--- a/client/css/style.css
+++ b/client/css/style.css
@@ -1173,6 +1173,20 @@ background on hover (unless active) */
 	font-size: 0.85em;
 }
 
+#chat .from .mode {
+	display: none;
+}
+
+#chat .mode-badge {
+	display: inline-block;
+	color: #999;
+	border: 1px solid #999;
+	border-radius: 5px;
+	font-size: 0.75em;
+	padding: 0 6px;
+	margin-left: 5px;
+}
+
 #chat .message .from,
 #chat .notice .from {
 	padding-left: 10px;
@@ -1180,7 +1194,8 @@ background on hover (unless active) */
 }
 
 #chat .same-sender .from,
-#chat .same-sender .time {
+#chat .same-sender .time,
+#chat .same-sender .mode-badge {
 	display: none;
 }
 
@@ -1394,6 +1409,11 @@ background on hover (unless active) */
 
 #chat .channel .message.highlight .content {
 	border-left: 1px solid var(--highlight-bg-color);
+}
+
+#chat .channel .message.highlight .mode-badge {
+	color: #696969;
+	border-color: #696969;
 }
 
 #chat .toggle-content.opened .more-caret, /* Expand/Collapse link previews */

--- a/client/js/render.js
+++ b/client/js/render.js
@@ -47,6 +47,12 @@ function appendMessage(container, chanId, chanType, msg) {
 	let lastChild = container.children(".msg, .date-marker-container").last();
 	const renderedMessage = buildChatMessage(msg);
 
+	if ((lastChild.hasClass("message") && msg.type === "message" ||
+			lastChild.hasClass("notice") && msg.type === "notice") &&
+			lastChild.data("from") === msg.from.nick) {
+		renderedMessage.addClass("same-sender");
+	}
+
 	// Check if date changed
 	const msgTime = new Date(msg.time);
 	const prevMsgTime = new Date(lastChild.data("time"));

--- a/client/themes/morning.css
+++ b/client/themes/morning.css
@@ -10,8 +10,22 @@
 	--highlight-border-color: #b08c4f;
 }
 
-#chat .channel .message.highlight .time {
+#chat .channel .message.highlight {
+	background-color: #4d4332;
+	border-left: 5px solid #b08c4f;
+}
+
+#chat .channel .message.highlight .time,
+#chat .channel .message.highlight .mode-badge {
 	color: white;
+}
+
+#chat .channel .message.highlight .mode-badge {
+	border-color: white;
+}
+
+#chat .channel .message.highlight .content {
+	border-left: 1px solid #4d4332;
 }
 
 #windows .logo {
@@ -140,6 +154,7 @@
 }
 
 #chat .time,
+#chat .mode-badge,
 #chat .condensed .content,
 #chat .away .content,
 #chat .back .content,
@@ -152,6 +167,10 @@
 #chat .topic .content,
 #chat .topic_set_by .content {
 	color: #b7c5d1;
+}
+
+#chat .mode-badge {
+	border-color: #b7c5d1;
 }
 
 #chat table.channel-list td {

--- a/client/views/actions/whois.tpl
+++ b/client/views/actions/whois.tpl
@@ -1,9 +1,14 @@
-<p>
-	{{> ../user_name nick=whois.nick}}
-	{{#if whois.whowas}} is offline, last information:{{/if}}
-</p>
+<dl class="whois-details">
+	<dt>Nick:</dt>
+	<dd>{{> ../user_name nick=whois.nick}}</dd>
 
-<dl class="whois">
+	<dt>Status:</dt>
+{{#if whois.whowas}}
+	<dd>Offline</dd>
+{{else}}
+	<dd>Online</dd>
+{{/if}}
+
 {{#if whois.account}}
 	<dt>Logged in as:</dt>
 	<dd>{{whois.account}}</dd>

--- a/client/views/msg.tpl
+++ b/client/views/msg.tpl
@@ -11,6 +11,28 @@
 	<span class="time tooltipped tooltipped-e" aria-label="{{localetime time}}">
 		{{tz time}}
 	</span>
+	{{#if from.mode}}
+		<span class="mode-badge">
+			{{#equal from.mode "~"}}
+				Owner
+			{{/equal}}
+			{{#equal from.mode "&"}}
+				Administrator
+			{{/equal}}
+			{{#equal from.mode "!"}}
+				Administrator
+			{{/equal}}
+			{{#equal from.mode "@"}}
+				Operator
+			{{/equal}}
+			{{#equal from.mode "%"}}
+				Half-Operator
+			{{/equal}}
+			{{#equal from.mode "+"}}
+				Voiced
+			{{/equal}}
+		</span>
+	{{/if}}
 	<div class="content">
 		<span class="text">{{{parse text users}}}</span>
 

--- a/client/views/msg.tpl
+++ b/client/views/msg.tpl
@@ -1,17 +1,21 @@
-<div class="msg {{type}}{{#if self}} self{{/if}}{{#if highlight}} highlight{{/if}}" id="msg-{{id}}" data-time="{{time}}"{{#if from.nick}} data-from="{{from.nick}}"{{/if}}>
-	<span class="time tooltipped tooltipped-e" aria-label="{{localetime time}}">
-		{{tz time}}
-	</span>
-	<span class="from">
+<div
+	class="msg {{type}}{{#if self}} self{{/if}}{{#if highlight}} highlight{{/if}}"
+	id="msg-{{id}}"
+	data-time="{{time}}"{{#if from.nick}} data-from="{{from.nick}}"{{/if}}
+>
+	<strong class="from">
 		{{#if from.nick}}
 			{{> user_name from}}
 		{{/if}}
+	</strong>
+	<span class="time tooltipped tooltipped-e" aria-label="{{localetime time}}">
+		{{tz time}}
 	</span>
-	<span class="content">
+	<div class="content">
 		<span class="text">{{{parse text users}}}</span>
 
 		{{#each previews}}
 			<div class="preview" data-url="{{link}}"></div>
 		{{/each}}
-	</span>
+	</div>
 </div>

--- a/client/views/msg_condensed.tpl
+++ b/client/views/msg_condensed.tpl
@@ -1,7 +1,5 @@
 <div class="msg condensed closed" data-time="{{time}}">
 	<div class="condensed-summary">
-		<span class="time">{{tz time}}</span>
-		<span class="from"></span>
 		<span class="content"></span>
 	</div>
 </div>

--- a/client/views/user_name.tpl
+++ b/client/views/user_name.tpl
@@ -1,1 +1,1 @@
-<span role="button" class="user {{colorClass nick}}" data-name="{{nick}}">{{mode}}{{nick}}</span>
+<span role="button" class="user {{colorClass nick}}" data-name="{{nick}}"><span class="mode">{{mode}}</span>{{nick}}</span>


### PR DESCRIPTION
Alright, this is the last overall visual change that I am planning for v3.0, and it focuses on the main chat layout (which was left alone in previous PRs).

<img width="1013" alt="screen shot 2018-06-18 at 00 35 26" src="https://user-images.githubusercontent.com/113730/41889453-c588fda0-78d8-11e8-8fde-d68fcbbad1d4.png">

<img width="834" alt="screen shot 2018-06-18 at 00 37 49" src="https://user-images.githubusercontent.com/113730/41889468-d7a12ae4-78d8-11e8-8eb8-b17c0fa7ba0b.png">

In short:

- Instead of a table layout, messages are now displayed in a "conversation layout".
- When multiple messages are sent by a same user in a row (not interrupted by status messages), they are grouped together.
- User modes now have a UI through small badges next to the nicks, in lieu of `@`, `+`, etc.
- All of the above is completely cancellable (and tweakable) via custom CSS.

Now, just like #2315, I know not everyone will like that, but I hope no one will be upset at this proposal. I really have tried my best at making a maximum of people happy (see custom CSS provided below), but obviously I am open to make things better.
I realize that this is not a layout traditional IRC clients usually go for. It is however a direction all modern chats I have encountered have adopted over the last couple years (Discord, Telegram, Slack, Rocket.Chat, HipChat, Riot, etc.). I think overall this is a UX improvement.

Some concerns people may have:

### Does this reduce message density?

Yes, no doubt. In my tests, depending on the channel (Is it crowded or mostly status messages? Are people mostly talking with brief messages or is it more talkative? etc.), I noticed between 10% and 20% less messages on screen overall.
That said, I find it overall improves readability, and I had less mental efforts to make to follow a long discussion after coming back on a lot of messages.

### I hate it. Can we have a settings for this?

No. Maintaining several layouts in the core project adds a substantial amount of work on the core team, increases the risk of breaking things, and imposes people who open PRs to think about what they're adding/fixing in multiple scenarios.

If people hate it because it's imperfect, then it can and should be improved. The layout on `master` was not done in one day, and had at least 2 rewrites since we started. I'm not pretending this is going to be perfect at merge time or that nothing should be changed, but it's a starting point.

If people hate it because they simply preferred how something was before, I have tried to make this as flexible as possible:

- All the changes can be "reverted" with custom CSS, all provided below.
- I can think of a few customizations that can be made solely with custom CSS as well, I provided some below.
- Due to these 2 points, someone could decide to own and maintain a package whose job is to revert some part of the layout, or tweak it in some way. That way, we can still have multiple layouts without having to maintain it in core, we get help from the community.
- [`thelounge-theme-classic`](https://github.com/thelounge/thelounge-theme-classic) is meant to be a complete replica of v2.7.1 look. When this PR is ready, I will open a PR there that "reverts" everything for that theme.

### Is this 100% ready?

As of this writing, no. I have a few things I need to tackle, but it's in the most part what I was going for. I'm opening this unfinished to have early reactions so I can integrate as much feedback as I can in upcoming design.

If you see something that seems clearly broken, don't assume I went for this on purpose, it's likely that it's, in fact, broken, so let me know :)
On the top of my head, there are a few things I have just not even started to approach yet, but I am probably forgetting some so feel free to comment and I'll tackle them:

- [x] Notices
- [ ] Server window
- [x] Copy-paste
- [ ] `/me` messages aren't great
- [ ] Loading from history
- [x] Whois response
- [ ] Highlights have poor paddings (when non-highlighted and highlighted messages are mixed with same-sender)
- [ ] Channel list, ban list, ignore list

# Custom CSS snippets

These are meant to _just work_ with the changes on this PR. When it gets merged, if anything looks off, let me know and I'll fix.
If you can think of something else you'd like me to come up with, post here and I'll do my best.

### I don't like merging same-sender messages together

<details>
<summary>Snippet</summary>

```css
#chat .same-sender {
  margin-top: initial;
}

#chat .same-sender .from,
#chat .same-sender .time,
#chat .same-sender .mode-badge {
  display: inline;
}
```

</details>

Before | After
--- | ---
<img width="330" alt="screen shot 2018-06-22 at 00 51 54" src="https://user-images.githubusercontent.com/113730/41889318-f2fe5c68-78d7-11e8-88cd-1fb01602e882.png"> | <img width="334" alt="screen shot 2018-06-22 at 00 51 13" src="https://user-images.githubusercontent.com/113730/41889317-f2f32f50-78d7-11e8-9ac8-911d9ea53fa0.png">

### I don't like the mode badges, bring back the prefixes!

<details>
<summary>Snippet</summary>

```css
#chat .mode-badge {
  display: none;
}

#chat .from .mode {
  display: initial;
}
```

</details>

Before | After
--- | ---
<img width="151" alt="screen shot 2018-06-22 at 00 53 28" src="https://user-images.githubusercontent.com/113730/41889358-3164cec4-78d8-11e8-8fcb-5f93b5d528d9.png"> | <img width="96" alt="screen shot 2018-06-22 at 00 54 17" src="https://user-images.githubusercontent.com/113730/41889359-3170362e-78d8-11e8-94de-6312c978efba.png">

### I want to see timestamp for all messages

⚠️ This is very hacky (and probably buggy), but it illustrates one possibility to show all timestamps. I have no doubt someone smarter than me will come up with something better :)

<details>
<summary>Snippet</summary>

```css
#chat .same-sender .time {
  display: initial;
  float: left;
  margin-left: 10px;
  margin-top: 5px;
}

#chat .message:not(.same-sender) .time {
  float: left;
  left: 10px;
  top: 24px;
}

/* FIXME: This is surely not working correctly when displaying seconds in timestamps */

#chat .message:not(.same-sender) .from {
  margin-left: -28px;
}

#chat .message:not(.same-sender) .content {
  text-indent: 40px;
}
```

</details>

Before | After
--- | ---
<img width="386" alt="screen shot 2018-06-22 at 01 12 16" src="https://user-images.githubusercontent.com/113730/41889402-80f5a5b2-78d8-11e8-903a-8f289d867dc9.png"> | <img width="430" alt="screen shot 2018-06-22 at 01 11 54" src="https://user-images.githubusercontent.com/113730/41889401-80e6cb78-78d8-11e8-8428-81b5671c38b5.png">

### I like the conversation layout, but I need more density

<details>
<summary>Snippet</summary>

```css
.messages .msg {
  line-height: 1.2;
}

#chat .msg {
	padding-top: 3px;
	padding-bottom: 3px;
}

#chat .same-sender {
	margin-top: -6px;
}
```

</details>

Before | After
--- | ---
<img width="1280" alt="screen shot 2018-06-26 at 23 44 07" src="https://user-images.githubusercontent.com/113730/41951870-1460ce18-799b-11e8-8a7e-be48bb34e799.png"> | <img width="1280" alt="screen shot 2018-06-26 at 23 44 11" src="https://user-images.githubusercontent.com/113730/41951871-146e9570-799b-11e8-900d-1416b1e9b136.png">

### I hate _everything_, you fool!

This cancels everything this PR does. No Before/After screenshots, because it really just is "master vs this PR" :)

_(⚠️ Snippet needs a refresh to reflect latest changes to this PR)_

<details>
<summary>Snippet</summary>

```css
#chat .msg {
	display: flex;
	padding-top: 0;
	padding-bottom: 0;
}

#chat .msg:not(.message) {
	padding-left: 0;
	padding-right: 0;
	text-align: left;
}

#chat .from,
#chat .time,
#chat .content {
	padding-top: 3px;
	padding-bottom: 3px;
}

#chat .from,
#chat .time {
	font-size: 1em;
	flex: 0 0 auto;
}

#chat .time {
	order: -1;
	padding-left: 10px;
	width: 55px;
}

#chat.show-seconds .time {
	width: 75px;
}

#chat .from {
	font-weight: normal;
	text-align: right;
	width: 134px;
	overflow: hidden;
	white-space: nowrap;
}

#chat .from,
#chat .message .from {
	padding-right: 10px;
}

#chat .mode-badge {
	display: none;
}

#chat .from .mode {
	display: initial;
}

#chat .same-sender {
	margin-top: initial;
}

#chat .same-sender .from,
#chat .same-sender .time {
	display: inline;
}

#chat .content {
	border-left: 1px solid #f6f6f6;
}

#chat .msg:not(.message) .content {
	padding-left: 10px;
	padding-right: 10px;
}

#chat .condensed-summary {
	margin-left: 189px;
}

#chat.show-seconds .condensed-summary {
	margin-left: 209px;
}

@media (min-width: 480px) {
	/* Fade out for long usernames */
	#chat .from {
		padding-left: 10px;
		-webkit-mask-image: linear-gradient(to left, transparent, black 10px);
		mask-image: linear-gradient(to left, transparent, black 10px);
	}
}
```

</details>