### PR TITLE
Drop spdy module in favor of native https module

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "request": "2.88.0",
     "semver": "5.5.1",
     "socket.io": "2.1.1",
-    "spdy": "3.4.7",
     "thelounge-ldapjs-non-maintained-fork": "1.0.2",
     "tlds": "1.203.1",
     "ua-parser-js": "0.7.18",

--- a/src/server.js
+++ b/src/server.js
@@ -108,7 +108,7 @@ module.exports = function() {
 			process.exit();
 		}
 
-		server = require("spdy");
+		server = require("https");
 		server = server.createServer({
 			key: fs.readFileSync(keyPath),
 			cert: fs.readFileSync(certPath),

--- a/yarn.lock
+++ b/yarn.lock
@@ -6910,7 +6910,7 @@ spdy-transport@^2.0.18:
     safe-buffer "^5.0.1"
     wbuf "^1.7.2"
 
-spdy@3.4.7, spdy@^3.4.1:
+spdy@^3.4.1:
   version "3.4.7"
   resolved "https://registry.yarnpkg.com/spdy/-/spdy-3.4.7.tgz#42ff41ece5cc0f99a3a6c28aabb73f5c3b03acbc"
   dependencies:


### PR DESCRIPTION
It appears that spdy is dangerously unmaintaned, and started breaking on latest Node versions.

Inspired by https://github.com/webpack/webpack-dev-server/pull/1451 and https://github.com/spdy-http2/node-spdy/issues/333

We should be able to use native http2 module once its stable and express supports it, if we need to. We already recommend using reverse proxies for TLS termination anyway.
