### PR TITLE
Add `try`/`catch` to `localStorage` methods

### DIFF
--- a/client/js/localStorage.js
+++ b/client/js/localStorage.js
@@ -1,22 +1,43 @@
 "use strict";
 
+// This is a simple localStorage wrapper because browser can throw errors
+// in different situations, including:
+// - Unable to store data if storage is full
+// - Local storage is blocked if "third-party cookies and site data" is disabled
+//
+// For more details, see:
+// https://stackoverflow.com/q/14555347/1935861
+// https://github.com/thelounge/thelounge/issues/2699
+// https://www.chromium.org/for-testers/bug-reporting-guidelines/uncaught-securityerror-failed-to-read-the-localstorage-property-from-window-access-is-denied-for-this-document
+
 module.exports = {
 	set(key, value) {
 		try {
 			window.localStorage.setItem(key, value);
 		} catch (e) {
-			// Do nothing. If we end up here, web storage quota exceeded, or user is
-			// in Safari's private browsing where localStorage's setItem is not
-			// available. See http://stackoverflow.com/q/14555347/1935861.
+			//
 		}
 	},
 	get(key) {
-		return window.localStorage.getItem(key);
+		try {
+			return window.localStorage.getItem(key);
+		} catch (e) {
+			// Return null as if data is not set
+			return null;
+		}
 	},
 	remove(key) {
-		window.localStorage.removeItem(key);
+		try {
+			window.localStorage.removeItem(key);
+		} catch (e) {
+			//
+		}
 	},
 	clear() {
-		window.localStorage.clear();
+		try {
+			window.localStorage.clear();
+		} catch (e) {
+			//
+		}
 	},
 };


### PR DESCRIPTION
Return null when attempting to get an item from localStorage
Now with 66% less commits.

REF: #2699