### PR TITLE
Key condensed messages by first message in array

### DIFF
--- a/client/components/MessageList.vue
+++ b/client/components/MessageList.vue
@@ -34,7 +34,7 @@
 
 				<MessageCondensed
 					v-if="message.type === 'condensed'"
-					:key="message.id"
+					:key="message.messages[0].id"
 					:network="network"
 					:keep-scroll-position="keepScrollPosition"
 					:messages="message.messages"


### PR DESCRIPTION
By changing `MessageCondensed` key to the first message id in the array (instead of last), Vue will no longer redraw the component and it will stay open.

Fixes #3139