### PR TITLE
Set correct file owner for created user files and warn about it

### DIFF
--- a/src/clientManager.js
+++ b/src/clientManager.js
@@ -137,6 +137,35 @@ ClientManager.prototype.addUser = function(name, password, enableLog) {
 		throw e;
 	}
 
+	try {
+		const userFolderStat = fs.statSync(Helper.getUsersPath());
+		const userFileStat = fs.statSync(userPath);
+
+		if (
+			userFolderStat &&
+			userFileStat &&
+			(userFolderStat.uid !== userFileStat.uid || userFolderStat.gid !== userFileStat.gid)
+		) {
+			log.warn(
+				`User ${colors.green(
+					name
+				)} has been created, but with a different uid (or gid) than expected.`
+			);
+			log.warn(
+				"The file owner has been changed to the expected user. " +
+					"To prevent any issues, please run thelounge commands " +
+					"as the correct user that owns the config folder."
+			);
+			log.warn(
+				"See https://thelounge.chat/docs/usage#using-the-correct-system-user for more information."
+			);
+			fs.chownSync(userPath, userFolderStat.uid, userFolderStat.gid);
+		}
+	} catch (e) {
+		// We're simply verifying file owner as a safe guard for users
+		// that run `thelounge add` as root, so we don't care if it fails
+	}
+
 	return true;
 };
 

--- a/src/command-line/index.js
+++ b/src/command-line/index.js
@@ -40,16 +40,20 @@ if (process.getuid) {
 		);
 	}
 
-	fs.stat(path.join(Helper.getHomePath(), "config.js"), (err, stat) => {
-		if (!err && stat.uid !== uid) {
-			log.warn(
-				"Config file owner does not match the user you are currently running The Lounge as."
-			);
-			log.warn(
-				"To avoid issues, you should execute The Lounge commands under the same user."
-			);
-		}
-	});
+	const configStat = fs.statSync(path.join(Helper.getHomePath(), "config.js"));
+
+	if (configStat && configStat.uid !== uid) {
+		log.warn(
+			"Config file owner does not match the user you are currently running The Lounge as."
+		);
+		log.warn(
+			"To prevent any issues, please run thelounge commands " +
+				"as the correct user that owns the config folder."
+		);
+		log.warn(
+			"See https://thelounge.chat/docs/usage#using-the-correct-system-user for more information."
+		);
+	}
 }
 
 Utils.checkOldHome();


### PR DESCRIPTION
This is targeted at users that run `thelounge add` as root when they have TL installed a service.

This will fix the file owner for them, but also complain about it and link to the documentation.