### PR TITLE
Enable underlines on links

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -69,13 +69,8 @@ a:focus {
 	color: var(--link-color);
 }
 
-a {
-	transition: opacity 0.2s;
-}
-
 a:hover {
-	text-decoration: none;
-	opacity: 0.8;
+	text-decoration: underline;
 }
 
 /**
@@ -1240,12 +1235,11 @@ background on hover (unless active) */
 #chat .user,
 .inline-channel {
 	cursor: pointer;
-	transition: opacity 0.2s;
 }
 
 .chat .user:hover,
 .inline-channel:hover {
-	opacity: 0.6;
+	text-decoration: underline;
 }
 
 /* Nicknames */


### PR DESCRIPTION
This seems like an easy fix to improve accessibility since color change on hover is not always enough to see that it's a link you can click.

I also set dashed underline on nicks and channels in chat messages (it's dashed to differentiate that it's an action that will take place in-app).