### PR TITLE
Add setting to hide version from CTCP query

### DIFF
--- a/defaults/config.js
+++ b/defaults/config.js
@@ -176,6 +176,14 @@ module.exports = {
 	// default.
 	leaveMessage: "The Lounge - https://thelounge.chat",
 
+	// ### `hideCtcpVersion`
+	//
+	// When set to `true`, The Lounge won't include the version number
+	// in a CTCP VERSION query reply.
+	//
+	// This value is set to `false` by default.
+	hideCtcpVersion: false,
+
 	// ## Default network
 
 	// ### `defaults`

--- a/src/plugins/irc-events/ctcp.js
+++ b/src/plugins/irc-events/ctcp.js
@@ -13,7 +13,13 @@ const ctcpResponses = {
 		.join(" "),
 	PING: ({message}) => message.substring(5),
 	SOURCE: () => pkg.repository.url,
-	VERSION: () => pkg.name + " " + Helper.getVersion() + " -- " + pkg.homepage,
+	VERSION() {
+		if (Helper.config.hideCtcpVersion) {
+			return pkg.name + " -- " + pkg.homepage;
+		}
+
+		return pkg.name + " " + Helper.getVersion() + " -- " + pkg.homepage;
+	},
 };
 
 module.exports = function(irc, network) {


### PR DESCRIPTION
I don't know if admins should be able to configure custom VERSION replies. 
This just adds a setting that allows you to disable it, returning `thelounge -- https://thelounge.chat` instead of `thelounge v3.0.0-rc.1 -- https://thelounge.chat`.