### PR TITLE
Make links in generated config relative

### DIFF
--- a/scripts/generate-config-doc.js
+++ b/scripts/generate-config-doc.js
@@ -28,6 +28,7 @@ const configContent = readFileSync(
 const docPath = join(process.argv[2], "_includes", "config.js.md");
 
 const extractedDoc = configContent
+	.replace(/https:\/\/thelounge\.chat\/docs/g, "/docs") // make links relative
 	.split("\n")
 	.reduce((acc, line) => {
 		line = line.trim();


### PR DESCRIPTION
Here's how it looks: https://github.com/thelounge/thelounge.github.io/commit/abc0aba03b3d562c163b1a3eff0ee0195f7935ef

Since we use netlify for previews, we want them to be relative.