### PR TITLE
Use Vue to show/hide insecure/disconnected icons instead of CSS

### DIFF
--- a/client/components/Channel.vue
+++ b/client/components/Channel.vue
@@ -14,7 +14,8 @@
 			<span
 				v-if="channel.state === 0"
 				class="parted-channel-tooltip tooltipped tooltipped-w"
-				aria-label="Not currently joined">
+				aria-label="Not currently joined"
+			>
 				<span class="parted-channel-icon" />
 			</span>
 			<span

--- a/client/components/NetworkLobby.vue
+++ b/client/components/NetworkLobby.vue
@@ -22,12 +22,14 @@
 				class="name"
 			>{{ channel.name }}</span>
 			<span
+				v-if="network.status.connected && !network.status.secure"
 				class="not-secure-tooltip tooltipped tooltipped-w"
 				aria-label="Insecure connection"
 			>
 				<span class="not-secure-icon" />
 			</span>
 			<span
+				v-if="!network.status.connected"
 				class="not-connected-tooltip tooltipped tooltipped-w"
 				aria-label="Disconnected"
 			>

--- a/client/css/style.css
+++ b/client/css/style.css
@@ -662,21 +662,6 @@ background on hover (unless active) */
 }
 
 #sidebar .not-connected-tooltip,
-#sidebar .not-secure-tooltip {
-	display: none;
-}
-
-#sidebar .not-connected .not-connected-tooltip,
-#sidebar .not-secure .not-secure-tooltip {
-	display: inline-block;
-}
-
-#sidebar .not-connected .not-secure-tooltip {
-	/* Do not display insecure icon if disconnected */
-	display: none;
-}
-
-#sidebar .not-connected-tooltip,
 #sidebar .not-secure-tooltip,
 #sidebar .parted-channel-tooltip {
 	margin: 0 8px;


### PR DESCRIPTION
Follow-up of https://github.com/thelounge/thelounge/pull/3082#discussion_r260173171.

@xPaw, I believe this is what you meant, let me know if I messed up something here.