### PR TITLE
Implement keep nick when client gets "nick in use" on connection

### DIFF
--- a/src/models/network.js
+++ b/src/models/network.js
@@ -19,6 +19,7 @@ const filteredFromClient = {
 	irc: true,
 	password: true,
 	ignoreList: true,
+	keepNick: true,
 };
 
 function Network(attr) {
@@ -43,6 +44,7 @@ function Network(attr) {
 		},
 		chanCache: [],
 		ignoreList: [],
+		keepNick: null,
 	});
 
 	if (!this.uuid) {
@@ -188,6 +190,7 @@ Network.prototype.edit = function(client, args) {
 	const oldNick = this.nick;
 	const oldRealname = this.realname;
 
+	this.keepNick = null;
 	this.nick = args.nick;
 	this.host = String(args.host || "");
 	this.name = String(args.name || "") || this.host;
@@ -217,7 +220,7 @@ Network.prototype.edit = function(client, args) {
 		if (this.nick !== oldNick) {
 			if (connected) {
 				// Send new nick straight away
-				this.irc.raw("NICK", this.nick);
+				this.irc.changeNick(this.nick);
 			} else {
 				this.irc.options.nick = this.irc.user.nick = this.nick;
 
@@ -269,6 +272,10 @@ Network.prototype.setNick = function(nick) {
 		// Case insensitive search
 		"i"
 	);
+
+	if (this.keepNick === nick) {
+		this.keepNick = null;
+	}
 };
 
 /**

--- a/src/plugins/irc-events/connection.js
+++ b/src/plugins/irc-events/connection.js
@@ -124,6 +124,19 @@ module.exports = function(irc, network) {
 			);
 		}
 
+		if (network.keepNick) {
+			// We disconnected without getting our original nick back yet, just set it back locally
+			irc.options.nick = irc.user.nick = network.keepNick;
+
+			network.setNick(network.keepNick);
+			network.keepNick = null;
+
+			this.emit("nick", {
+				network: network.uuid,
+				nick: network.nick,
+			});
+		}
+
 		sendStatus();
 	});
 

--- a/src/plugins/irc-events/quit.js
+++ b/src/plugins/irc-events/quit.js
@@ -27,5 +27,11 @@ module.exports = function(irc, network) {
 				chan: chan.id,
 			});
 		});
+
+		// If user with the nick we are trying to keep has quit, try to get this nick
+		if (network.keepNick === data.nick) {
+			irc.changeNick(network.keepNick);
+			network.keepNick = null;
+		}
 	});
 };


### PR DESCRIPTION
Clients usually get nick in use on connect when reconnecting to a network after a network failure (like ping timeout), and as a result of that, TL will append a random number to the nick.

keepNick will try to set the original nick name back if it sees a QUIT for that nick. This should work fine in most cases, as you'll rejoin the same channels you were in. Changing nick or editing network will cancel this.

This essentially implements a subset of ZNC's altnick+keepnick features while being hidden from the user.

Fixes #3380