### PR TITLE
Fix incorrect left padding for highlights on mobile

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -2463,6 +2463,10 @@ part/quit messages where we don't load previews (adds a blank line otherwise) */
 		padding: 0;
 	}
 
+	#chat .channel .message.highlight {
+		padding-left: 5px;
+	}
+
 	#chat .channel .message.highlight .time {
 		padding-left: 0;
 	}


### PR DESCRIPTION
Fixing something @xPaw mentioned to me a couple days ago. Hope I got it right.