### PR TITLE
Fix stacktraces in client tests

### DIFF
--- a/webpack.config-test.js
+++ b/webpack.config-test.js
@@ -4,6 +4,7 @@ const path = require("path");
 const config = require("./webpack.config.js");
 
 config.target = "node";
+config.devtool = "eval";
 
 // Instrumentation for coverage with Istanbul
 config.module.rules.push({


### PR DESCRIPTION
Before:
```
      at parseStyle (public\main:727:26)
      at prepare (public\main:832:10)
      at parse (public\main:968:26)
      at Context.it (public\main:51623:18)
```

After:
```
      at parseStyle (webpack:///./client/js/libs/handlebars/ircmessageparser/parseStyle.js?:82:26)
      at prepare (webpack:///./client/js/libs/handlebars/ircmessageparser/parseStyle.js?:187:10)
      at parse (webpack:///./client/js/libs/handlebars/parse.js?:72:26)
      at Context.it (webpack:///./test/client/js/libs/handlebars/parse.js?:457:18)
```

It's also supposedly faster.