### PR TITLE
Switch close button text on channels to Leave and kept as Close for other types.

### DIFF
--- a/client/views/chan.tpl
+++ b/client/views/chan.tpl
@@ -25,14 +25,19 @@
 		<span class="add-channel-tooltip tooltipped tooltipped-w tooltipped-no-touch" aria-label="Join a channel…" data-alt-label="Cancel">
 			<button class="add-channel" aria-label="Join a channel…" aria-controls="join-channel-{{id}}"></button>
 		</span>
-	{{/equal}}
-	{{#notEqual type "lobby"}}
+	{{else}}
 		<span class="name" title="{{name}}">{{name}}</span>
 		<span class="badge{{#if highlight}} highlight{{/if}}" data-highlight="{{highlight}}">{{#if unread}}{{roundBadgeNumber unread}}{{/if}}</span>
-		<span class="close-tooltip tooltipped tooltipped-w" aria-label="Leave">
-			<button class="close" aria-label="Leave"></button>
-		</span>
-	{{/notEqual}}
+		{{#equal type "channel"}}
+			<span class="close-tooltip tooltipped tooltipped-w" aria-label="Leave">
+				<button class="close" aria-label="Leave"></button>
+			</span>
+		{{else}}
+			<span class="close-tooltip tooltipped tooltipped-w" aria-label="Close">
+				<button class="close" aria-label="Close"></button>
+			</span>		
+		{{/equal}}
+	{{/equal}}
 </div>
 {{#equal type "lobby"}}
 	{{> join_channel}}


### PR DESCRIPTION
Matches other UI elements, like context menus