### PR TITLE
Add Webpack context replacement plugin to remove vue server renderer errors

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -147,6 +147,10 @@ const config = {
 			/debug/,
 			path.resolve(__dirname, "scripts/noop.js")
 		),
+		new webpack.ContextReplacementPlugin(
+			/vue-server-renderer/,
+			path.resolve(__dirname, "./src/vue-server-renderer")
+		),
 	],
 };
 


### PR DESCRIPTION
Webpack was throwing the following critical warning while compiling `vue-server-renderer`:

```
Warning in ./node_modules/vue-server-renderer/build.dev.js
Critical dependency: the request of a dependency is an expression
```

This was due to dynamic imports in the `vue-server-renderer` module (line 9301 and related function). Since I can't change the offending function, I added a webpack plugin for the `vue-server-renderer` module to provide context for these dynamic imports and clear the error.

Hope it helps!