### PR TITLE
Disable file uploads by default until the UX is better

### DIFF
--- a/defaults/config.js
+++ b/defaults/config.js
@@ -156,7 +156,7 @@ module.exports = {
 	//   `-1` disables the file size limit and allows files of any size. **Use at
 	//   your own risk.** This value is set to `10240` kilobytes by default.
 	fileUpload: {
-		enable: true,
+		enable: false,
 		maxFileSize: 10240,
 	},
 


### PR DESCRIPTION
We agreed that it should be disabled by default in the initial release, and after we polish it (e.g. add confirm dialogs, etc) in a further release we can switch it.