### PR TITLE
Only prepend text with 'Notice: ' if it's the nick it's from

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -1393,7 +1393,7 @@ background on hover (unless active) */
 	color: #0074d9 !important;
 }
 
-#chat .notice .user::before {
+#chat .notice .from .user::before {
 	content: "Notice: ";
 }
 


### PR DESCRIPTION
When I do a `/notice` to a channel that contains a nick of a client in the channel, "Notice: " is prepended to that client's nick. For example, sending `/notice #channel hi emerson!emerson@emerson hi` results in:
![Screenshot_20190614_135610](https://user-images.githubusercontent.com/5402360/59528433-484c7480-8eac-11e9-9263-63aeade1bce3.png)

This patch changes it so it is:

![Screenshot_20190614_135632](https://user-images.githubusercontent.com/5402360/59528449-4f738280-8eac-11e9-9f5d-33283901ac9a.png)