### PR TITLE
Remove Node.js v9 from the Travis CI matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: node_js
 # https://github.com/nodejs/Release
 node_js:
 - 10 # EOL: April 2021
-- 9 # EOL: June 2018
 - 8 # EOL: December 2019
 - 6 # EOL: April 2019
 


### PR DESCRIPTION
See https://github.com/nodejs/Release

To this day, Node.js v6 is in maintenance mode, v8 is an active LTS, and v10 is the current stable. v9 has been EOL since June.

Marking this as part of The Lounge v3 so we can use the major bump opportunity. I will document this in the upgrade guide.
Do we want to reflect this in https://github.com/thelounge/thelounge/blob/master/package.json#L39? I'd say no. The Lounge is probably compatible with v9, in fact, but we don't support it.