### PR TITLE
Add X-Purpose header to link prefetcher

### DIFF
--- a/src/plugins/irc-events/link.js
+++ b/src/plugins/irc-events/link.js
@@ -301,6 +301,7 @@ function getRequestHeaders(headers) {
 	const formattedHeaders = {
 		"User-Agent": "Mozilla/5.0 (compatible; The Lounge IRC Client; +https://github.com/thelounge/thelounge)",
 		"Accept": headers.accept || "*/*",
+		"X-Purpose": "preview",
 	};
 
 	if (headers.language) {


### PR DESCRIPTION
Closes #2680.

I'm not sure if this is the industry standard. I did a quick search and found out [this bug report, which renames the header to `Purpose`](https://bugs.webkit.org/show_bug.cgi?id=47802), following a IETF recommendation. Also, it looks like that Firefox stopped prefetching requests; they did it with their (now defunct, I suppose) `X-moz: prefetch` header.

Anyways, it was tested with https://webhook.site/ and the header was there.