### PR TITLE
Update context and auto complete menu styles

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -2121,13 +2121,13 @@ part/quit messages where we don't load previews (adds a blank line otherwise) */
 	position: absolute;
 	list-style: none;
 	margin: 0;
-	padding: 0;
+	padding: 0 6px;
 	min-width: 180px;
 	font-size: 14px;
 	background-color: #fff;
 	box-shadow: 0 3px 12px rgba(0, 0, 0, 0.15);
 	border: 1px solid rgba(0, 0, 0, 0.15);
-	border-radius: 2px;
+	border-radius: 5px;
 }
 
 .context-menu-divider {
@@ -2146,6 +2146,7 @@ part/quit messages where we don't load previews (adds a blank line otherwise) */
 	margin-bottom: 6px;
 	line-height: 1.4;
 	transition: background-color 0.2s;
+	border-radius: 3px;
 }
 
 .context-menu-item:focus,
@@ -2154,7 +2155,7 @@ part/quit messages where we don't load previews (adds a blank line otherwise) */
 .textcomplete-item:hover,
 .textcomplete-menu .active,
 #chat .userlist .user.active {
-	background-color: #f6f6f6;
+	background-color: rgba(0, 0, 0, 0.1);
 	transition: none;
 	outline: 0;
 }


### PR DESCRIPTION
Before:
![](https://user-images.githubusercontent.com/613331/67151652-c6dd7680-f2d1-11e9-94ea-761f2a14d502.png)

After:
![](https://user-images.githubusercontent.com/613331/67151653-c9d86700-f2d1-11e9-8a7f-24f0d4fbf376.png)

Makes it look slightly less boxed in.