### PR TITLE
Don't fallback to `host` in identd server

### DIFF
--- a/src/identification.js
+++ b/src/identification.js
@@ -26,7 +26,7 @@ class Identification {
 			const server = net.createServer(this.serverConnection.bind(this));
 			server.listen({
 				port: Helper.config.identd.port || 113,
-				host: Helper.config.bind || Helper.config.host,
+				host: Helper.config.bind,
 			}, () => {
 				const address = server.address();
 				log.info(`Identd server available on ${colors.green(address.address + ":" + address.port)}`);


### PR DESCRIPTION
That doesn't really make much sense as `bind` is used for outgoing connections, but it does not fallback to `host`.

So if you left `bind: undefined`, but set `host` to some IP address, identd would listen on a different IP than outgoing connections.