### PR TITLE
Add message type for plugins

### DIFF
--- a/client/components/Message.vue
+++ b/client/components/Message.vue
@@ -43,7 +43,7 @@
 			<span v-else-if="message.type === 'plugin'" class="from">
 				<template v-if="message.from && message.from.nick">
 					<span class="only-copy">[</span>
-					*{{ message.from.nick }}
+					{{ message.from.nick }}
 					<span class="only-copy">] </span>
 				</template>
 			</span>

--- a/client/components/Message.vue
+++ b/client/components/Message.vue
@@ -40,6 +40,13 @@
 					<span class="only-copy">&gt; </span>
 				</template>
 			</span>
+			<span v-else-if="message.type === 'plugin'" class="from">
+				<template v-if="message.from && message.from.nick">
+					<span class="only-copy">[</span>
+					*{{ message.from.nick }}
+					<span class="only-copy">] </span>
+				</template>
+			</span>
 			<span v-else class="from">
 				<template v-if="message.from && message.from.nick">
 					<span class="only-copy">-</span>

--- a/client/css/style.css
+++ b/client/css/style.css
@@ -276,6 +276,7 @@ kbd {
 #chat .whois .from::before,
 #chat .nick .from::before,
 #chat .action .from::before,
+#chat .plugin .from::before,
 #chat .raw .from::before,
 #chat .toggle-button::after,
 #chat .toggle-content .more-caret::before,
@@ -436,6 +437,13 @@ kbd {
 
 #chat .action .from::before {
 	content: "\f005"; /* http://fontawesome.io/icon/star/ */
+}
+
+#chat .plugin .from::before {
+	content: "\f1e6"; /* http://fontawesome.io/icon/plug/ */
+	transform: rotate(45deg);
+	display: inline-block;
+	padding: 1px;
 }
 
 #chat .toggle-button {

--- a/src/client.js
+++ b/src/client.js
@@ -374,7 +374,7 @@ Client.prototype.inputLine = function(data) {
 		if (typeof plugin.input === "function" && (connected || plugin.allowDisconnected)) {
 			connected = true;
 			plugin.input(
-				new PublicClient(client),
+				new PublicClient(client, plugin.packageInfo),
 				{network: target.network, chan: target.chan},
 				cmd,
 				args

--- a/src/models/msg.js
+++ b/src/models/msg.js
@@ -48,7 +48,8 @@ class Msg {
 			this.type !== Msg.Type.TOPIC_SET_BY &&
 			this.type !== Msg.Type.MODE_CHANNEL &&
 			this.type !== Msg.Type.RAW &&
-			this.type !== Msg.Type.WHOIS
+			this.type !== Msg.Type.WHOIS &&
+			this.type !== Msg.Type.PLUGIN
 		);
 	}
 }
@@ -77,6 +78,7 @@ Msg.Type = {
 	TOPIC_SET_BY: "topic_set_by",
 	WHOIS: "whois",
 	RAW: "raw",
+	PLUGIN: "plugin",
 };
 
 module.exports = Msg;

--- a/src/plugins/inputs/index.js
+++ b/src/plugins/inputs/index.js
@@ -51,7 +51,10 @@ const getCommands = () =>
 		.concat(passThroughCommands)
 		.sort();
 
-const addPluginCommand = (command, func) => pluginCommands.set(command, func);
+const addPluginCommand = (packageInfo, command, func) => {
+	func.packageInfo = packageInfo;
+	pluginCommands.set(command, func);
+};
 
 module.exports = {
 	addPluginCommand,

--- a/src/plugins/packages/index.js
+++ b/src/plugins/packages/index.js
@@ -27,16 +27,16 @@ module.exports = {
 	outdated,
 };
 
-const packageApis = function(packageName) {
+const packageApis = function(packageInfo) {
 	return {
 		Stylesheets: {
-			addFile: addStylesheet.bind(this, packageName),
+			addFile: addStylesheet.bind(this, packageInfo.packageName),
 		},
 		PublicFiles: {
-			add: addFile.bind(this, packageName),
+			add: addFile.bind(this, packageInfo.packageName),
 		},
 		Commands: {
-			add: inputs.addPluginCommand,
+			add: inputs.addPluginCommand.bind(this, packageInfo),
 			runAsUser: (command, targetId, client) =>
 				client.inputLine({target: targetId, text: command}),
 		},
@@ -98,6 +98,7 @@ function loadPackages() {
 		}
 
 		packageInfo = packageInfo.thelounge;
+		packageInfo.packageName = packageName;
 
 		packageMap.set(packageName, packageFile);
 
@@ -112,7 +113,7 @@ function loadPackages() {
 		}
 
 		if (packageFile.onServerStart) {
-			packageFile.onServerStart(packageApis(packageName));
+			packageFile.onServerStart(packageApis(packageInfo));
 		}
 
 		log.info(`Package ${colors.bold(packageName)} loaded`);

--- a/src/plugins/packages/publicClient.js
+++ b/src/plugins/packages/publicClient.js
@@ -1,3 +1,5 @@
+const Msg = require("../../models/msg");
+
 module.exports = class PublicClient {
 	constructor(client) {
 		this.client = client;
@@ -36,5 +38,25 @@ module.exports = class PublicClient {
 	 */
 	getChannel(chanId) {
 		return this.client.find(chanId);
+	}
+
+	/**
+	 * Sends a message to this client, displayed in the given channel.
+	 *
+	 * @param {String} text the message to send
+	 * @param {Chan} chan the channel to send the message to
+	 * @param {String} identifier the identifier/name of the packages that is sending this message
+	 */
+	sendMessage(text, chan, identifier) {
+		chan.pushMessage(
+			this.client,
+			new Msg({
+				type: Msg.Type.PLUGIN,
+				text: text,
+				from: {
+					nick: identifier,
+				},
+			})
+		);
 	}
 };

--- a/src/plugins/packages/publicClient.js
+++ b/src/plugins/packages/publicClient.js
@@ -1,8 +1,9 @@
 const Msg = require("../../models/msg");
 
 module.exports = class PublicClient {
-	constructor(client) {
+	constructor(client, packageInfo) {
 		this.client = client;
+		this.packageInfo = packageInfo;
 	}
 
 	/**
@@ -45,16 +46,15 @@ module.exports = class PublicClient {
 	 *
 	 * @param {String} text the message to send
 	 * @param {Chan} chan the channel to send the message to
-	 * @param {String} identifier the identifier/name of the packages that is sending this message
 	 */
-	sendMessage(text, chan, identifier) {
+	sendMessage(text, chan) {
 		chan.pushMessage(
 			this.client,
 			new Msg({
 				type: Msg.Type.PLUGIN,
 				text: text,
 				from: {
-					nick: identifier,
+					nick: this.packageInfo.name || this.packageInfo.packageName,
 				},
 			})
 		);


### PR DESCRIPTION
This adds a new public api to send messages, with their own message type so that its clearly visible to a user where the message came from.
(it also changes some internals to make the package info available in the api)

Usage (in some command for example):
```js
const red = '04';
client.sendMessage(red + "You did something wrong", target.chan);
client.sendMessage("Try this instead", target.chan);
```

![https://i.imgur.com/TUduR8L.png](https://i.imgur.com/TUduR8L.png)

Ideally publicClient would automatically know who just called the method so that plugins don't need to pass their identifier every time, but I wasn't sure on how to accomplish that nicely. 
We could have a "shortName" in the package info for that I guess.
