### PR TITLE
Merge network/channel objects when reconnecting to keep object references

### DIFF
--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -91,7 +91,7 @@ window.vueMounted = () => {
 		});
 	});
 
-	const openWindow = function openWindow(e, {keepSidebarOpen, pushState, replaceHistory} = {}) {
+	const openWindow = function openWindow(e, {pushState, replaceHistory} = {}) {
 		const self = $(this);
 		const target = self.attr("data-target");
 
@@ -133,7 +133,7 @@ window.vueMounted = () => {
 
 			socket.emit("open", channel ? channel.channel.id : null);
 
-			if (!keepSidebarOpen && $(window).outerWidth() <= utils.mobileViewportPixels) {
+			if ($(window).outerWidth() <= utils.mobileViewportPixels) {
 				slideoutMenu.toggle(false);
 			}
 		}


### PR DESCRIPTION
Old code handled reconnects by setting some variables like pending message/scrolled to bottom by taking it from the old client object. This has a fatal flaw of making the channel and network objects in `vueApp.networks` completely fresh, which means whatever channel is set in `vueApp.currentChannel` no longer references the same object.

I changed the code to re-use the existing client object and re-set the variables which come from the server, which leaves client-only variables in place by default. I still had to put some logic in place for `users` and `messages` arrays.

Merging objects is a little more convoluted, but hopefully will reduce any hidden bugs we might get (and probably lessen the burden on Vue to accurately diff the object internally).

---

I decided to rewrite it like this when I looked at why sidebar would automatically close on mobile when client reconnected,

That happened because the code supposed to return early if you open the same active channel did not pass the check as `vueApp.activeChannel.channel` object did not equal the new channel object returned by `findChannel`. That happened because the `init` event rewrote `vueApp.networks` objects and thus the channel reference was lost.

https://github.com/thelounge/thelounge/blob/01347787b778fa1da63b98a2146541e1b5f33bf7/client/js/lounge.js#L109-L114

With this PR, that code works correctly, as the channel and network object references are kept.

---

There was this piece of code, but I'm not entirely sure what it accomplishes in current setup so I removed it. If we get some bug with history not loading when it should, that's probably because of this.
https://github.com/thelounge/thelounge/blob/01347787b778fa1da63b98a2146541e1b5f33bf7/client/js/socket-events/init.js#L52-L54