### PR TITLE
plugin/ctcp: Let the user know a CTCP request was sent

### DIFF
--- a/src/plugins/inputs/ctcp.js
+++ b/src/plugins/inputs/ctcp.js
@@ -1,9 +1,23 @@
 "use strict";
 
+const Msg = require("../../models/msg");
+
 exports.commands = ["ctcp"];
 
 exports.input = function({irc}, chan, cmd, args) {
-	if (args.length > 1) {
-		irc.ctcpRequest(...args);
+	if (args.length < 2) {
+		chan.pushMessage(this, new Msg({
+			type: Msg.Type.ERROR,
+			text: "Usage: /ctcp <nick> <ctcp_type>",
+		}));
+		return;
 	}
+
+	chan.pushMessage(this, new Msg({
+		type: Msg.Type.CTCP_REQUEST,
+		ctcpMessage: `"${args.slice(1).join(" ")}" to ${args[0]}`,
+		from: chan.getUser(irc.user.nick),
+	}));
+
+	irc.ctcpRequest(...args);
 };


### PR DESCRIPTION
Because responding to a CTCP request is completely optional,
sometimes thelounge will just do absolutely nothing. (the request
was received, but the client did not respond to it)

This alleviates the problem by always notifying the user that
*something* was sent.


----

I tested some CLIENTINFOs on myself and the response was `* Zarthus CLIENTINFO VERSION` - which was a bit confusing to me.

----

![img](https://liefland.net/~zarthus/image/chrome_a03533e1da8958392d7c505e.png)