### PR TITLE
Recommend using Yarn instead of NPM in changelog and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,13 +68,13 @@ Run this in a terminal to install (or upgrade) the latest stable release from
 [npm registry](https://www.npmjs.com/):
 
 ```sh
-[sudo] yarn global add thelounge
+yarn global add thelounge
 ```
 
 If you already have The Lounge installed globally, use the following command to update it:
 
 ```sh
-[sudo] yarn global upgrade thelounge
+yarn global upgrade thelounge
 ```
 
 When installation is complete, run:

--- a/scripts/changelog.js
+++ b/scripts/changelog.js
@@ -106,7 +106,7 @@ Please refer to the commit list given above for a complete list of changes, or w
 As with all pre-releases, this version requires explicit use of the \`next\` tag to be installed:
 
 \`\`\`sh
-npm install -g thelounge@next
+[sudo] yarn global add thelounge@next
 \`\`\`
 `;
 }

--- a/scripts/changelog.js
+++ b/scripts/changelog.js
@@ -106,7 +106,7 @@ Please refer to the commit list given above for a complete list of changes, or w
 As with all pre-releases, this version requires explicit use of the \`next\` tag to be installed:
 
 \`\`\`sh
-[sudo] yarn global add thelounge@next
+yarn global add thelounge@next
 \`\`\`
 `;
 }


### PR DESCRIPTION
TheLounge has started using Yarn, but does also support NPM. Yarn seems to in some cases solve issues people experience when using NPM, e.g. Sqlite3 installation.

I think it's good and about time to recommend using Yarn instead of NPM.