### PR TITLE
Use default cursor for active channels

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -820,6 +820,10 @@ background on hover (unless active) */
 	opacity: 1;
 }
 
+#sidebar .chan.active {
+	cursor: default;
+}
+
 #sidebar .chan.active .close {
 	opacity: 0.4;
 	display: unset;


### PR DESCRIPTION
Since clicking an active channel does nothing now, we can update cursor to also indicate that.

![13-104382434](https://user-images.githubusercontent.com/613331/62935663-5e08e800-bdd0-11e9-98b5-c928ed76c53f.gif)
