### PR TITLE
Remove network name from window title

### DIFF
--- a/client/js/utils.js
+++ b/client/js/utils.js
@@ -85,7 +85,7 @@ function updateTitle() {
 	let title = vueApp.appName;
 
 	if (vueApp.activeChannel) {
-		title = `${vueApp.activeChannel.channel.name} — ${vueApp.activeChannel.network.name} — ${title}`;
+		title = `${vueApp.activeChannel.channel.name} — ${title}`;
 	}
 
 	// add highlight count to title


### PR DESCRIPTION
Follow-up of https://github.com/thelounge/thelounge/pull/2647.

It can be redundant on network tab.

This follows a comment I made in the initial Vue PR: https://github.com/thelounge/thelounge/pull/2647#issuecomment-463914534
I went with no network at all because I don't think it brings any particular value, see comment for more details. I am not married to the idea of entirely removing network name if it's something we think is really needed though, so let me know.