### PR TITLE
Force express server to run in production mode

### DIFF
--- a/src/plugins/uploader.js
+++ b/src/plugins/uploader.js
@@ -52,7 +52,7 @@ class Uploader {
 			} while (fs.stat(destPath, (err) => (err ? true : false)));
 
 			fsextra.move(data.file.pathName, destPath).then(() => {
-				const slug = path.basename(data.file.pathName);
+				const slug = encodeURIComponent(path.basename(data.file.pathName));
 				const url = `uploads/${randomName}/${slug}`;
 				socket.emit("upload:success", url);
 			}).catch(() => {

--- a/src/server.js
+++ b/src/server.js
@@ -46,6 +46,7 @@ module.exports = function() {
 	};
 
 	const app = express()
+		.set("env", "production")
 		.disable("x-powered-by")
 		.use(allRequests)
 		.use(index)


### PR DESCRIPTION
Uploaded files that contained percentages weren't encoded, and express happily throws bad request with a full stacktrace.