### PR TITLE
Make userlist section titles sticky on scroll, improve contrasts for accessibility, use CSS variables

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -5,6 +5,9 @@
 	/* Main text color */
 	--body-color: #222;
 
+	/* Secondary text color, dimmed. Make sure to keep contrast WCAG 2.0 AA compliant on var(--window-bg-color) */
+	--body-color-muted: #767676;
+
 	/* Background color of the whole page */
 	--body-bg-color: #415364;
 
@@ -1564,13 +1567,19 @@ part/quit messages where we don't load previews (adds a blank line otherwise) */
 	white-space: nowrap;
 }
 
+#chat .user-mode {
+	margin-bottom: 15px;
+}
+
 #chat .user-mode::before {
-	content: "";
-	border-bottom: 1px solid #eee;
+	background: var(--window-bg-color);
+	color: var(--body-color-muted);
 	display: block;
+	font-size: 0.85em;
 	line-height: 1.6;
-	padding: 12px 16px 10px;
-	margin-bottom: 10px;
+	padding: 5px 16px;
+	position: sticky;
+	top: 0;
 }
 
 #chat .user-mode.owner::before {

--- a/client/css/style.css
+++ b/client/css/style.css
@@ -372,11 +372,13 @@ kbd {
 
 #chat .motd .from::before {
 	content: "\f02e"; /* https://fontawesome.com/icons/bookmark?style=solid */
+	color: var(--body-color-muted);
 }
 
 #chat .ctcp .from::before,
 #chat .ctcp_request .from::before {
 	content: "\f15c"; /* https://fontawesome.com/icons/file-alt?style=solid */
+	color: var(--body-color-muted);
 }
 
 #chat .whois .from::before {
@@ -1195,7 +1197,6 @@ background on hover (unless active) */
 }
 
 #chat .from {
-	color: #b1c3ce;
 	padding-right: 10px;
 	text-align: right;
 	width: 134px;
@@ -1211,6 +1212,10 @@ background on hover (unless active) */
 	padding-right: 6px;
 	border-left: 1px solid #f6f6f6;
 	overflow: hidden; /* Prevents Zalgo text to expand beyond messages */
+}
+
+#chat .unhandled .from {
+	color: var(--body-color-muted);
 }
 
 #chat .special .time,
@@ -1329,14 +1334,6 @@ background on hover (unless active) */
 #chat table.channel-list .users {
 	text-align: center;
 	width: 50px;
-}
-
-#chat table.channel-list td.channel .inline-channel {
-	color: #428bca;
-}
-
-#chat table.channel-list td {
-	color: #555;
 }
 
 #chat.hide-status-messages .condensed,

--- a/client/css/style.css
+++ b/client/css/style.css
@@ -961,7 +961,7 @@ background on hover (unless active) */
 }
 
 #windows .header .topic {
-	color: #777;
+	color: var(--body-color-muted);
 	margin-left: 8px;
 	word-break: break-all;
 	flex-grow: 1;
@@ -1185,7 +1185,7 @@ background on hover (unless active) */
 }
 
 #chat .time {
-	color: #999;
+	color: var(--body-color-muted);
 	padding-left: 10px;
 	width: 55px;
 }
@@ -1280,7 +1280,7 @@ background on hover (unless active) */
 #chat.colored-nicks .user.color-32 { color: #e60082; }
 
 #chat .self .text {
-	color: #999;
+	color: var(--body-color-muted);
 }
 
 #chat .msg.channel_list_loading .text {
@@ -1362,7 +1362,7 @@ background on hover (unless active) */
 #chat .quit .content,
 #chat .topic .content,
 #chat .topic_set_by .content {
-	color: #999;
+	color: var(--body-color-muted);
 }
 
 #chat .action .from,

--- a/client/js/utils.js
+++ b/client/js/utils.js
@@ -60,7 +60,7 @@ function hasRoleInChannel(channel, roles, nick) {
 function scrollIntoViewNicely(el) {
 	// Ideally this would use behavior: "smooth", but that does not consistently work in e.g. Chrome
 	// https://github.com/iamdustan/smoothscroll/issues/28#issuecomment-364061459
-	el.scrollIntoView({block: "nearest", inline: "nearest"});
+	el.scrollIntoView({block: "center", inline: "nearest"});
 }
 
 function collapse() {

--- a/client/themes/morning.css
+++ b/client/themes/morning.css
@@ -107,10 +107,6 @@
 	color: #b7c5d1;
 }
 
-#windows .header .topic {
-	color: #b7c5d1;
-}
-
 #viewport .lt,
 #viewport .rt,
 #chat button.menu,
@@ -123,35 +119,12 @@
 	color: #f3f3f3;
 }
 
-#chat .self .text {
-	color: #b7c5d1;
-}
-
 #chat .error,
 #chat .error .from {
 	color: #f92772;
 }
 
 #chat .unhandled .from {
-	color: #b7c5d1;
-}
-
-#chat .msg.topic {
-	color: #b7c5d1;
-}
-
-#chat .time,
-#chat .condensed .content,
-#chat .away .content,
-#chat .back .content,
-#chat .join .content,
-#chat .kick .content,
-#chat .mode .content,
-#chat .nick .content,
-#chat .part .content,
-#chat .quit .content,
-#chat .topic .content,
-#chat .topic_set_by .content {
 	color: #b7c5d1;
 }
 

--- a/client/themes/morning.css
+++ b/client/themes/morning.css
@@ -2,6 +2,7 @@
 
 :root {
 	--body-color: #f3f3f3;
+	--body-color-muted: #b7c5d1;
 	--link-color: #77abd9;
 	--window-bg-color: #303e4a;
 	--date-marker-color: #97ea70;

--- a/client/themes/morning.css
+++ b/client/themes/morning.css
@@ -124,14 +124,6 @@
 	color: #f92772;
 }
 
-#chat .unhandled .from {
-	color: #b7c5d1;
-}
-
-#chat table.channel-list td {
-	color: #b7c5d1;
-}
-
 #chat .msg.motd .text,
 code,
 .irc-monospace {

--- a/client/views/user.tpl
+++ b/client/views/user.tpl
@@ -1,3 +1,4 @@
+<!-- htmlmin:ignore -->
 {{#diff "reset"}}{{/diff}}
 {{#each users}}
 	{{#diff mode}}
@@ -9,3 +10,4 @@
 	{{> user_name}}
 {{/each}}
 </div>
+<!-- htmlmin:ignore -->


### PR DESCRIPTION
Stickiness extracted from https://github.com/thelounge/thelounge/pull/2527. Also slightly updated styling, and improved accessibility of muted texts on default theme (via the new CSS var) and was able to get rid of some overrides in Morning due to that CSS var.

Browsers that do not support `position: sticky` essentially do nothing with it (i.e. treat it as an element positioned by default) so that's good enough graceful degradation. It's essentially only Safari at this point so I'm not planning on a polyfill (Autoprefixer would take care of this anyway).

Before | After
--- | ---
![userlist_before](https://user-images.githubusercontent.com/113730/42672440-fe974c56-8633-11e8-816b-8af20918b252.gif) | ![userlist_after](https://user-images.githubusercontent.com/113730/42672439-fe8ba8f6-8633-11e8-8b50-30e83477c6d5.gif)

~(This is currently affected by #2635. It still works but doesn't look as good, so test without `html-minifier-loader` if you want to get the expected look)~
This PR now fixes #2635.

This happens to fix #909.