### PR TITLE
Remove incorrect lowest node version from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The Lounge is the official and community-managed fork of [Shout](https://github.
 
 ## Installation and usage
 
-The Lounge requires [Node.js](https://nodejs.org/) v6 or more recent.
+The Lounge requires [Node.js](https://nodejs.org/) v8 or more recent.
 [Yarn package manager](https://yarnpkg.com/) is also recommended.  
 If you want to install with npm, `--unsafe-perm` is required for a correct install.
 


### PR DESCRIPTION
We are only supporting 8 and up. Think this has been around for a long time, apparently.