### PR TITLE
Add try catch to all localStorage methods.

### DIFF
--- a/client/js/localStorage.js
+++ b/client/js/localStorage.js
@@ -14,7 +14,12 @@ module.exports = {
 		try {
 			return window.localStorage.getItem(key);
 		} catch (e) {
-			console.warn("Cannot get item from localStorage");
+			// Do nothing. You can end up here because localStorage isn't 
+			// accessable due to browser blocking 3rd party cookies when 
+			// theLounge is loaded via iFrame.
+			// See: https://github.com/thelounge/thelounge/issues/2699
+
+			// Return null as if we we're a new client
 			return null;
 		}
 	},
@@ -22,14 +27,20 @@ module.exports = {
 		try {
 			window.localStorage.removeItem(key);
 		} catch (e) {
-			console.warn("Cannot remove item from localStorage");
+			// Do nothing. You can end up here because localStorage isn't 
+			// accessable due to browser blocking 3rd party cookies when 
+			// theLounge is loaded via iFrame
+			// See: https://github.com/thelounge/thelounge/issues/2699
 		}
 	},
 	clear() {
 		try {
 			window.localStorage.clear();
 		} catch (e) {
-			console.warn("Cannot clear localStorage");
+			// Do nothing. You can end up here because localStorage isn't 
+			// accessable due to browser blocking 3rd party cookies when 
+			// theLounge is loaded via iFrame
+			// See: https://github.com/thelounge/thelounge/issues/2699
 		}
 	},
 };

--- a/client/js/localStorage.js
+++ b/client/js/localStorage.js
@@ -11,12 +11,25 @@ module.exports = {
 		}
 	},
 	get(key) {
-		return window.localStorage.getItem(key);
+		try {
+			return window.localStorage.getItem(key);
+		} catch (e) {
+			console.warn("Cannot get item from localStorage");
+			return null;
+		}
 	},
 	remove(key) {
-		window.localStorage.removeItem(key);
+		try {
+			window.localStorage.removeItem(key);
+		} catch (e) {
+			console.warn("Cannot remove item from localStorage");
+		}
 	},
 	clear() {
-		window.localStorage.clear();
+		try {
+			window.localStorage.clear();
+		} catch (e) {
+			console.warn("Cannot clear localStorage");
+		}
 	},
 };

--- a/client/js/localStorage.js
+++ b/client/js/localStorage.js
@@ -14,8 +14,8 @@ module.exports = {
 		try {
 			return window.localStorage.getItem(key);
 		} catch (e) {
-			// Do nothing. You can end up here because localStorage isn't 
-			// accessable due to browser blocking 3rd party cookies when 
+			// Do nothing. You can end up here because localStorage isn't
+			// accessable due to browser blocking 3rd party cookies when
 			// theLounge is loaded via iFrame.
 			// See: https://github.com/thelounge/thelounge/issues/2699
 
@@ -27,8 +27,8 @@ module.exports = {
 		try {
 			window.localStorage.removeItem(key);
 		} catch (e) {
-			// Do nothing. You can end up here because localStorage isn't 
-			// accessable due to browser blocking 3rd party cookies when 
+			// Do nothing. You can end up here because localStorage isn't
+			// accessable due to browser blocking 3rd party cookies when
 			// theLounge is loaded via iFrame
 			// See: https://github.com/thelounge/thelounge/issues/2699
 		}
@@ -37,8 +37,8 @@ module.exports = {
 		try {
 			window.localStorage.clear();
 		} catch (e) {
-			// Do nothing. You can end up here because localStorage isn't 
-			// accessable due to browser blocking 3rd party cookies when 
+			// Do nothing. You can end up here because localStorage isn't
+			// accessable due to browser blocking 3rd party cookies when
 			// theLounge is loaded via iFrame
 			// See: https://github.com/thelounge/thelounge/issues/2699
 		}


### PR DESCRIPTION
Return a warning to console when we need to catch.
Return null when attempting to get an item from localStorage

REF: #2699