### PR TITLE
Set yarn cache folder in the packages folder

### DIFF
--- a/src/command-line/install.js
+++ b/src/command-line/install.js
@@ -55,13 +55,8 @@ program
 
 			return Utils.executeYarnCommand(
 				"add",
-				"--json",
-				"--exact",
 				"--production",
-				"--ignore-scripts",
-				"--non-interactive",
-				"--cwd",
-				packagesPath,
+				"--exact",
 				`${json.name}@${json.version}`
 			).then(() => {
 				log.info(`${colors.green(json.name + " v" + json.version)} has been successfully installed.`);

--- a/src/command-line/uninstall.js
+++ b/src/command-line/uninstall.js
@@ -39,11 +39,6 @@ program
 
 		return Utils.executeYarnCommand(
 			"remove",
-			"--json",
-			"--ignore-scripts",
-			"--non-interactive",
-			"--cwd",
-			packagesPath,
 			packageName
 		).then(() => {
 			log.info(`${colors.green(packageName)} has been successfully uninstalled.`);

--- a/src/command-line/upgrade.js
+++ b/src/command-line/upgrade.js
@@ -20,13 +20,8 @@ program
 		const packagesList = JSON.parse(fs.readFileSync(packagesConfig)).dependencies;
 		const argsList = [
 			"upgrade",
-			"--latest",
-			"--json",
 			"--production",
-			"--ignore-scripts",
-			"--non-interactive",
-			"--cwd",
-			packagesPath,
+			"--latest",
 		];
 
 		let count = 0;
@@ -44,7 +39,7 @@ program
 				log.info(`- ${colors.green(p)}`);
 
 				if (packagesList.hasOwnProperty(p)) {
-					argsList.splice(1, 0, p);
+					argsList.push(p);
 					count++;
 				} else {
 					log.error(`${colors.green(p)} is not installed.`);

--- a/src/command-line/utils.js
+++ b/src/command-line/utils.js
@@ -107,7 +107,7 @@ class Utils {
 		return memo;
 	}
 
-	static executeYarnCommand(...parameters) {
+	static executeYarnCommand(command, ...parameters) {
 		// First off, try to find yarn inside of The Lounge
 		let yarn = path.join(
 			__dirname, "..", "..", "node_modules",
@@ -127,9 +127,27 @@ class Utils {
 			}
 		}
 
+		const packagesPath = Helper.getPackagesPath();
+		const cachePath = path.join(packagesPath, "package_manager_cache");
+
+		const staticParameters = [
+			"--cache-folder",
+			cachePath,
+			"--cwd",
+			packagesPath,
+			"--json",
+			"--ignore-scripts",
+			"--non-interactive",
+		];
+
 		return new Promise((resolve, reject) => {
 			let success = false;
-			const add = require("child_process").spawn(process.execPath, [yarn, ...parameters]);
+			const add = require("child_process").spawn(process.execPath, [
+				yarn,
+				command,
+				...staticParameters,
+				...parameters,
+			]);
 
 			add.stdout.on("data", (data) => {
 				data.toString().trim().split("\n").forEach((line) => {


### PR DESCRIPTION
Fixes thelounge/thelounge-docker#71.

This solves permissions problems where The Lounge can't write outside of it's config folder.

I also moved common parameters that we pass into yarn to the utility function.