### PR TITLE
Store ip and language in a separate object in user file

### DIFF
--- a/defaults/config.js
+++ b/defaults/config.js
@@ -298,23 +298,23 @@ module.exports = {
 	//
 	//   ```json
 	//   webirc: {
-	//     "irc.example.net": "password1",
-	//     "irc.example.org": "passw0rd",
+	//     "irc.example.net": "thisiswebircpassword1",
+	//     "irc.example.org": "thisiswebircpassword2",
 	//   },
 	//   ```
 	//
 	// - **Advanced**: an object where keys are IRC hosts and values are functions
-	//   that take three arguments (`client`, `args`, `trusted`) and return an
-	//   object to be directly passed to `irc-framework`. For example:
+	//   that take two arguments (`webircObj`, `network`) and return an
+	//   object to be directly passed to `irc-framework`. `webircObj` contains the
+	//   generated object which you can modify. For example:
 	//
 	//   ```js
 	//   webirc: {
-	//     "irc.example.net": (client, args, trusted) => ({
-	//       username: "thelounge",
-	//       password: "password1",
-	//       address: args.ip,
-	//       hostname: `webirc/${args.hostname}`
-	//     }),
+	//     "irc.example.com": (webircObj, network) => {
+	//       webircObj.password = "thisiswebircpassword";
+	//       webircObj.hostname = `webirc/${webircObj.hostname}`;
+	//       return webircObj;
+	//     },
 	//   },
 	//   ```
 	//

--- a/src/client.js
+++ b/src/client.js
@@ -92,6 +92,10 @@ function Client(manager, name, config = {}) {
 		client.config.clientSettings = {};
 	}
 
+	if (typeof client.config.browser !== "object") {
+		client.config.browser = {};
+	}
+
 	client.compileCustomHighlights();
 
 	_.forOwn(client.config.sessions, (session) => {
@@ -195,8 +199,6 @@ Client.prototype.connect = function(args) {
 		username: String(args.username || ""),
 		realname: String(args.realname || ""),
 		commands: args.commands || [],
-		ip: args.ip || (client.config && client.config.ip) || client.ip,
-		hostname: args.hostname || (client.config && client.config.hostname) || client.hostname,
 		channels: channels,
 		ignoreList: args.ignoreList ? args.ignoreList : [],
 	});
@@ -547,7 +549,6 @@ Client.prototype.quit = function(signOut) {
 
 Client.prototype.clientAttach = function(socketId, token) {
 	const client = this;
-	let save = false;
 
 	if (client.awayMessage && _.size(client.attachedClients) === 0) {
 		client.networks.forEach(function(network) {
@@ -561,27 +562,6 @@ Client.prototype.clientAttach = function(socketId, token) {
 
 	const openChannel = client.lastActiveChannel;
 	client.attachedClients[socketId] = {token, openChannel};
-
-	// Update old networks to store ip and hostmask
-	client.networks.forEach((network) => {
-		if (!network.ip) {
-			save = true;
-			network.ip = (client.config && client.config.ip) || client.ip;
-		}
-
-		if (!network.hostname) {
-			const hostmask = (client.config && client.config.hostname) || client.hostname;
-
-			if (hostmask) {
-				save = true;
-				network.hostmask = hostmask;
-			}
-		}
-	});
-
-	if (save) {
-		client.save();
-	}
 };
 
 Client.prototype.clientDetach = function(socketId) {

--- a/src/clientManager.js
+++ b/src/clientManager.js
@@ -118,6 +118,7 @@ ClientManager.prototype.addUser = function(name, password, enableLog) {
 		networks: [],
 		sessions: {},
 		clientSettings: {},
+		browser: {},
 	};
 
 	try {

--- a/src/plugins/irc-events/connection.js
+++ b/src/plugins/irc-events/connection.js
@@ -79,7 +79,7 @@ module.exports = function(irc, network) {
 		let ident = client.name || network.username;
 
 		if (Helper.config.useHexIp) {
-			ident = Helper.ip2hex(network.ip);
+			ident = Helper.ip2hex(client.config.browser.ip);
 		}
 
 		identSocketId = client.manager.identHandler.addSocket(socket, ident);

--- a/src/plugins/irc-events/link.js
+++ b/src/plugins/irc-events/link.js
@@ -63,7 +63,7 @@ module.exports = function(client, chan, msg) {
 
 		fetch(url, {
 			accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-			language: client.language,
+			language: client.config.browser.language,
 		}).then((res) => {
 			parse(msg, chan, preview, res, client);
 		}).catch((err) => {
@@ -106,7 +106,7 @@ function parseHtml(preview, res, client) {
 
 				// Verify that thumbnail pic exists and is under allowed size
 				if (preview.thumb.length) {
-					fetch(preview.thumb, {language: client.language}).then((resThumb) => {
+					fetch(preview.thumb, {language: client.config.browser.language}).then((resThumb) => {
 						if (resThumb === null
 						|| !(imageTypeRegex.test(resThumb.type))
 						|| resThumb.size > (Helper.config.prefetchMaxImageSize * 1024)) {
@@ -155,7 +155,7 @@ function parseHtmlMedia($, preview, client) {
 						accept: type === "video" ?
 							"video/webm,video/ogg,video/*;q=0.9,application/ogg;q=0.7,audio/*;q=0.6,*/*;q=0.5" :
 							"audio/webm, audio/ogg, audio/wav, audio/*;q=0.9, application/ogg;q=0.7, video/*;q=0.6; */*;q=0.5",
-						language: client.language,
+						language: client.config.browser.language,
 					}).then((resMedia) => {
 						if (resMedia === null || !mediaTypeRegex.test(resMedia.type)) {
 							return reject();

--- a/test/models/network.js
+++ b/test/models/network.js
@@ -39,8 +39,6 @@ describe("Network", function() {
 				realname: "",
 				commands: [],
 				nick: "chillin`",
-				ip: null,
-				hostname: null,
 				channels: [
 					{name: "#thelounge", key: ""},
 					{name: "&foobar", key: ""},
@@ -127,8 +125,8 @@ describe("Network", function() {
 
 			expect(saveCalled).to.be.true;
 			expect(network.guid).to.not.equal("newGuid");
-			expect(network.ip).to.be.null;
-			expect(network.hostname).to.be.null;
+			expect(network.ip).to.be.undefined;
+			expect(network.hostname).to.be.undefined;
 
 			expect(network.name).to.equal("Lounge Test Network");
 			expect(network.channels[0].name).to.equal("Lounge Test Network");
@@ -226,8 +224,6 @@ describe("Network", function() {
 				"channels",
 				"commands",
 				"host",
-				"hostname",
-				"ip",
 				"name",
 				"port",
 				"realname",

--- a/test/plugins/link.js
+++ b/test/plugins/link.js
@@ -287,7 +287,7 @@ describe("Link plugin", function() {
 
 	it("should use client's preferred language as Accept-Language header", function(done) {
 		const language = "sv,en-GB;q=0.9,en;q=0.8";
-		this.irc.language = language;
+		this.irc.config.browser.language = language;
 
 		app.get("/language-check", function(req, res) {
 			expect(req.headers["accept-language"]).to.equal(language);
@@ -449,7 +449,7 @@ describe("Link plugin", function() {
 		let requests = 0;
 		let responses = 0;
 
-		this.irc.language = "very nice language";
+		this.irc.config.browser.language = "very nice language";
 
 		link(this.irc, this.network.channels[0], message);
 		link(this.irc, this.network.channels[0], message);
@@ -489,11 +489,11 @@ describe("Link plugin", function() {
 		const requests = [];
 		let responses = 0;
 
-		this.irc.language = "first language";
+		this.irc.config.browser.language = "first language";
 		link(this.irc, this.network.channels[0], message);
 
 		setTimeout(() => {
-			this.irc.language = "second language";
+			this.irc.config.browser.language = "second language";
 			link(this.irc, this.network.channels[0], message);
 		}, 100);
 

--- a/test/util.js
+++ b/test/util.js
@@ -8,7 +8,9 @@ const Network = require("../src/models/network");
 const Chan = require("../src/models/chan");
 
 function MockClient() {
-	this.user = {nick: "test-user"};
+	this.config = {
+		browser: {},
+	};
 }
 
 util.inherits(MockClient, EventEmitter);


### PR DESCRIPTION
 Language was not stored in file at all before, meaning link preview requests would not send language header after server restart.

IP and hostname used to be stored for each network object, I changed it to store once per user instead, and added `isSecure` for future WEBIRC support.

The ip/hostname change will only really affect users that use webirc or hexip *and* if they used private mode. The code was kinda messy, so it's hard to tell how exactly it worked, this should simplify things.

Breaking change: Functions in webirc changed which objects are passed in.
Before: `(client, network)`
After: `(generatedDefaultWebircObject, network)`