### PR TITLE
Print a warning for invalid keys in config file or cli arguments

### DIFF
--- a/src/command-line/index.js
+++ b/src/command-line/index.js
@@ -1,6 +1,5 @@
 "use strict";
 
-const _ = require("lodash");
 const log = require("../log");
 const fs = require("fs");
 const path = require("path");
@@ -34,7 +33,7 @@ if (process.getuid) {
 Utils.checkOldHome();
 
 // Merge config key-values passed as CLI options into the main config
-_.merge(Helper.config, program.config);
+Helper.mergeConfig(Helper.config, program.config);
 
 require("./start");
 

--- a/src/helper.js
+++ b/src/helper.js
@@ -230,7 +230,11 @@ function getDefaultNick() {
 }
 
 function mergeConfig(oldConfig, newConfig) {
-	return _.mergeWith(oldConfig, newConfig, (objValue, srcValue, key) => {
+	return _.mergeWith(oldConfig, newConfig, (objValue, srcValue, key, object) => {
+		if (!object.hasOwnProperty(key)) {
+			log.warn(`Unknown key "${colors.bold(key)}", please verify your config.`);
+		}
+
 		// Do not override config variables if the type is incorrect (e.g. object changed into a string)
 		if (typeof objValue !== "undefined" && objValue !== null && typeof objValue !== typeof srcValue) {
 			log.warn(`Incorrect type for "${colors.bold(key)}", please verify your config.`);


### PR DESCRIPTION
This will work for the config file, and `-c` CLI argument.

Sadly I couldn't figure a way of printing full path to the key if it's in another object. (e.g. `fileUpload.badkey` will say `badkey` is unknown). Even with this limitation, I think it provides valuable information, especially when using `--config`.