### PR TITLE
Fix .active styles incorrectly applying to hovered users in userlist

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -935,7 +935,7 @@ background on hover (unless active) */
 	margin: 20px 0 10px;
 }
 
-#windows .active {
+#windows .window.active {
 	display: flex;
 	flex-direction: column;
 }
@@ -966,11 +966,6 @@ background on hover (unless active) */
 	flex-grow: 1;
 	overflow: hidden;
 	font-size: 14px;
-}
-
-#windows #chat-container.active {
-	display: flex;
-	flex-direction: column;
 }
 
 #chat {


### PR DESCRIPTION
Fixes #2969. `active` incorrectly applied flex styles to the user element, which caused a mysterious scroll event.

@thehaxxa @Jay2k1 please test and review.