### PR TITLE
Add opacity on user names hovering in userlist

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -1564,7 +1564,7 @@ part/quit messages where we don't load previews (adds a blank line otherwise) */
 	white-space: nowrap;
 }
 
-+#chat .names .user:hover {
+#chat .names .user:hover {
 	opacity: 0.6;
 }
 

--- a/client/css/style.css
+++ b/client/css/style.css
@@ -1564,6 +1564,10 @@ part/quit messages where we don't load previews (adds a blank line otherwise) */
 	white-space: nowrap;
 }
 
++#chat .names .user:hover {
+	opacity: 0.6;
+}
+
 #chat .user-mode::before {
 	content: "";
 	border-bottom: 1px solid #eee;


### PR DESCRIPTION
Add opacity on user names hovering in userlist. User names have same opacity on hovering in channel, and by adding this to user names in userlist we have more consistency, in my opinion.