### PR TITLE
Fix timing issue crashing on undefined when setting openChannel

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -404,9 +404,14 @@ Client.prototype.more = function(data) {
 };
 
 Client.prototype.open = function(socketId, target) {
+	// Due to how socket.io works internally, normal events may arrive later than
+	// the disconnect event, and because we can't control this timing precisely,
+	// process this event normally even if there is no attached client anymore.
+	const attachedClient = this.attachedClients[socketId] || {};
+
 	// Opening a window like settings
 	if (target === null) {
-		this.attachedClients[socketId].openChannel = -1;
+		attachedClient.openChannel = -1;
 		return;
 	}
 
@@ -420,7 +425,7 @@ Client.prototype.open = function(socketId, target) {
 	target.chan.unread = 0;
 	target.chan.highlight = 0;
 
-	this.attachedClients[socketId].openChannel = target.chan.id;
+	attachedClient.openChannel = target.chan.id;
 	this.lastActiveChannel = target.chan.id;
 
 	this.emit("open", target.chan.id);

--- a/src/server.js
+++ b/src/server.js
@@ -295,7 +295,7 @@ function initializeClient(socket, client, token, lastMessage) {
 	}
 
 	socket.on("disconnect", function() {
-		client.clientDetach(socket.id);
+		process.nextTick(() => client.clientDetach(socket.id));
 	});
 
 	socket.on("input", (data) => {


### PR DESCRIPTION
I was looking at the socket.io code, and came to the conclusion that events can arrive at 2 ticks later + there may be delay from middleware, while onclose event avoids all that.

So I added nextTick for clientDetach, and an empty object in `open` to fix the crash for good (nothing bad happens, as we only access that object to set the active channel for a specific connection).

Fixes #1995.
Fixes #2831.