### PR TITLE
Synchronize open channel on client on reconnection

### DIFF
--- a/client/js/socket-events/auth.js
+++ b/client/js/socket-events/auth.js
@@ -79,15 +79,19 @@ socket.on("auth", function(data) {
 
 			for (const network of vueApp.networks) {
 				for (const chan of network.channels) {
-					for (const msg of chan.messages) {
-						if (msg.id > lastMessage) {
-							lastMessage = msg.id;
+					if (chan.messages.length > 0) {
+						const id = chan.messages[chan.messages.length - 1].id;
+
+						if (lastMessage < id) {
+							lastMessage = id;
 						}
 					}
 				}
 			}
 
-			socket.emit("auth", {user, token, lastMessage});
+			const openChannel = (vueApp.activeChannel && vueApp.activeChannel.channel.id) || null;
+
+			socket.emit("auth", {user, token, lastMessage, openChannel});
 		}
 	}
 


### PR DESCRIPTION
This fixes active channel displaying unread counter after reconnect, and fixes server losing track of the currently open channel on said client.