### PR TITLE
Use async/await in service worker, do not wait for cache for successful requests

### DIFF
--- a/client/index.html.tpl
+++ b/client/index.html.tpl
@@ -5,11 +5,12 @@
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, user-scalable=no">
 
-	<link rel="preload" as="script" href="js/bundle.vendor.js">
-	<link rel="preload" as="script" href="js/bundle.js">
+	<link rel="preload" as="script" href="js/loading-error-handlers.js?v=<%- cacheBust %>">
+	<link rel="preload" as="script" href="js/bundle.vendor.js?v=<%- cacheBust %>">
+	<link rel="preload" as="script" href="js/bundle.js?v=<%- cacheBust %>">
 
-	<link rel="stylesheet" href="css/primer-tooltips.css">
-	<link rel="stylesheet" href="css/style.css">
+	<link rel="stylesheet" href="css/primer-tooltips.css?v=<%- cacheBust %>">
+	<link rel="stylesheet" href="css/style.css?v=<%- cacheBust %>">
 	<link id="theme" rel="stylesheet" href="themes/<%- theme %>.css" data-server-theme="<%- theme %>">
 	<% _.forEach(stylesheets, function(css) { %>
 		<link rel="stylesheet" href="packages/<%- css %>">
@@ -59,7 +60,7 @@
 					<p id="loading-slow">This is taking longer than it should, there might be connectivity issues.</p>
 					<button id="loading-reload" class="btn">Reload page</button>
 				</div>
-				<script async src="js/loading-error-handlers.js"></script>
+				<script async src="js/loading-error-handlers.js?v=<%- cacheBust %>"></script>
 			</div>
 		</div>
 		<div id="viewport"></div>
@@ -68,7 +69,7 @@
 		<div id="image-viewer"></div>
 		<div id="upload-overlay"></div>
 
-		<script src="js/bundle.vendor.js"></script>
-		<script src="js/bundle.js"></script>
+		<script src="js/bundle.vendor.js?v=<%- cacheBust %>"></script>
+		<script src="js/bundle.js?v=<%- cacheBust %>"></script>
 	</body>
 </html>

--- a/src/helper.js
+++ b/src/helper.js
@@ -9,6 +9,7 @@ const fs = require("fs");
 const net = require("net");
 const bcrypt = require("bcryptjs");
 const colors = require("chalk");
+const crypto = require("crypto");
 
 let homePath;
 let configPath;
@@ -32,6 +33,7 @@ const Helper = {
 	getUserLogsPath,
 	setHome,
 	getVersion,
+	getVersionCacheBust,
 	getGitCommit,
 	ip2hex,
 	mergeConfig,
@@ -87,6 +89,12 @@ function getGitCommit() {
 		_gitCommit = null;
 		return null;
 	}
+}
+
+function getVersionCacheBust() {
+	const hash = crypto.createHash("sha256").update(Helper.getVersion()).digest("hex");
+
+	return hash.substring(0, 10);
 }
 
 function setHome(newPath) {

--- a/src/server.js
+++ b/src/server.js
@@ -281,7 +281,10 @@ function index(req, res, next) {
 			throw err;
 		}
 
-		res.send(_.template(file)(getServerConfiguration()));
+		const config = getServerConfiguration();
+		config.cacheBust = Helper.getVersionCacheBust();
+
+		res.send(_.template(file)(config));
 	});
 }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,6 +5,7 @@ const path = require("path");
 const CopyPlugin = require("copy-webpack-plugin");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const VueLoaderPlugin = require("vue-loader/lib/plugin");
+const Helper = require("./src/helper.js");
 
 const config = {
 	mode: process.env.NODE_ENV === "production" ? "production" : "development",
@@ -123,7 +124,17 @@ const config = {
 			{
 				from: "./client/*",
 				to: "[name].[ext]",
-				ignore: "index.html.tpl",
+				ignore: [
+					"index.html.tpl",
+					"service-worker.js",
+				],
+			},
+			{
+				from: "./client/service-worker.js",
+				to: "[name].[ext]",
+				transform(content) {
+					return content.toString().replace("__HASH__", Helper.getVersionCacheBust());
+				},
 			},
 			{
 				from: "./client/audio/*",


### PR DESCRIPTION
Use async instead of promises, browsers that support service workers also support async already.

I also changed the cache logic to avoid blocking the request response. This means fetch() and its response are returned immediately if request succeeds and refreshing the content in cache is done in a separate async call.

Before:
1. Open cache
2. Fetch request
3. Put into cache
4. Return response

After:
1. Fetch request
2. Return response
3. Open cache
4. Put into cache