### PR TITLE
Bring back aria-label to fix broken code

### DIFF
--- a/client/views/chan.tpl
+++ b/client/views/chan.tpl
@@ -4,6 +4,7 @@
 	data-id="{{id}}"
 	data-target="#chan-{{id}}"
 	role="tab"
+	aria-label="{{name}}"
 	aria-controls="chan-{{id}}"
 	aria-selected="false"
 >


### PR DESCRIPTION
Fixes #2837
Reverts 78f0e544db55b448d9e163d382e719c7b5d7032e
Reverts d087c726e0044dab04a5928943b444cc34e7e776

Sorry, I tried, but the jquery mess makes it incredibly hard to fix quickly. This is implemented properly in Vue branch.