### PR TITLE
Remove underline from textcomplete dropdown

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -2075,7 +2075,7 @@ part/quit messages where we don't load previews (adds a blank line otherwise) */
 }
 
 .textcomplete-item a:hover {
-	opacity: 1;
+	text-decoration: none;
 }
 
 .emoji {


### PR DESCRIPTION
The `<a>` tag doesn't cover the entire line, and we change the background color. This matches context menus.

Fixes #2816