### PR TITLE
Some fixes in file uploading

### DIFF
--- a/client/js/upload.js
+++ b/client/js/upload.js
@@ -85,6 +85,7 @@ class Uploader {
 	filesChanged() {
 		const files = Array.from(this.uploadInput.files);
 		this.triggerUpload(files);
+		this.uploadInput.value = ""; // Reset <input> element so you can upload the same file
 	}
 
 	triggerUpload(files) {

--- a/src/plugins/uploader.js
+++ b/src/plugins/uploader.js
@@ -122,7 +122,7 @@ class Uploader {
 
 		// if the authentication token is incorrect, bail out
 		if (uploadTokens.delete(req.params.token) !== true) {
-			return abortWithError(Error("Unauthorized"));
+			return abortWithError(Error("Invalid upload token"));
 		}
 
 		// if the request does not contain any body data, bail out
@@ -197,6 +197,10 @@ class Uploader {
 
 		busboyInstance.on("finish", () => {
 			doneCallback();
+
+			if (!uploadUrl) {
+				return res.status(400).json({error: "Missing file"});
+			}
 
 			// upload was done, send the generated file url to the client
 			res.status(200).json({


### PR DESCRIPTION
- Update error messages for uploads (adds error message when client sends POST without a file)
- Reset upload input so the same file can be selected and uploaded again
- Do not request upload token if there's an upload in process (when the uploaded finishes, it already requests a token for next file in queue)