### PR TITLE
Don't require $HOME unless shortened paths are used

### DIFF
--- a/src/helper.js
+++ b/src/helper.js
@@ -205,6 +205,12 @@ function expandHome(shortenedPath) {
 		return "";
 	}
 
+	// no need to lookup the home dir if path doesn't contain '~'.
+	// os.homedir might throw and nothing will be expanded anyways.
+	if (shortenedPath.indexOf("~") === -1) {
+		return path.resolve(shortenedPath);
+	}
+
 	const home = os.homedir().replace("$", "$$$$");
 	return path.resolve(shortenedPath.replace(/^~($|\/|\\)/, home + "$1"));
 }


### PR DESCRIPTION
While [packaging TheLounge for NixOS](https://github.com/NixOS/nixpkgs/pull/51947) I've run into an exception in `os.homedir()`.
This happened because the service is run as a systemd DynamicUser and the user doesn't have a home directory assigned.
The easy workaround setting `$HOME` to something. It'd be nice though to be able to remove the workaround when updating the package to v3.