### PR TITLE
Make sure unhandled command has params

### DIFF
--- a/src/plugins/irc-events/unhandled.js
+++ b/src/plugins/irc-events/unhandled.js
@@ -8,16 +8,18 @@ module.exports = function(irc, network) {
 	irc.on("unknown command", function(command) {
 		let target = network.channels[0];
 
-		// Do not display users own name
-		if (command.params[0] === network.irc.user.nick) {
-			command.params.shift();
-		} else {
-			// If this numeric starts with a channel name that exists
-			// put this message in that channel
-			const channel = network.getChannel(command.params[0]);
+		if (command.params.length > 0) {
+			// Do not display users own name
+			if (command.params[0] === network.irc.user.nick) {
+				command.params.shift();
+			} else {
+				// If this numeric starts with a channel name that exists
+				// put this message in that channel
+				const channel = network.getChannel(command.params[0]);
 
-			if (typeof channel !== "undefined") {
-				target = channel;
+				if (typeof channel !== "undefined") {
+					target = channel;
+				}
 			}
 		}
 


### PR DESCRIPTION
We can crash on `network.getChannel(undefined)` call.