### PR TITLE
New feature: Added onJoin commands for channels

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -164,6 +164,7 @@ Client.prototype.connect = function(args) {
 					name: chan.name,
 					key: chan.key || "",
 					type: chan.type,
+					commands: chan.commands || [],
 				})
 			);
 		});

--- a/src/models/chan.js
+++ b/src/models/chan.js
@@ -40,6 +40,7 @@ function Chan(attr) {
 		firstUnread: 0,
 		unread: 0,
 		highlight: 0,
+		commands: [],
 		users: new Map(),
 	});
 }

--- a/src/models/network.js
+++ b/src/models/network.js
@@ -383,6 +383,10 @@ Network.prototype.export = function() {
 				keys.push("type");
 			}
 
+			if (chan.commands !== []) {
+				keys.push("commands");
+			}
+
 			return _.pick(chan, keys);
 		});
 

--- a/src/plugins/irc-events/join.js
+++ b/src/plugins/irc-events/join.js
@@ -34,6 +34,18 @@ module.exports = function(irc, network) {
 				chan: chan.id,
 				state: chan.state,
 			});
+
+			if (chan.commands !== []) {
+				const delay = 1000;
+				chan.commands.forEach(function(cmd) {
+					setTimeout(function() {
+						client.input({
+							target: network.channels[0].id,
+							text: cmd,
+						});
+					}, delay);
+				});
+			}
 		}
 
 		const user = new User({nick: data.nick});

--- a/test/models/chan.js
+++ b/test/models/chan.js
@@ -219,7 +219,8 @@ describe("Chan", function() {
 					"topic",
 					"type",
 					"unread",
-					"users"
+					"users",
+					"commands"
 				);
 		});
 

--- a/test/models/network.js
+++ b/test/models/network.js
@@ -40,11 +40,11 @@ describe("Network", function() {
 				commands: [],
 				nick: "chillin`",
 				channels: [
-					{name: "#thelounge", key: ""},
-					{name: "&foobar", key: ""},
-					{name: "#secret", key: "foo"},
-					{name: "&secure", key: "bar"},
-					{name: "PrivateChat", type: "query"},
+					{name: "#thelounge", key: "", commands: []},
+					{name: "&foobar", key: "", commands: []},
+					{name: "#secret", key: "foo", commands: []},
+					{name: "&secure", key: "bar", commands: []},
+					{name: "PrivateChat", type: "query", commands: []},
 				],
 				ignoreList: [],
 			});


### PR DESCRIPTION
Hey, I always had problems with running the op command on one of my regular channels, since it always ran before the connection to the channel was made.

I have just added a new parameter for the channel to have a channel separate command section, that is triggered after the connection to the channel was successfull.
I have also updated the tests that are connected.