### PR TITLE
Hide `Native App` settings section when no items are available

### DIFF
--- a/client/js/options.js
+++ b/client/js/options.js
@@ -333,6 +333,8 @@ function initialize() {
 
 			return false;
 		});
+
+		$("#native-app").prop("hidden", false);
 	} else {
 		defaultClientButton.hide();
 	}

--- a/client/js/socket-events/configuration.js
+++ b/client/js/socket-events/configuration.js
@@ -18,6 +18,8 @@ window.addEventListener("beforeinstallprompt", (installPromptEvent) => {
 			$(this).prop("hidden", true);
 		})
 		.prop("hidden", false);
+
+	$("#native-app").prop("hidden", false);
 });
 
 socket.on("configuration", function(data) {

--- a/client/views/windows/settings.tpl
+++ b/client/views/windows/settings.tpl
@@ -14,7 +14,7 @@
 	</div>
 
 	<div class="row">
-		<div class="col-sm-12">
+		<div class="col-sm-12" id="native-app" hidden>
 			<h2>Native app</h2>
 			<button type="button" class="btn" id="webapp-install-button" hidden>Add The Lounge to Home screen</button>
 			<button type="button" class="btn" id="make-default-client">Open irc:// URLs with The Lounge</button>


### PR DESCRIPTION
on Safari, there would be a "Native App" header with no options underneath it.

Alternatively, instead of hiding the options, I could set them to `disabled` and add a tooltip. Thoughts?