### PR TITLE
Change unable to load sqlite3 message

### DIFF
--- a/src/plugins/messageStorage/sqlite.js
+++ b/src/plugins/messageStorage/sqlite.js
@@ -13,7 +13,7 @@ try {
 } catch (e) {
 	Helper.config.messageStorage = Helper.config.messageStorage.filter((item) => item !== "sqlite");
 
-	log.error("Unable to load sqlite3 module. You might need to install it manually.");
+	log.error("Unable to load node-sqlite3 module. See https://github.com/mapbox/node-sqlite3/wiki/Binaries");
 }
 
 const currentSchemaVersion = 1520239200;


### PR DESCRIPTION
"You might need to install it manually." misleads users into thinking they need to install the system package, but that's not used by node.