### PR TITLE
Put unread and highlight counts in aria-label in the channel list

### DIFF
--- a/client/views/chan.tpl
+++ b/client/views/chan.tpl
@@ -4,7 +4,7 @@
 	data-id="{{id}}"
 	data-target="#chan-{{id}}"
 	role="tab"
-	aria-label="{{name}}"
+	aria-label="{{name}}{{#if unread}} ({{unread}} unread{{#if highlight}}, {{highlight}} mentions{{/if}}){{/if}}"
 	aria-controls="chan-{{id}}"
 	aria-selected="false"
 >


### PR DESCRIPTION
Putting it in 3.0 because this worked on 2.x and was broken in commit e448dc711c164f26ee2d3bd16e1958cb9677320c as it added `aria-label` attribute.