### PR TITLE
Enforce lobby to be the 0th channel when sorting

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -452,7 +452,17 @@ Client.prototype.sort = function(data) {
 			return;
 		}
 
-		network.channels.sort((a, b) => order.indexOf(a.id) - order.indexOf(b.id));
+		network.channels.sort((a, b) => {
+			// Always sort lobby to the top regardless of what the client has sent
+			// Because there's a lot of code that presumes channels[0] is the lobby
+			if (a.type === Chan.Type.LOBBY) {
+				return -1;
+			} else if (b.type === Chan.Type.LOBBY) {
+				return 1;
+			}
+
+			return order.indexOf(a.id) - order.indexOf(b.id);
+		});
 
 		// Sync order to connected clients
 		this.emit("sync_sort", {


### PR DESCRIPTION
This is only a server-side bug where it blindly trusted the client not to touch the lobby position. This change forces the lobby to always persist at the top regardless of what the client sends.