### PR TITLE
Bump minimum node version to v10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,8 @@ matrix:
     - name: "Production build"
       env: BUILD_ENV=production
 
-    # Next node version and minimum supported node version
+    # Next node version
     - node_js: 11 # EOL: June 2019
-    - node_js: 8.10.0 # EOL: December 2019 (test exact LTS version)
 
 cache: yarn
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The Lounge is the official and community-managed fork of [Shout](https://github.
 
 ## Installation and usage
 
-The Lounge requires [Node.js](https://nodejs.org/) v8 or more recent.
+The Lounge requires latest [Node.js](https://nodejs.org/) LTS version or more recent.
 [Yarn package manager](https://yarnpkg.com/) is also recommended.  
 If you want to install with npm, `--unsafe-perm` is required for a correct install.
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   ],
   "license": "MIT",
   "engines": {
-    "node": ">=8.10.0"
+    "node": ">=10.16.3"
   },
   "dependencies": {
     "bcryptjs": "2.4.3",

--- a/src/plugins/irc-events/link.js
+++ b/src/plugins/irc-events/link.js
@@ -12,18 +12,6 @@ const currentFetchPromises = new Map();
 const imageTypeRegex = /^image\/.+/;
 const mediaTypeRegex = /^(audio|video)\/.+/;
 
-// Fix ECDH curve client compatibility in Node v8/v9
-// This is fixed in Node 10, but The Lounge supports LTS versions
-// https://github.com/nodejs/node/issues/16196
-// https://github.com/nodejs/node/pull/16853
-// https://github.com/nodejs/node/pull/15206
-const tls = require("tls");
-const semver = require("semver");
-
-if (semver.gte(process.version, "8.6.0") && tls.DEFAULT_ECDH_CURVE === "prime256v1") {
-	tls.DEFAULT_ECDH_CURVE = "auto";
-}
-
 module.exports = function(client, chan, msg) {
 	if (!Helper.config.prefetch) {
 		return;


### PR DESCRIPTION
v8 will be EOL in December 2019, should be good timing for our next release to remove it.

I set it to `>=10.16.3` for a couple of reasons:
1. This release includes the HTTP/2 vulnerability fixes. https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V10.md#2019-08-15-version-10163-dubnium-lts-bethgriggs
2. ldapjs@next sets minimum version to 10.16.0 and I don't think they're willing to lower it.