### PR TITLE
Allow forcing /disconnect to stop reconnection timer from running

### DIFF
--- a/src/plugins/inputs/disconnect.js
+++ b/src/plugins/inputs/disconnect.js
@@ -3,11 +3,16 @@
 const Helper = require("../../helper");
 
 exports.commands = ["disconnect"];
+exports.allowDisconnected = true;
 
 exports.input = function(network, chan, cmd, args) {
 	const quitMessage = args[0] ? args.join(" ") : Helper.config.leaveMessage;
 
-	network.irc.quit(quitMessage);
+	// Even if we are disconnected, but there is an internal connection object
+	// pass the quit/end to it, so the reconnection timer stops
+	if (network.irc && network.irc.connection) {
+		network.irc.quit(quitMessage);
+	}
 
 	network.userDisconnected = true;
 	this.save();


### PR DESCRIPTION
If a network is not connected, and is currently on a reconnect timer, you were not able to stop that timer and mark the network as user disconnected.