### PR TITLE
Fix up link insertion after uploads to be saner

### DIFF
--- a/client/js/socket-events/uploads.js
+++ b/client/js/socket-events/uploads.js
@@ -1,10 +1,24 @@
 "use strict";
 
 const socket = require("../socket");
-const wrapCursor = require("undate").wrapCursor;
+const updateCursor = require("undate").update;
 
 socket.on("upload:success", (url) => {
-	const fullURL = new URL(url, location);
+	const fullURL = (new URL(url, location)).toString();
 	const textbox = document.getElementById("input");
-	wrapCursor(textbox, fullURL, " ");
+	const initStart = textbox.selectionStart;
+
+	// Get the text before the cursor, and add a space if it's not in the beginning
+	const headToCursor = initStart > 0 ? (textbox.value.substr(0, initStart) + " ") : "";
+
+	// Get the remaining text after the cursor
+	const cursorToTail = textbox.value.substr(initStart);
+
+	// Construct the value until the point where we want the cursor to be
+	const textBeforeTail = headToCursor + fullURL + " ";
+
+	updateCursor(textbox, textBeforeTail + cursorToTail);
+
+	// Set the cursor after the link and a space
+	textbox.selectionStart = textbox.selectionEnd = textBeforeTail.length;
 });


### PR DESCRIPTION
- If there's text before cursor, it will add a space before the url
- Will always put the cursor after the link + space
- Will no longer override selected text, instead will insert it where the selection starts