### PR TITLE
Display an error on unknown command

### DIFF
--- a/src/command-line/index.js
+++ b/src/command-line/index.js
@@ -15,6 +15,12 @@ program
 		"override entries of the configuration file, must be specified for each entry that needs to be overriden",
 		Utils.parseConfigOptions
 	)
+	.on("command:*", () => {
+		log.error(
+			`Unknown command. See ${colors.bold("--help")} for a list of available commands.`
+		);
+		process.exit(1);
+	})
 	.on("--help", Utils.extraHelp);
 
 // Parse options from `argv` returning `argv` void of these options.


### PR DESCRIPTION
Before this, trying to execute an unknown command would just silently exit and say nothing.

Ref https://github.com/tj/commander.js#custom-event-listeners

Fixes #1967