### PR TITLE
Don't put .log in text log folder name

### DIFF
--- a/src/plugins/messageStorage/text.js
+++ b/src/plugins/messageStorage/text.js
@@ -97,7 +97,7 @@ class TextFileMessageStorage {
 
 		line += "\n";
 
-		fs.appendFile(path.join(logPath, cleanFilename(channel.name)), line, (e) => {
+		fs.appendFile(path.join(logPath, `${cleanFilename(channel.name)}.log`), line, (e) => {
 			if (e) {
 				log.error("Failed to write user log", e);
 			}
@@ -122,5 +122,5 @@ function cleanFilename(name) {
 	name = filenamify(name, {replacement: "_"});
 	name = name.toLowerCase();
 
-	return `${name}.log`;
+	return name;
 }


### PR DESCRIPTION
`.log` was added to network folder names, which is confusing.