### PR TITLE
Improve scroll-down button UI

### DIFF
--- a/client/components/Chat.vue
+++ b/client/components/Chat.vue
@@ -58,7 +58,8 @@
 					v-else
 					class="chat-content">
 					<div
-						:class="['scroll-down', {'scroll-down-shown': !channel.scrolledToBottom}]"
+						:class="['scroll-down tooltipped tooltipped-w', {'scroll-down-shown': !channel.scrolledToBottom}]"
+						aria-label="Jump to recent messages"
 						@click="$refs.messageList.jumpToBottom()">
 						<div class="scroll-down-arrow" />
 					</div>

--- a/client/css/style.css
+++ b/client/css/style.css
@@ -1097,7 +1097,7 @@ background on hover (unless active) */
 	pointer-events: none;
 	opacity: 0;
 	transform: translateY(16px);
-	transition: all 0.2s ease-in-out;
+	transition: transform 0.2s, opacity 0.2s;
 	cursor: pointer;
 }
 
@@ -1108,18 +1108,23 @@ background on hover (unless active) */
 }
 
 .scroll-down-arrow {
-	width: 48px;
-	height: 48px;
-	line-height: 48px;
+	width: 36px;
+	height: 36px;
+	line-height: 34px;
 	border-radius: 50%;
-	background: #fff;
-	color: #333;
-	border: 1px solid #84ce88;
+	background: var(--window-bg-color);
+	color: #84ce88;
+	border: 2px solid #84ce88;
 	text-align: center;
+	transition: background 0.2s, color 0.2s;
+	box-shadow:
+		0 3px 5px -1px rgba(0, 0, 0, 0.2),
+		0 6px 10px 0 rgba(0, 0, 0, 0.14);
 }
 
 .scroll-down:hover .scroll-down-arrow {
 	background: #84ce88;
+	color: var(--window-bg-color);
 }
 
 .scroll-down-arrow::after {

--- a/client/css/style.css
+++ b/client/css/style.css
@@ -1121,9 +1121,7 @@ background on hover (unless active) */
 	border: 2px solid var(--button-color);
 	text-align: center;
 	transition: background 0.2s, color 0.2s;
-	box-shadow:
-		0 3px 5px -1px rgba(0, 0, 0, 0.2),
-		0 6px 10px 0 rgba(0, 0, 0, 0.14);
+	box-shadow: 0 6px 10px 0 rgba(0, 0, 0, 0.15);
 }
 
 .scroll-down:hover .scroll-down-arrow {

--- a/client/css/style.css
+++ b/client/css/style.css
@@ -11,6 +11,10 @@
 	/* Background color of the whole page */
 	--body-bg-color: #415364;
 
+	/* Main button color. Applies to border, text, and background on hover */
+	--button-color: #84ce88;
+	--button-text-color-hover: #fff;
+
 	/* Links and link-looking buttons */
 	--link-color: #50a656;
 
@@ -155,9 +159,9 @@ kbd {
 }
 
 .btn {
-	border: 2px solid #84ce88;
+	border: 2px solid var(--button-color);
 	border-radius: 3px;
-	color: #84ce88;
+	color: var(--button-color);
 	display: inline-block;
 	font-size: 12px;
 	font-weight: bold;
@@ -177,8 +181,8 @@ kbd {
 .btn:disabled,
 .btn:hover,
 .btn:focus {
-	background: #84ce88;
-	color: #fff;
+	background: var(--button-color);
+	color: var(--button-text-color-hover);
 	opacity: 1;
 }
 
@@ -1113,8 +1117,8 @@ background on hover (unless active) */
 	line-height: 34px;
 	border-radius: 50%;
 	background: var(--window-bg-color);
-	color: #84ce88;
-	border: 2px solid #84ce88;
+	color: var(--button-color);
+	border: 2px solid var(--button-color);
 	text-align: center;
 	transition: background 0.2s, color 0.2s;
 	box-shadow:
@@ -1123,8 +1127,8 @@ background on hover (unless active) */
 }
 
 .scroll-down:hover .scroll-down-arrow {
-	background: #84ce88;
-	color: var(--window-bg-color);
+	background: var(--button-color);
+	color: var(--button-text-color-hover);
 }
 
 .scroll-down-arrow::after {


### PR DESCRIPTION
Follow-up of https://github.com/thelounge/thelounge/pull/2647.

Addresses a comment made by @williamboman at https://github.com/thelounge/thelounge/pull/2647#issuecomment-462155721.

Theme | Before | After
--- | --- | ---
Default (normal) | <img width="168" alt="screen shot 2019-02-18 at 01 03 06" src="https://user-images.githubusercontent.com/113730/52931557-d52a5b80-331a-11e9-9728-b7050709276c.png"> | <img width="141" alt="screen shot 2019-02-18 at 13 52 51" src="https://user-images.githubusercontent.com/113730/52971190-8c0ef180-3384-11e9-91c8-d6abbc012eb1.png">
Default (hover) | <img width="155" alt="screen shot 2019-02-18 at 01 03 20" src="https://user-images.githubusercontent.com/113730/52931549-cb085d00-331a-11e9-9d76-281f70cc8068.png"> | <img width="154" alt="screen shot 2019-02-18 at 13 52 56" src="https://user-images.githubusercontent.com/113730/52971199-9204d280-3384-11e9-97ee-3d74cff0f038.png">
Morning (normal) | <img width="143" alt="screen shot 2019-02-18 at 01 10 21" src="https://user-images.githubusercontent.com/113730/52931482-81b80d80-331a-11e9-8140-018b23efd65e.png"> | <img width="159" alt="screen shot 2019-02-18 at 01 10 48" src="https://user-images.githubusercontent.com/113730/52931512-a4e2bd00-331a-11e9-9d88-ae352d720a7c.png">
Morning (hover) | <img width="155" alt="screen shot 2019-02-18 at 01 10 31" src="https://user-images.githubusercontent.com/113730/52931525-b3c96f80-331a-11e9-9e7c-acaf53874f12.png"> | <img width="157" alt="screen shot 2019-02-18 at 13 26 54" src="https://user-images.githubusercontent.com/113730/52971002-cf1c9500-3383-11e9-905f-43cf516ac190.png">


**With the tooltip on hover:**

<img width="237" alt="screen shot 2019-02-18 at 01 26 26" src="https://user-images.githubusercontent.com/113730/52931961-4a4a6080-331c-11e9-9699-2b65db0a57af.png">
