### PR TITLE
Move cross-platform CI builds to GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,37 @@
+name: Build
+
+on: push
+
+jobs:
+  build:
+    name: Node ${{ matrix.node_version }} on ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+        node_version: [
+            8.10.0, # EOL: December 2019 (test exact LTS version)
+            10.x, # EOL: April 2021
+            12.x, # EOL: April 2022
+          ]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@master
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node_version }}
+
+      - name: Install
+        run: yarn --frozen-lockfile --non-interactive
+
+      - name: Build
+        run: yarn build
+        env:
+          NODE_ENV: production
+
+      - name: Test
+        run: yarn test

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,25 +8,8 @@ node_js:
 os:
   - linux
 
-# https://github.com/nodejs/Release
-matrix:
-  fast_finish: true
-  include:
-    - name: "Windows build"
-      os: windows
-      cache: false # windows cache uploads are slow
-      env: YARN_GPG=no # starts gpg-agent that never exits
-
-    - name: "macOS build"
-      os: osx
-
-    # Version used to deploy to npm registry
-    - name: "Production build"
-      env: BUILD_ENV=production
-
-    # Next node version and minimum supported node version
-    - node_js: 11 # EOL: June 2019
-    - node_js: 8.10.0 # EOL: December 2019 (test exact LTS version)
+env:
+  - BUILD_ENV=production
 
 cache: yarn
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@
 	<a href="https://travis-ci.com/thelounge/thelounge"><img
 		alt="Travis CI Build Status"
 		src="https://img.shields.io/travis/com/thelounge/thelounge/master.svg?style=flat-square&maxAge=60"></a>
+	<a href="https://github.com/thelounge/thelounge/actions"><img
+		alt="Build Status"
+		src="https://github.com/thelounge/thelounge/workflows/Build/badge.svg"></a>
 	<a href="https://david-dm.org/thelounge/thelounge"><img
 		alt="Dependencies Status"
 		src="https://img.shields.io/david/thelounge/thelounge.svg?style=flat-square&maxAge=3600"></a>

--- a/test/src/helperTest.js
+++ b/test/src/helperTest.js
@@ -21,11 +21,13 @@ describe("Helper", function() {
 		});
 
 		it("should not expand paths not starting with tilde", function() {
-			expect(Helper.expandHome("/tmp")).to.match(/^\/tmp|[A-Z]:\\tmp$/);
+			expect(Helper.expandHome("/tmp")).to.match(/^\/tmp|[a-zA-Z]:\\{1,2}tmp$/);
 		});
 
 		it("should not expand a tilde in the middle of a string", function() {
-			expect(Helper.expandHome("/tmp/~foo")).to.match(/^\/tmp\/~foo|[A-Z]:\\tmp\\~foo$/);
+			expect(Helper.expandHome("/tmp/~foo")).to.match(
+				/^\/tmp\/~foo|[a-zA-Z]:\\{1,2}?tmp\\{1,2}~foo$/
+			);
 		});
 
 		it("should return an empty string when given an empty string", function() {


### PR DESCRIPTION
This keeps Node 10/Linux/production build on Travis for release purposes, as I didn't bother moving that to actions yet.

Some differences: all `yarn build` are now always run with NODE_ENV=production,
build matrix is bigger as it tests each node version on each OS.