### PR TITLE
Serve requests from cache when server responds with non 2xx response

### DIFF
--- a/client/service-worker.js
+++ b/client/service-worker.js
@@ -49,6 +49,11 @@ function networkOrCache(uri) {
 						return response;
 					});
 				}
+
+				// eslint-disable-next-line no-console
+				console.error(`Request for ${uri.href} failed with HTTP ${response.status}`);
+
+				return Promise.reject("request-failed");
 			})
 			.catch(function() {
 				return cache.match(uri).then(function(matching) {


### PR DESCRIPTION
When lounge usually runs behind a reverse proxy, the proxy can return a response like 504 gateway timeout and this will cause the service worker to fail lookup the file in cache which may result in a broken page.

Adding a reject here will make it lookup in cache, like it normally would for completely failed requests.