### PR TITLE
Make /raw actually write to network as-is

### DIFF
--- a/src/plugins/inputs/raw.js
+++ b/src/plugins/inputs/raw.js
@@ -4,7 +4,7 @@ exports.commands = ["raw", "send", "quote"];
 
 exports.input = function({irc}, chan, cmd, args) {
 	if (args.length !== 0) {
-		irc.raw(args);
+		irc.connection.write(args.join(" "));
 	}
 
 	return true;


### PR DESCRIPTION
raw in irc-framework has a little bit of magic behind it where it appends colon to last argument if it has a space or starts with a colon.

As a result of that, doing `/raw topic #test :` would actually send `topic #test ::`.