### PR TITLE
Update changelog generator script

### DIFF
--- a/scripts/changelog.js
+++ b/scripts/changelog.js
@@ -580,11 +580,11 @@ function isFeature({labels}) {
 //   chore(deps): update dependency mini-css-extract-plugin to v0.4.3
 //   fix(deps): update dependency web-push to v3.3.3
 //   chore(deps): update babel monorepo to v7.1.0
-function extractPackages(title) {
+function extractPackages({title, url}) {
 	const extracted = /(?:U|u)pdate(?: dependency)? ([\w-,` ./@]+?) (?:monorepo )?to /.exec(title);
 
 	if (!extracted) {
-		log.warn(`Failed to extract package from: ${title}`);
+		log.warn(`Failed to extract package from: ${title}  ${colors.gray(url)}`);
 		return [];
 	}
 
@@ -601,7 +601,7 @@ function parse(entries) {
 
 		if (isSkipped(entry)) {
 			result.skipped.push(entry);
-		} else if (isDependency(entry) && (deps = extractPackages(entry.title))) {
+		} else if (isDependency(entry) && (deps = extractPackages(entry))) {
 			deps.forEach((packageName) => {
 				const dependencyType = whichDependencyType(packageName);
 
@@ -612,7 +612,7 @@ function parse(entries) {
 
 					result[dependencyType][packageName].push(entry);
 				} else {
-					log.info(`${colors.bold(packageName)} was updated in ${colors.green("#" + entry.number)} then removed since last release. Skipping.`);
+					log.info(`${colors.bold(packageName)} was updated in ${colors.green("#" + entry.number)} then removed since last release. Skipping.  ${colors.gray(entry.url)}`);
 				}
 			});
 		} else if (isDocumentation(entry)) {

--- a/scripts/changelog.js
+++ b/scripts/changelog.js
@@ -525,7 +525,7 @@ function hasLabel(labels, expected) {
 function hasAnnotatedComment(comments, expected) {
 	return comments && comments.nodes.some(({authorAssociation, body}) =>
 		["OWNER", "MEMBER"].includes(authorAssociation) &&
-		body.split("\n").includes(`[${expected}]`)
+		body.split("\r\n").includes(`[${expected}]`)
 	);
 }
 

--- a/scripts/changelog.js
+++ b/scripts/changelog.js
@@ -667,7 +667,8 @@ async function generateChangelogEntry(targetVersion) {
 		contributors = extractContributors(codeCommitsAndPullRequests);
 
 		const websiteRepo = new RepositoryFetcher(client, "thelounge.github.io");
-		items.websiteDocumentation = await websiteRepo.fetchCommitsAndPullRequestsSince("v" + previousVersion);
+		const previousWebsiteVersion = await websiteRepo.fetchPreviousVersion(targetVersion);
+		items.websiteDocumentation = await websiteRepo.fetchCommitsAndPullRequestsSince("v" + previousWebsiteVersion);
 	}
 
 	items.version = targetVersion;

--- a/scripts/changelog.js
+++ b/scripts/changelog.js
@@ -151,7 +151,7 @@ ${printList(items.documentation)}`
 }
 
 ${_.isEmpty(items.websiteDocumentation) ? "" :
-		`On the [website repository](https://github.com/thelounge/thelounge.chat):
+		`On the [website repository](https://github.com/thelounge/thelounge.github.io):
 
 ${printList(items.websiteDocumentation)}`
 }
@@ -654,7 +654,7 @@ async function generateChangelogEntry(targetVersion) {
 		items.milestone = await codeRepo.fetchMilestone(targetVersion);
 		contributors = extractContributors(codeCommitsAndPullRequests);
 
-		const websiteRepo = new RepositoryFetcher(client, "thelounge.chat");
+		const websiteRepo = new RepositoryFetcher(client, "thelounge.github.io");
 		items.websiteDocumentation = await websiteRepo.fetchCommitsAndPullRequestsSince("v" + previousVersion);
 	}
 

--- a/scripts/changelog.js
+++ b/scripts/changelog.js
@@ -78,7 +78,11 @@ if (!version) {
 	version = semver.inc(packageJson.version, process.argv[2]);
 }
 
-if (!/^[0-9]+\.[0-9]+\.[0-9]+(-(pre|rc)+\.[0-9]+)?$/.test(version)) {
+function isValidVersion(str) {
+	return (/^[0-9]+\.[0-9]+\.[0-9]+(-(pre|rc)+\.[0-9]+)?$/.test(str));
+}
+
+if (!isValidVersion(version)) {
 	log.error(`Argument ${colors.bold("version")} is incorrect It must be either:`);
 	log.error(`- A keyword among: ${colors.green("major")}, ${colors.green("minor")}, ${colors.green("patch")}, ${colors.green("prerelease")}, ${colors.green("pre")}`);
 	log.error(`- An explicit version of format ${colors.green("x.y.z")} (stable) or ${colors.green("x.y.z-(pre|rc).n")} (pre-release).`);
@@ -526,7 +530,15 @@ function hasAnnotatedComment(comments, expected) {
 }
 
 function isSkipped(entry) {
-	return hasLabelOrAnnotatedComment(entry, "Meta: Skip Changelog");
+	return (
+		(entry.messageHeadline && (
+			// Version bump commits created by `yarn version`
+			isValidVersion(entry.messageHeadline) ||
+			// Commit message suggested by this script
+			entry.messageHeadline.startsWith("Add changelog entry for v")
+		)) ||
+		hasLabelOrAnnotatedComment(entry, "Meta: Skip Changelog")
+	);
 }
 
 // Dependency update PRs are listed in a special, more concise way in the changelog.


### PR DESCRIPTION
- Add support  for optional deps (puts them in as normal dep)
- Updates for renovate bot (it currently still fails for babel monorepo)
- Fixed website repo name
- Split pull request query into chunks (100 prs per request) as github api was failing