### PR TITLE
Keep timestamps aligned when using a font with variable-width numbers

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -1190,6 +1190,7 @@ background on hover (unless active) */
 	color: var(--body-color-muted);
 	padding-left: 10px;
 	width: 55px;
+	font-variant-numeric: tabular-nums;
 }
 
 #chat.show-seconds .time {


### PR DESCRIPTION
This PR adds [`font-variant-numeric`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-numeric): `tabular-nums`; to the timestamps to keep them aligned when using a font like San Francisco, which is unusual for defaulting to variable-width numbers.

Before and after screenshot with the San Francisco font in Chrome 68 on Linux:

![screenshot_2018-07-29_15-14-42](https://user-images.githubusercontent.com/4458/43367805-79c969de-9342-11e8-87f8-2e3f5b4ba768.png)
![screenshot_2018-07-29_15-13-34](https://user-images.githubusercontent.com/4458/43367809-80c953de-9342-11e8-8824-afe24f81d0f7.png)

ignore the border, my screenshotting software is not good