### PR TITLE
Disable Travis caching on Windows builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ matrix:
   include:
     - node_js: 10
       os: windows
+      cache: false
       env: YARN_GPG=no # starts gpg-agent that never exits
     - node_js: 10
       os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,16 +13,16 @@ os:
 matrix:
   fast_finish: true
   include:
-    - node_js: 10
-      os: windows
-      cache: false
-      env: YARN_GPG=no # starts gpg-agent that never exits
-    - node_js: 10
-      os: osx
     - name: "Production build"
       node_js: 10 # Version used to deploy to npm registry
       os: linux
       env: BUILD_ENV=production
+    - node_js: 10
+      os: osx
+    - node_js: 10
+      os: windows
+      cache: false
+      env: YARN_GPG=no # starts gpg-agent that never exits
 
 cache: yarn
 


### PR DESCRIPTION
This is a band aid fix.

Yarn installs are unpredicably slow, and storing cache is just very slow, so disabling the cache over all makes the builds faster a little.