### PR TITLE
Fix passwords not being saved in Firefox

### DIFF
--- a/client/views/windows/sign_in.tpl
+++ b/client/views/windows/sign_in.tpl
@@ -3,11 +3,11 @@
 	<img src="img/logo-vertical-transparent-bg-inverted.svg" class="logo-inverted" alt="The Lounge" width="256" height="170">
 
 	<label>Username</label>
-	<input class="input" name="user" autocapitalize="none" autofocus>
+	<input class="input" type="text" name="user" autocapitalize="none" autocorrect="off" autocomplete="username" required autofocus>
 
 	<div class="password-container">
 		<label>Password</label>
-		<input class="input" type="password" name="password">
+		<input class="input" type="password" name="password" autocapitalize="none" autocorrect="off" autocomplete="current-password" required>
 		{{> ../reveal-password}}
 	</div>
 

--- a/src/server.js
+++ b/src/server.js
@@ -245,7 +245,7 @@ function index(req, res, next) {
 
 	const policies = [
 		"default-src 'none'", // default to nothing
-		"form-action 'none'", // no default-src fallback
+		"form-action 'self'", // 'self' to fix saving passwords in Firefox, even though login is handled in javascript
 		"connect-src 'self' ws: wss:", // allow self for polling; websockets
 		"style-src 'self' https: 'unsafe-inline'", // allow inline due to use in irc hex colors
 		"script-src 'self'", // javascript


### PR DESCRIPTION
Fixes #1740.

This also sets `autocorrect`, `autocapitalize` on password field because we have a button to turn it into text field to see the password.

Also makes both login and password fields required.