### PR TITLE
Set scrollbar properties for Firefox 64+

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -550,6 +550,7 @@ kbd {
 	overflow-x: auto;
 	flex-grow: 1;
 	touch-action: pan-y;
+	scrollbar-width: thin;
 	overscroll-behavior: contain;
 	-webkit-overflow-scrolling: touch;
 }
@@ -897,6 +898,7 @@ background on hover (unless active) */
 	display: none;
 	overflow-y: auto;
 	height: 100%;
+	scrollbar-width: thin;
 	overscroll-behavior: contain;
 	-webkit-overflow-scrolling: touch;
 }
@@ -1045,6 +1047,7 @@ background on hover (unless active) */
 	display: flex;
 	flex-grow: 1;
 	flex-direction: column;
+	scrollbar-width: thin;
 	overscroll-behavior: contain;
 	-webkit-overflow-scrolling: touch;
 	outline: none;
@@ -1569,6 +1572,7 @@ part/quit messages where we don't load previews (adds a blank line otherwise) */
 	padding-bottom: 10px;
 	width: 100%;
 	touch-action: pan-y;
+	scrollbar-width: thin;
 	overscroll-behavior: contain;
 	-webkit-overflow-scrolling: touch;
 }

--- a/client/themes/morning.css
+++ b/client/themes/morning.css
@@ -11,6 +11,10 @@
 	--highlight-border-color: #b08c4f;
 }
 
+body {
+	scrollbar-color: rgba(0, 0, 0, 0.3) rgba(0, 0, 0, 0.05);
+}
+
 #chat .channel .msg.highlight .time {
 	color: white;
 }


### PR DESCRIPTION
This should make the scrollbar thin on platforms that allow for it, and changes the scrollbar color in Morning theme so it doesn't stand out like a sore thumb.

Refs:
https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-color
https://drafts.csswg.org/css-scrollbars-1/