### PR TITLE
Fix confirmation box text for network removal in client

### DIFF
--- a/client/js/utils.js
+++ b/client/js/utils.js
@@ -169,7 +169,7 @@ function closeChan(chan) {
 		cmd = "/quit";
 		const server = chan.find(".name").html();
 
-		if (!confirm("Disconnect from " + server + "?")) { // eslint-disable-line no-alert
+		if (!confirm(`Are you sure you want to remove ${server}?`)) { // eslint-disable-line no-alert
 			return false;
 		}
 	}


### PR DESCRIPTION
This PR will make the text inside confirmation box for network removal in client more correct. Earlier it said "Disconnect from", but in reality it disconnects and remove the network entierly.

The js code may be utterly wrong. If so, please help. Also, if @astorije would like a different text to be more consistent with other parts of TheLounge, please say.