### PR TITLE
Remove bogus prefetch limit

### DIFF
--- a/src/plugins/irc-events/link.js
+++ b/src/plugins/irc-events/link.js
@@ -330,8 +330,6 @@ function fetch(uri, headers) {
 		let response;
 		let limit = Helper.config.prefetchMaxImageSize * 1024;
 
-		limit = 10240;
-
 		try {
 			got
 				.stream(uri, {


### PR DESCRIPTION
Leftover from test code when I ported to `got`.