### PR TITLE
Keep using npm to clean up dist-tags after a stable release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,5 +63,5 @@ deploy:
 # If the current release is a stable release, remove potential pre-release tag
 after_deploy: |
   if [ "$(npm_dist_tag)" == "latest" ]; then
-    yarn tag remove thelounge next || true
+    npm dist-tag rm thelounge next || true
   fi


### PR DESCRIPTION
- After deploy, `yarn tag` gets prompted for login, because npm login != yarn login
- When I tried to do it locally, `yarn tag remove thelounge next` consistently gave me a 404, but `npm dist-tag rm thelounge next` worked nbd.