### PR TITLE
Remove moment locales from build

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -129,6 +129,7 @@ const config = {
 				to: "css/primer-tooltips.[ext]",
 			},
 		]),
+		new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
 		// socket.io uses debug, we don't need it
 		new webpack.NormalModuleReplacementPlugin(/debug/, path.resolve(__dirname, "scripts/noop.js")),
 	],


### PR DESCRIPTION
This removes about 400kb from development build. We don't use locales in moment, and I plan on replacing moment with native JS stuff later on, so these locales should not come into play.

Putting in 3.0 because an easy fix.