### PR TITLE
Add google analytics support

### DIFF
--- a/client/index.html.tpl
+++ b/client/index.html.tpl
@@ -45,7 +45,10 @@
 	<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
 	<meta name="mobile-web-app-capable" content="yes">
 	<meta name="theme-color" content="<%- themeColor %>">
-
+	<% if (analytics.enable === true && analytics.google.ga_id !== null) { %>
+	<!-- Global site tag (gtag.js) - Google Analytics -->
+	<script async src="https://www.googletagmanager.com/gtag/js?id=<%- analytics.google.ga_id %>"></script>
+	<% } %>
 	</head>
 	<body class="signed-out<%- public ? " public" : "" %>" data-transports="<%- JSON.stringify(transports) %>">
 		<div id="viewport" role="tablist">
@@ -105,5 +108,14 @@
 
 		<script src="js/bundle.vendor.js"></script>
 		<script src="js/bundle.js"></script>
+		<% if (analytics.enable === true && analytics.google.ga_id !== null) { %> 	
+		<script>
+		window.dataLayer = window.dataLayer || [];
+		function gtag(){dataLayer.push(arguments);}
+		gtag('js', new Date());
+
+		gtag('config', '<%- analytics.google.ga_id %>');
+		</script>
+		<% } %>
 	</body>
 </html>

--- a/defaults/config.js
+++ b/defaults/config.js
@@ -430,4 +430,27 @@ module.exports = {
 		// server window, displayed on the client.
 		raw: false,
 	},
+
+	// ## Analytics 
+	// For all your stats tracking needs
+	analytics: {
+
+		// ### `analytics.enable`
+		//
+		// when set to `true`, this globally enables the logic used to inject analytics
+		// trackers into thelounge
+		//
+		// Defaults to `false`
+		enable: false,
+
+		// ### `analytics.google`
+		//
+		// The google object is used to hold any configuration items specific to google analytics.
+		// Currently this is only the Google Analytics ID.
+		//
+		// ga_id is `null` by default. Change it to a string tracking ID to enable google analytics e.g. `UA-123456-1`
+		google: {
+			ga_id: null,
+		},
+	},
 };


### PR DESCRIPTION

- Modify CSP policy to allow google analytics in script and img policies when requried
- Inject the google analytics tracking and google tag manager as required for tracking.
  - Auto fill tracking ID based on Google Analytics ID value
- Add to default configuration.
