### PR TITLE
Fix bugs with URL overrides in Connect window

### DIFF
--- a/client/js/socket-events/configuration.js
+++ b/client/js/socket-events/configuration.js
@@ -176,6 +176,12 @@ function parseOverrideParams(params, data) {
 			continue;
 		}
 
+		// When the network is locked, URL overrides should not affect disabled fields
+		if (data.lockNetwork &&
+				["host", "port", "tls", "rejectUnauthorized"].includes(key)) {
+			continue;
+		}
+
 		if (key === "join") {
 			value = value.split(",").map((chan) => {
 				if (!chan.match(/^[#&!+]/)) {

--- a/client/js/socket-events/configuration.js
+++ b/client/js/socket-events/configuration.js
@@ -182,6 +182,11 @@ function parseOverrideParams(params, data) {
 			continue;
 		}
 
+		// When the network is not displayed, its name in the UI is not customizable
+		if (!data.displayNetwork && key === "name") {
+			continue;
+		}
+
 		if (key === "join") {
 			value = value.split(",").map((chan) => {
 				if (!chan.match(/^[#&!+]/)) {

--- a/src/server.js
+++ b/src/server.js
@@ -590,6 +590,7 @@ function getClientConfiguration(network) {
 	} else {
 		// Only send defaults that are visible on the client
 		config.defaults = _.pick(network || Helper.config.defaults, [
+			"name",
 			"nick",
 			"username",
 			"password",


### PR DESCRIPTION
Follow-up of https://github.com/thelounge/thelounge/commit/94f1d8dde053570bade85096b67cc8a49ee8b809 and probably another commit.

💥 _3 bug fixes for the price of 1!_ 💥


### 1. Disallow URL override of network-related fields on the client when the network is locked

Before | After
--- | ---
<img width="884" alt="screen shot 2018-08-11 at 18 16 38" src="https://user-images.githubusercontent.com/113730/43996536-bb6c6968-9d92-11e8-8043-a40a6801d90b.png"> | <img width="875" alt="screen shot 2018-08-11 at 18 16 47" src="https://user-images.githubusercontent.com/113730/43996537-bb781ee8-9d92-11e8-8033-edb171ca92c3.png">


### 2. Pass network name along to the client connect window when network is locked and not displayed

Before | After
--- | ---
<img width="496" alt="screen shot 2018-08-11 at 18 08 00" src="https://user-images.githubusercontent.com/113730/43996526-7b260d28-9d92-11e8-83fe-f3f035692fec.png"> | <img width="484" alt="screen shot 2018-08-11 at 18 09 40" src="https://user-images.githubusercontent.com/113730/43996527-7b32b92e-9d92-11e8-9a1c-eaf6531036e3.png">


### 3. Make sure the network name cannot be changed through URL override when the network info is not displayed

Before | After
--- | ---
<img width="868" alt="screen shot 2018-08-11 at 18 10 37" src="https://user-images.githubusercontent.com/113730/43996528-7b3e5eaa-9d92-11e8-95b6-634b43b3a7d4.png"> | <img width="866" alt="screen shot 2018-08-11 at 18 11 20" src="https://user-images.githubusercontent.com/113730/43996529-7b48c674-9d92-11e8-9761-bfe2b71d7a48.png">
