### PR TITLE
Fix uploader being initialized more than once

### DIFF
--- a/client/components/ChatInput.vue
+++ b/client/components/ChatInput.vue
@@ -18,7 +18,13 @@
 			aria-label="Upload file"
 			@click="openFileUpload"
 		>
-			<input id="upload-input" ref="uploadInput" type="file" multiple />
+			<input
+				id="upload-input"
+				ref="uploadInput"
+				type="file"
+				multiple
+				@change="onUploadInputChange"
+			/>
 			<button
 				id="upload"
 				type="button"
@@ -138,7 +144,7 @@ export default {
 		});
 
 		if (this.$root.isFileUploadEnabled) {
-			upload.initialize();
+			upload.mounted();
 		}
 	},
 	destroyed() {
@@ -219,6 +225,11 @@ export default {
 			}
 
 			socket.emit("input", {target, text});
+		},
+		onUploadInputChange() {
+			const files = Array.from(this.$refs.uploadInput.files);
+			upload.triggerUpload(files);
+			this.$refs.uploadInput.value = ""; // Reset <input> element so you can upload the same file
 		},
 		openFileUpload() {
 			this.$refs.uploadInput.click();

--- a/client/js/socket-events/configuration.js
+++ b/client/js/socket-events/configuration.js
@@ -49,7 +49,7 @@ socket.on("configuration", function(data) {
 	});
 
 	if (data.fileUpload) {
-		upload.setMaxFileSize(data.fileUploadMaxFileSize);
+		upload.initialize(data.fileUploadMaxFileSize);
 	}
 
 	utils.togglePasswordField("#change-password .reveal-password");


### PR DESCRIPTION
If you switched to another window and ChatInput got destroyed, it would bind socket event multiple times.

This would cause "invalid upload token" error to happen.