### PR TITLE
Disable touch tooltip on "jump to recent messages" button

### DIFF
--- a/client/components/Chat.vue
+++ b/client/components/Chat.vue
@@ -70,7 +70,7 @@
 					class="chat-content"
 				>
 					<div
-						:class="['scroll-down tooltipped tooltipped-w', {'scroll-down-shown': !channel.scrolledToBottom}]"
+						:class="['scroll-down tooltipped tooltipped-w tooltipped-no-touch', {'scroll-down-shown': !channel.scrolledToBottom}]"
 						aria-label="Jump to recent messages"
 						@click="$refs.messageList.jumpToBottom()"
 					>


### PR DESCRIPTION
Fixes #3089