### PR TITLE
A better way of disabling sorting on touch devices

### DIFF
--- a/client/components/NetworkList.vue
+++ b/client/components/NetworkList.vue
@@ -8,7 +8,7 @@
 	<Draggable
 		v-else
 		:list="networks"
-		:disabled="isSortingEnabled"
+		:filter="isCurrentlyInTouch"
 		handle=".lobby"
 		draggable=".network"
 		ghost-class="ui-sortable-ghost"
@@ -51,7 +51,7 @@
 				ghost-class="ui-sortable-ghost"
 				drag-class="ui-sortable-dragged"
 				:group="network.uuid"
-				:disabled="isSortingEnabled"
+				:filter="isCurrentlyInTouch"
 				:list="network.channels"
 				class="channels"
 				@change="onChannelSort"
@@ -91,15 +91,11 @@ export default {
 		activeChannel: Object,
 		networks: Array,
 	},
-	computed: {
-		isSortingEnabled() {
-			const isTouch = !!("ontouchstart" in window || (window.DocumentTouch && document instanceof window.DocumentTouch));
-
-			// TODO: Implement a way to sort on touch devices
-			return isTouch;
-		},
-	},
 	methods: {
+		isCurrentlyInTouch(e) {
+			// TODO: Implement a way to sort on touch devices
+			return e.pointerType !== "mouse";
+		},
 		onDragStart(e) {
 			e.target.classList.add("ui-sortable-active");
 		},


### PR DESCRIPTION
`ontouchstart in window` may be false on Firefox Windows, which causes issues on touch devices. On top of that, if we detected a touch device we completely disabled sorting, which means even if you tried to use a mouse, it would still not work.

This fix should make the disabling a little smarter, where it will filter based on what caused the dragging to start.

Ref: https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent/pointerType