### PR TITLE
Only warn for top-level unknown config keys

### DIFF
--- a/src/helper.js
+++ b/src/helper.js
@@ -238,11 +238,13 @@ function getDefaultNick() {
 }
 
 function mergeConfig(oldConfig, newConfig) {
-	return _.mergeWith(oldConfig, newConfig, (objValue, srcValue, key, object) => {
-		if (!Object.prototype.hasOwnProperty.call(object, key)) {
+	for (const key in newConfig) {
+		if (!Object.prototype.hasOwnProperty.call(oldConfig, key)) {
 			log.warn(`Unknown key "${colors.bold(key)}", please verify your config.`);
 		}
+	}
 
+	return _.mergeWith(oldConfig, newConfig, (objValue, srcValue, key) => {
 		// Do not override config variables if the type is incorrect (e.g. object changed into a string)
 		if (typeof objValue !== "undefined" && objValue !== null && typeof objValue !== typeof srcValue) {
 			log.warn(`Incorrect type for "${colors.bold(key)}", please verify your config.`);


### PR DESCRIPTION
This removes warning when using `webirc`. ` _.mergeWith` is not really suited for doing these warnings, and in the future we should look into another solution. For now, just warn for top level keys.

This warning was only present since v3.1.0-pre.1. https://github.com/thelounge/thelounge/commit/7c1efb18d161a912e3d0b64d40eeb46823b97194