### PR TITLE
Add an extra check for setting names

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -494,7 +494,7 @@ function initializeClient(socket, client, token, lastMessage) {
 				return;
 			}
 
-			if (typeof newSetting.name !== "string" || newSetting.name[0] === "_") {
+			if (typeof newSetting.value === "object" || typeof newSetting.name !== "string" || newSetting.name[0] === "_") {
 				return;
 			}
 

--- a/src/server.js
+++ b/src/server.js
@@ -494,6 +494,10 @@ function initializeClient(socket, client, token, lastMessage) {
 				return;
 			}
 
+			if (typeof newSetting.name !== "string" || newSetting.name[0] === "_") {
+				return;
+			}
+
 			// Older user configs will not have the clientSettings property.
 			if (!client.config.hasOwnProperty("clientSettings")) {
 				client.config.clientSettings = {};


### PR DESCRIPTION
The `_` should cover the cases of trying to write `__proto__`.

Added to 3.0.0 because that's the first release that adds syncing.