### PR TITLE
Limit network name length and replace spaces in log folders

### DIFF
--- a/src/plugins/messageStorage/text.js
+++ b/src/plugins/messageStorage/text.js
@@ -31,8 +31,7 @@ class TextFileMessageStorage {
 			return;
 		}
 
-		const networkFolderName = cleanFilename(`${network.name}-${network.uuid.substring(network.name.length + 1)}`);
-		const logPath = path.join(Helper.getUserLogsPath(), this.client.name, networkFolderName);
+		const logPath = path.join(Helper.getUserLogsPath(), this.client.name, TextFileMessageStorage.getNetworkFolderName(network));
 
 		try {
 			fsextra.ensureDirSync(logPath);
@@ -113,6 +112,14 @@ class TextFileMessageStorage {
 
 	canProvideMessages() {
 		return false;
+	}
+
+	static getNetworkFolderName(network) {
+		// Limit network name in the folder name to 23 characters
+		// So we can still fit 12 characters of the uuid for de-duplication
+		const networkName = cleanFilename(network.name.substring(0, 23).replace(/ /g, "-"));
+
+		return `${networkName}-${network.uuid.substring(networkName.length + 1)}`;
 	}
 }
 

--- a/test/tests/textLogFolder.js
+++ b/test/tests/textLogFolder.js
@@ -1,0 +1,34 @@
+"use strict";
+
+const expect = require("chai").expect;
+const TextFileMessageStorage = require("../../src/plugins/messageStorage/text");
+
+describe("TextFileMessageStorage", function() {
+	it("should combine network name and uuid into a safe name", function() {
+		expect(TextFileMessageStorage.getNetworkFolderName({
+			name: "Freenode",
+			uuid: "f9042ec9-4016-45e0-a8a8-d378fb252628",
+		})).to.equal("freenode-4016-45e0-a8a8-d378fb252628");
+	});
+
+	it("network name should be cleaned up and lowercased", function() {
+		expect(TextFileMessageStorage.getNetworkFolderName({
+			name: "@ TeSt ../..\\<>:\"/\\|?*",
+			uuid: "f9042ec9-4016-45e0-a8a8-d378fb252628",
+		})).to.equal("@-test-.._..--45e0-a8a8-d378fb252628");
+	});
+
+	it("folder name may contain two dashes if on boundary", function() {
+		expect(TextFileMessageStorage.getNetworkFolderName({
+			name: "Freenod",
+			uuid: "f9042ec9-4016-45e0-a8a8-d378fb252628",
+		})).to.equal("freenod--4016-45e0-a8a8-d378fb252628");
+	});
+
+	it("should limit network name length", function() {
+		expect(TextFileMessageStorage.getNetworkFolderName({
+			name: "This network name is longer than the uuid itself but it should be limited",
+			uuid: "f9042ec9-4016-45e0-a8a8-d378fb252628",
+		})).to.equal("this-network-name-is-lo-d378fb252628");
+	});
+});


### PR DESCRIPTION
This makes sure we always have UUID in the name for de-duplication, and makes sure that folder names are always the same length (36 characters).

Also added tests for this.