### PR TITLE
Update `no-confusing-error` eslint rule to allow parenthesis

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -30,7 +30,7 @@ rules:
   linebreak-style: [error, unix]
   no-alert: error
   no-catch-shadow: error
-  no-confusing-arrow: error
+  no-confusing-arrow: [error, {allowParens: true}]
   no-control-regex: off
   no-duplicate-imports: error
   no-else-return: error


### PR DESCRIPTION
ref https://github.com/eslint/eslint/issues/5332#issuecomment-193271946