### PR TITLE
Bump minimum node version to 8 LTS

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -2,6 +2,9 @@
 
 root: true
 
+parserOptions:
+  ecmaVersion: 2017
+
 env:
   es6: true
   browser: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,7 @@ language: node_js
 node_js:
   - 11 # EOL: June 2019
   - 10 # EOL: April 2021
-  - 8 # EOL: December 2019
-  - 6 # EOL: April 2019
+  - 8.10.0 # EOL: December 2019 (test exact LTS version)
 
 os:
   - linux

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   ],
   "license": "MIT",
   "engines": {
-    "node": ">=6.13.0"
+    "node": ">=8.10.0"
   },
   "dependencies": {
     "bcryptjs": "2.4.3",

--- a/scripts/.eslintrc.yml
+++ b/scripts/.eslintrc.yml
@@ -1,5 +1,0 @@
----
-
-# Necessary to support async/await... grumble grumble...
-parserOptions:
-  ecmaVersion: 8


### PR DESCRIPTION
8.9.0 is the first Carbon LTS, as seen on https://nodejs.org/en/download/releases/

6 LTS expires in April, as per https://github.com/nodejs/Release