### PR TITLE
Make sure the editorconfig indent size applies to all file formats

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,7 +6,7 @@ root = true
 
 [*]
 indent_style = tab
-indent_size = 2
+indent_size = 4
 
 end_of_line = lf
 charset = utf-8
@@ -18,3 +18,4 @@ trim_trailing_whitespace = false
 
 [*.{json,yml}]
 indent_style = space
+indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -6,6 +6,7 @@ root = true
 
 [*]
 indent_style = tab
+indent_size = 2
 
 end_of_line = lf
 charset = utf-8
@@ -17,4 +18,3 @@ trim_trailing_whitespace = false
 
 [*.{json,yml}]
 indent_style = space
-indent_size = 2


### PR DESCRIPTION
I was glancing at the Vue PR, and was tired of scrolling horizontally on files with a lot of levels. I first discovered the `?ts=2` query string for GitHub, but then [read here](https://stackoverflow.com/a/33831598/1935861) that it will respect the `indent_size` for tabs, which is rather nifty.

This should end up looking like this:

Before | After
--- | ---
<img width="992" alt="screen shot 2019-02-03 at 02 45 25" src="https://user-images.githubusercontent.com/113730/52174150-d32e9d00-275d-11e9-907d-aca43615d6fa.png"> | <img width="999" alt="screen shot 2019-02-03 at 02 45 00" src="https://user-images.githubusercontent.com/113730/52174149-d32e9d00-275d-11e9-8127-723166ac2e73.png">
