### PR TITLE
Fix touch position being null when touching with multiple fingers

### DIFF
--- a/client/js/slideout.js
+++ b/client/js/slideout.js
@@ -28,20 +28,19 @@ class SlideoutMenu {
 }
 
 function onTouchStart(e) {
+	touchStartPos = touchCurPos = e.touches.item(0);
+
 	if (e.touches.length !== 1) {
 		onTouchEnd();
 		return;
 	}
 
-	const touch = e.touches.item(0);
 	const styles = window.getComputedStyle(menu);
 
 	menuWidth = parseFloat(styles.width);
 	menuIsAbsolute = styles.position === "absolute";
 
-	if (!menuIsOpen || touch.screenX > menuWidth) {
-		touchStartPos = touch;
-		touchCurPos = touch;
+	if (!menuIsOpen || touchStartPos.screenX > menuWidth) {
 		touchStartTime = Date.now();
 
 		document.body.addEventListener("touchmove", onTouchMove, {passive: true});


### PR DESCRIPTION
This threw an error, but we didn't know about it until Vue showed the errors in UI.

The repro goes something like:
1. Start moving menu with 1 finger
2. Place second finger on screen, thus cancelling the swipe
3. Lift off first finger while keeping second finger on screen
4. Place first/another finger on screen again
5. It should call `onTouchEnd` while both touch objects containing `screenX` are null