### PR TITLE
Refactor command API for plugins

### DIFF
--- a/src/plugins/inputs/index.js
+++ b/src/plugins/inputs/index.js
@@ -37,18 +37,25 @@ const userInputs = [
 	"whois",
 ].reduce(function(plugins, name) {
 	const plugin = require(`./${name}`);
-	plugin.commands.forEach((command) => (plugins[command] = plugin));
+	plugin.commands.forEach((command) => plugins.set(command, plugin));
 	return plugins;
-}, {});
+}, new Map());
+
+const pluginCommands = new Map();
 
 const getCommands = () =>
-	Object.keys(userInputs)
+	Array.from(userInputs.keys())
+		.concat(Array.from(pluginCommands.keys()))
 		.map((command) => `/${command}`)
 		.concat(clientSideCommands)
 		.concat(passThroughCommands)
 		.sort();
 
+const addPluginCommand = (command, func) => pluginCommands.set(command, func);
+
 module.exports = {
+	addPluginCommand,
 	getCommands,
+	pluginCommands,
 	userInputs,
 };

--- a/src/plugins/packages/index.js
+++ b/src/plugins/packages/index.js
@@ -16,14 +16,14 @@ module.exports = {
 	loadPackages,
 };
 
-const packageApis = function(clientManager, packageName) {
+const packageApis = function(packageName) {
 	return {
 		Stylesheets: {
 			addFile: addStylesheet.bind(this, packageName),
 		},
 		Commands: {
-			add: (command, func) => inputs.userInputs[command] = func,
-			runAsUser: (line, userName, target) => clientManager.findClient(userName).inputLine({target, text: line}),
+			add: inputs.addPluginCommand,
+			runAsUser: (command, targetId, client) => client.inputLine({target: targetId, text: command}),
 		},
 		Config: {
 			getConfig: () => Helper.config,
@@ -43,7 +43,7 @@ function getPackage(name) {
 	return packageMap.get(name);
 }
 
-function loadPackages(clientManager) {
+function loadPackages() {
 	const packageJson = path.join(Helper.getPackagesPath(), "package.json");
 	let packages;
 	let anyPlugins = false;
@@ -83,7 +83,7 @@ function loadPackages(clientManager) {
 		}
 
 		if (packageFile.onServerStart) {
-			packageFile.onServerStart(packageApis(clientManager, packageName));
+			packageFile.onServerStart(packageApis(packageName));
 		}
 
 		log.info(`Package ${colors.bold(packageName)} loaded`);

--- a/src/plugins/packages/publicClient.js
+++ b/src/plugins/packages/publicClient.js
@@ -1,0 +1,40 @@
+module.exports = class PublicClient {
+	constructor(client) {
+		this.client = client;
+	}
+
+	/**
+	 *
+	 * @param {String} command - IRC command to run, this is in the same format that a client would send to the server (eg: JOIN #test)
+	 * @param {String} targetId - The id of the channel to simulate the command coming from. Replies will go to this channel if appropriate
+	 */
+	runAsUser(command, targetId) {
+		this.client.inputLine({target: targetId, text: command});
+	}
+
+	/**
+	 *
+	 * @param {Object} attributes
+	 */
+	createChannel(attributes) {
+		return this.client.createChannel(attributes);
+	}
+
+	/**
+	 * Emits an `event` to the browser client, with `data` in the body of the event.
+	 *
+	 * @param {String} event - Name of the event, must be something the browser will recognise
+	 * @param {Object} data - Body of the event, can be anything, but will need to be properly interpreted by the client
+	 */
+	sendToBrowser(event, data) {
+		this.client.emit(event, data);
+	}
+
+	/**
+	 *
+	 * @param {Number} chanId
+	 */
+	getChannel(chanId) {
+		return this.client.find(chanId);
+	}
+};

--- a/src/server.js
+++ b/src/server.js
@@ -173,7 +173,7 @@ module.exports = function() {
 		});
 
 		manager = new ClientManager();
-		packages.loadPackages(manager);
+		packages.loadPackages();
 
 		new Identification((identHandler) => {
 			manager.init(identHandler, sockets);


### PR DESCRIPTION
So, previously we were treating plugin commands as exactly the same as internal ones. That was a bit confusing. We are changing them to have:

1. A new publicClient wrapper around the client, so plugins don't have access to all the internal functions that we want
2. The publicClient as an argument, rather than bound to `this`
3. The whole target object, rather than just the network and channel as separate objects. This one, after having done the work, might not be necessary as I think the target is just an object containing the 2 of them ... but it is nice not having to have the 2 different args. I dunno.

Here's the code for my test plugin up to date with the new API.

```
const shrug = {
  input: function(client, target, command, args) {
    const messageWithShrug = args.join(" ").replace(/^\//, "") + " ¯\\_(ツ)_/¯";
    client.runAsUser(messageWithShrug, target.chan.id);
  }
};

module.exports = {
  onServerStart: thelounge => {
    thelounge.Commands.add("shrug", shrug);
  }
};
```

Client is the publicClient, as can be seen in `publicClient.js`.