### PR TITLE
Update badges in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,23 +21,19 @@
 <p align="center">
 	<a href="https://demo.thelounge.chat/"><img
 		alt="#thelounge IRC channel on freenode"
-		src="https://img.shields.io/badge/freenode-%23thelounge-415364.svg?colorA=ff9e18&style=flat-square"></a>
-	<br>
+		src="https://img.shields.io/badge/freenode-%23thelounge-415364.svg?colorA=ff9e18"></a>
 	<a href="https://yarn.pm/thelounge"><img
 		alt="npm version"
-		src="https://img.shields.io/npm/v/thelounge.svg?style=flat-square&maxAge=3600"></a>
+		src="https://img.shields.io/npm/v/thelounge.svg?maxAge=3600"></a>
 	<a href="https://travis-ci.com/thelounge/thelounge"><img
 		alt="Travis CI Build Status"
-		src="https://img.shields.io/travis/com/thelounge/thelounge/master.svg?style=flat-square&maxAge=60"></a>
+		src="https://img.shields.io/travis/com/thelounge/thelounge/master.svg?label=Travis+Build&maxAge=60"></a>
 	<a href="https://github.com/thelounge/thelounge/actions"><img
 		alt="Build Status"
 		src="https://github.com/thelounge/thelounge/workflows/Build/badge.svg"></a>
-	<a href="https://david-dm.org/thelounge/thelounge"><img
-		alt="Dependencies Status"
-		src="https://img.shields.io/david/thelounge/thelounge.svg?style=flat-square&maxAge=3600"></a>
 	<a href="https://npm-stat.com/charts.html?package=thelounge&from=2016-02-12"><img
 		alt="Total downloads on npm"
-		src="https://img.shields.io/npm/dt/thelounge.svg?colorB=007dc7&style=flat-square&maxAge=3600"></a>
+		src="https://img.shields.io/npm/dy/thelounge.svg?colorB=007dc7&maxAge=3600"></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
- Removed david-dm - The site is dead, and we have automatic package update PRs, so it's not really that useful.
- Remove `style` so it matches the github ci badge
- Added label for travis badge
- Changed downloads to downloads per year because that badge doesn't count total downloads correctly, so this is less misleading