### PR TITLE
Parse target group for sent messages when echo-message is not enabled

### DIFF
--- a/src/plugins/inputs/msg.js
+++ b/src/plugins/inputs/msg.js
@@ -16,7 +16,7 @@ function getTarget(cmd, args, chan) {
 }
 
 exports.input = function(network, chan, cmd, args) {
-	const targetName = getTarget(cmd, args, chan);
+	let targetName = getTarget(cmd, args, chan);
 
 	if (cmd === "query") {
 		if (!targetName) {
@@ -92,6 +92,14 @@ exports.input = function(network, chan, cmd, args) {
 	network.irc.say(targetName, msg);
 
 	if (!network.irc.network.cap.isEnabled("echo-message")) {
+		const parsedTarget = network.irc.network.extractTargetGroup(targetName);
+		let targetGroup;
+
+		if (parsedTarget) {
+			targetName = parsedTarget.target;
+			targetGroup = parsedTarget.target_group;
+		}
+
 		const channel = network.getChannel(targetName);
 
 		if (typeof channel !== "undefined") {
@@ -99,7 +107,8 @@ exports.input = function(network, chan, cmd, args) {
 				nick: network.irc.user.nick,
 				ident: network.irc.user.username,
 				hostname: network.irc.user.host,
-				target: channel.name,
+				target: targetName,
+				group: targetGroup,
 				message: msg,
 			});
 		}

--- a/src/plugins/inputs/notice.js
+++ b/src/plugins/inputs/notice.js
@@ -7,20 +7,30 @@ exports.input = function(network, chan, cmd, args) {
 		return;
 	}
 
-	let targetChan = network.getChannel(args[0]);
+	let targetName = args[0];
 	let message = args.slice(1).join(" ");
 
-	network.irc.notice(args[0], message);
-
-	if (typeof targetChan === "undefined") {
-		message = "{to " + args[0] + "} " + message;
-		targetChan = chan;
-	}
+	network.irc.notice(targetName, message);
 
 	if (!network.irc.network.cap.isEnabled("echo-message")) {
+		let targetGroup;
+		const parsedTarget = network.irc.network.extractTargetGroup(targetName);
+
+		if (parsedTarget) {
+			targetName = parsedTarget.target;
+			targetGroup = parsedTarget.target_group;
+		}
+
+		const targetChan = network.getChannel(targetName);
+
+		if (typeof targetChan === "undefined") {
+			message = "{to " + args[0] + "} " + message;
+		}
+
 		network.irc.emit("notice", {
 			nick: network.irc.user.nick,
-			target: targetChan.name,
+			target: targetName,
+			group: targetGroup,
 			message: message,
 		});
 	}


### PR DESCRIPTION
`/msg @#channel hello world` would not display a message if server does not support `echo-message`. This PR extracts the target group the same way as actual PRIVMSG/NOTICE processing does in irc-fw.