### PR TITLE
Disable io cookie

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -158,6 +158,7 @@ module.exports = function() {
 
 		const sockets = io(server, {
 			wsEngine: "ws",
+			cookie: false,
 			serveClient: false,
 			transports: Helper.config.transports,
 		});


### PR DESCRIPTION
It's completely useless in socket.io/engine.io, after looking through the code, all it does is send Set-Cookie for polling requests, but it's completely unused and the actual id is verified from the `sid` parameter in the url.

There was a user in IRC that thought the `io` cookie was used by lounge for sessions, but it's not, as we use localStorage.

Ref https://github.com/socketio/socket.io/issues/2276