### PR TITLE
Clarify /topic command without newtopic

### DIFF
--- a/client/views/windows/help.tpl
+++ b/client/views/windows/help.tpl
@@ -545,7 +545,7 @@
 		<div class="description">
 			<p>
 				Get the topic in the current channel. 
-				If <code>newtopic</code> is specified the command sets the 
+				If <code>newtopic</code> is specified, sets the 
 				topic in the current channel.
 			</p>
 		</div>

--- a/client/views/windows/help.tpl
+++ b/client/views/windows/help.tpl
@@ -540,10 +540,14 @@
 
 	<div class="help-item">
 		<div class="subject">
-			<code>/topic newtopic</code>
+			<code>/topic [newtopic]</code>
 		</div>
 		<div class="description">
-			<p>Set the topic in the current channel.</p>
+			<p>
+				Get the topic in the current channel. 
+				If <code>newtopic</code> is specified the command sets the 
+				topic in the current channel.
+			</p>
 		</div>
 	</div>
 


### PR DESCRIPTION
Just found it that I could get the current topic with `/topic` and since it wasn't mentioned in the help, I would like to add it.