### PR TITLE
Make the MOTDs a little nicer if possible

### DIFF
--- a/client/js/render.js
+++ b/client/js/render.js
@@ -101,6 +101,20 @@ function buildChatMessage(msg) {
 		template = "msg_unhandled";
 	}
 
+	// Make the MOTDs a little nicer if possible
+	if (msg.type === "motd") {
+		let lines = msg.text.split("\n");
+
+		// If all non-empty lines of the MOTD start with a hyphen (which is common
+		// across MOTDs), remove all the leading hyphens.
+		if (lines.every((line) => line === "" || line[0] === "-")) {
+			lines = lines.map((line) => line.substr(2));
+		}
+
+		// Remove empty lines around the MOTD (but not within it)
+		msg.text = lines.join("\n").trim();
+	}
+
 	const renderedMessage = $(templates[template](msg));
 	const content = renderedMessage.find(".content");
 


### PR DESCRIPTION
This removes the leading hyphens from MOTD lines (under the condition they all do) and trims empty lines around the MOTD (but not inside).

I couldn't find if MOTD lines were always leading with dashes so I went the conservative way, but when I looked at the 4 servers I am on right now, they all do that. I found that unnecessary in a GUI like ours (I'm guessing it's more useful in terminal clients, though I'm not sure why it would be) so figured it wouldn't hurt to add a bit of logic to make this nicer on our end.

Before | After
--- | ---
<img width="933" alt="screen shot 2018-07-09 at 01 21 48" src="https://user-images.githubusercontent.com/113730/42432281-cca9f014-8317-11e8-9a18-f5fbff92ad69.png"> | <img width="916" alt="screen shot 2018-07-09 at 01 21 26" src="https://user-images.githubusercontent.com/113730/42432282-ccb71bfe-8317-11e8-997e-01b792e80725.png">
<img width="1069" alt="screen shot 2018-07-09 at 01 22 46" src="https://user-images.githubusercontent.com/113730/42432288-d2b2e420-8317-11e8-9ef3-d22fa0225123.png"> | <img width="1055" alt="screen shot 2018-07-09 at 01 28 19" src="https://user-images.githubusercontent.com/113730/42432289-d2c109d8-8317-11e8-9eda-f90938ccaa06.png">
