### PR TITLE
Remove punctuation mark in settings

### DIFF
--- a/client/views/windows/settings.tpl
+++ b/client/views/windows/settings.tpl
@@ -30,7 +30,7 @@
 			</h2>
 			<label class="opt">
 				<input type="checkbox" name="syncSettings">
-				Synchronize settings with other clients.
+				Synchronize settings with other clients
 			</label>
 			<p class="sync-warning-override"><strong>Warning</strong> Checking this box will override the settings of this client with those stored on the server.</p>
 			<p class="sync-warning-base"><strong>Warning</strong> No settings have been synced before. Enabling this will sync all settings of this client as the base for other clients.</p>


### PR DESCRIPTION
I assume this was just an oversight. Keeps it consistent with all other check-boxes on the settings page.