### PR TITLE
Sanitize logo url in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 	<img
 		width="300"
 		alt="The Lounge"
-		src="client/img/logo-vertical-transparent-bg.svg">
+		src="https://raw.githubusercontent.com/thelounge/thelounge/master/client/img/logo-vertical-transparent-bg.svg?sanitize=true">
 </h1>
 
 <h3 align="center">


### PR DESCRIPTION
Otherwise npm site doesn't want to display it: https://www.npmjs.com/package/thelounge/v/3.0.0-rc.4

And yarn site probably too, when it picks up new readme.