### PR TITLE
Empty storage directory after destroying all channels

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -181,6 +181,11 @@ module.exports = function() {
 				return;
 			}
 
+			log.info("Exiting...");
+
+			// Close all client and IRC connections
+			manager.clients.forEach((client) => client.quit());
+
 			if (Helper.config.prefetchStorage) {
 				log.info("Clearing prefetch storage folder, this might take a while...");
 
@@ -189,11 +194,6 @@ module.exports = function() {
 
 			// Forcefully exit after 3 seconds
 			suicideTimeout = setTimeout(() => process.exit(1), 3000);
-
-			log.info("Exiting...");
-
-			// Close all client and IRC connections
-			manager.clients.forEach((client) => client.quit());
 
 			// Close http server
 			server.close(() => {


### PR DESCRIPTION
I noticed that lounge first cleared out the storage directory, then when it tried to dereference all the previews when clients->networks->channels are destroyed it dereferenced all of them and then tried to `fs.unlink` the files, but they were deleted already.

This change should dereference and unlink them first, and empty the directory if there's anything remaining in it.