### PR TITLE
Fix stored image previews not being dereferenced

### DIFF
--- a/src/models/chan.js
+++ b/src/models/chan.js
@@ -84,17 +84,25 @@ Chan.prototype.pushMessage = function(client, msg, increasesUnread) {
 
 		// If maxHistory is 0, image would be dereferenced before client had a chance to retrieve it,
 		// so for now, just don't implement dereferencing for this edge case.
-		if (Helper.config.prefetch && Helper.config.prefetchStorage && Helper.config.maxHistory > 0) {
+		if (Helper.config.maxHistory > 0) {
 			this.dereferencePreviews(deleted);
 		}
 	}
 };
 
 Chan.prototype.dereferencePreviews = function(messages) {
+	if (!Helper.config.prefetch || !Helper.config.prefetchStorage) {
+		return;
+	}
+
 	messages.forEach((message) => {
-		if (message.preview && message.preview.thumb) {
-			storage.dereference(message.preview.thumb);
-			message.preview.thumb = null;
+		if (message.previews) {
+			message.previews.forEach((preview) => {
+				if (preview.thumb) {
+					storage.dereference(preview.thumb);
+					preview.thumb = null;
+				}
+			});
 		}
 	});
 };


### PR DESCRIPTION
Broken in 64ebe0f4372b789e79033b7307d0259360d96ed1 (#1303) when we added support for multiple previews in a single message