### PR TITLE
Fix copying text in Firefox

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -103,6 +103,8 @@ button {
 	margin: 0;
 	outline: none;
 	padding: 0;
+	-moz-user-select: inherit; /* Firefox makes buttons unselectable by default which breaks copying */
+	user-select: inherit;
 }
 
 code,


### PR DESCRIPTION
Fixes #3035.

1. Firefox makes `<button>` unselectable by default
2. Firefox creates multiple ranges which go around the unselectable button element

I have a Firefox bug created, but it's easier to just fix it in Lounge for now.