### PR TITLE
Bump ecmaVersion to 2018

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -2,7 +2,7 @@
 root: true
 
 parserOptions:
-  ecmaVersion: 2017
+  ecmaVersion: 2018
 
 env:
   es6: true


### PR DESCRIPTION
Since our minimum node version is 10 now, we can bump it up.

https://node.green/#ES2018