### PR TITLE
Add keybind for cycling to the next unread window

### DIFF
--- a/client/js/keybinds.js
+++ b/client/js/keybinds.js
@@ -3,6 +3,7 @@
 const $ = require("jquery");
 const Mousetrap = require("mousetrap");
 const utils = require("./utils");
+const {vueApp} = require("./vue");
 
 Mousetrap.bind(["alt+up", "alt+down"], function(e, keys) {
 	const sidebar = $("#sidebar");
@@ -66,6 +67,31 @@ Mousetrap.bind(["alt+shift+up", "alt+shift+down"], function(e, keys) {
 
 	target = lobbies.eq(target).click();
 	utils.scrollIntoViewNicely(target[0]);
+
+	return false;
+});
+
+// Jump to the first window with a highlight in it, or the first with unread
+// activity if there are none with highlights.
+Mousetrap.bind(["alt+a"], function() {
+	let targetchan;
+
+	outer_loop: for (const network of vueApp.networks) {
+		for (const chan of network.channels) {
+			if (chan.highlight) {
+				targetchan = chan;
+				break outer_loop;
+			}
+
+			if (chan.unread && !targetchan) {
+				targetchan = chan;
+			}
+		}
+	}
+
+	if (targetchan) {
+		$(`#sidebar .chan[data-id="${targetchan.id}"]`).trigger("click");
+	}
 
 	return false;
 });

--- a/client/views/windows/help.tpl
+++ b/client/views/windows/help.tpl
@@ -89,6 +89,16 @@
 
 	<div class="help-item">
 		<div class="subject">
+			<span class="key-all"><kbd>Alt</kbd> <kbd>A</kbd></span>
+			<span class="key-apple"><kbd>⌥</kbd> <kbd>A</kbd></span>
+		</div>
+		<div class="description">
+			<p>Switch to the first window with unread messages.</p>
+		</div>
+	</div>
+
+	<div class="help-item">
+		<div class="subject">
 			<span class="key-all"><kbd>Ctrl</kbd> <kbd>K</kbd></span>
 			<span class="key-apple"><kbd>⌘</kbd> <kbd>K</kbd></span>
 		</div>


### PR DESCRIPTION
This PR replicates Irssi and WeeChat's `Alt+A` keyboard shortcuts which move to the next window which has unread activity in it.

I am not a front-end developer, feel free to suggest improvements!