### PR TITLE
Remove margin-top: auto

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -1106,10 +1106,6 @@ background on hover (unless active) */
 	touch-action: pan-y;
 }
 
-#chat .chan:not(.special) .messages {
-	margin-top: auto;
-}
-
 #chat .msg {
 	word-wrap: break-word;
 	word-break: break-word; /* Webkit-specific */


### PR DESCRIPTION
This CSS is used to push messages to the bottom of the chat if there aren't enough messages to fill the container, however this property is causing a lot of mysterious scroll related issues in Chrome both on master and Vue branches.

In it's current state, it's causing way more problems with scroll than it solves.

This property is also the real cause behind the #2975 bug (while that was incorrect css on our part, it still shouldn't have scrolled). And this is causing problems in @MiniDigger's theme where he changes opacity in user list.

Do we have a better way of pushing messages to the bottom if we want to keep this behavior?