### PR TITLE
Remove Windows/OSX builds from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,14 +12,6 @@ os:
 matrix:
   fast_finish: true
   include:
-    - name: "Windows build"
-      os: windows
-      cache: false # windows cache uploads are slow
-      env: YARN_GPG=no # starts gpg-agent that never exits
-
-    - name: "macOS build"
-      os: osx
-
     # Version used to deploy to npm registry
     - name: "Production build"
       env: BUILD_ENV=production

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
       env: BUILD_ENV=production
 
     # Next node version
-    - node_js: 11 # EOL: June 2019
+    - node_js: 12 # EOL: April 2022
 
 cache: yarn
 


### PR DESCRIPTION
We have github actions now which tests all the target operating systems and it runs much faster.

Removing these from Travis should reduce the possibility of it choking on too many builds.