### PR TITLE
Remove aria-label on channels in channel list

### DIFF
--- a/client/views/chan.tpl
+++ b/client/views/chan.tpl
@@ -4,7 +4,6 @@
 	data-id="{{id}}"
 	data-target="#chan-{{id}}"
 	role="tab"
-	aria-label="{{name}}{{#if unread}} ({{unread}} unread{{#if highlight}}, {{highlight}} mentions{{/if}}){{/if}}"
 	aria-controls="chan-{{id}}"
 	aria-selected="false"
 >


### PR DESCRIPTION
Fixes #2829. This effectively reverts to the behavior that existed in 2.7.

I can't be bothered to write jquery code to update the label, and I did implement it in Vue branch correctly (much easier there since it's reactive).