### PR TITLE
Allow configuring base url for uploads

### DIFF
--- a/defaults/config.js
+++ b/defaults/config.js
@@ -154,9 +154,16 @@ module.exports = {
 	//   this limit will be prompted with an error message in their browser. A value of
 	//   `-1` disables the file size limit and allows files of any size. **Use at
 	//   your own risk.** This value is set to `10240` kilobytes by default.
+	// - `baseUrl`: If you want change the URL where uploaded files are accessed,
+	//   you can set this option to `"https://example.com/folder/"` and the final URL
+	//   would look like `"https://example.com/folder/aabbccddeeff1234/name.png"`.
+	//   If you use this option, you must have a reverse proxy configured,
+	//   to correctly proxy the uploads URLs back to The Lounge.
+	//   This value is set to `null` by default.
 	fileUpload: {
 		enable: false,
 		maxFileSize: 10240,
+		baseUrl: null,
 	},
 
 	// ### `transports`

--- a/src/helper.js
+++ b/src/helper.js
@@ -135,6 +135,16 @@ function setHome(newPath) {
 		);
 	}
 
+	if (this.config.fileUpload.baseUrl) {
+		try {
+			new URL("test/file.png", this.config.fileUpload.baseUrl);
+		} catch (e) {
+			this.config.fileUpload.baseUrl = null;
+
+			log.warn(`The ${colors.bold("fileUpload.baseUrl")} you specified is invalid: ${e}`);
+		}
+	}
+
 	const manifestPath = path.resolve(
 		path.join(__dirname, "..", "public", "thelounge.webmanifest")
 	);

--- a/src/plugins/uploader.js
+++ b/src/plugins/uploader.js
@@ -179,7 +179,13 @@ class Uploader {
 		streamWriter.on("error", abortWithError);
 
 		busboyInstance.on("file", (fieldname, fileStream, filename) => {
-			uploadUrl = `uploads/${randomName}/${encodeURIComponent(filename)}`;
+			uploadUrl = `${randomName}/${encodeURIComponent(filename)}`;
+
+			if (Helper.config.fileUpload.baseUrl) {
+				uploadUrl = new URL(uploadUrl, Helper.config.fileUpload.baseUrl).toString();
+			} else {
+				uploadUrl = `uploads/${uploadUrl}`;
+			}
 
 			// if the busboy data stream errors out or goes over the file size limit
 			// abort the processing with an error


### PR DESCRIPTION
Fixes #3484.

Will need to update reverse proxy guide to add relevant configs. Example nginx config:
```
location /folder/ {
	proxy_pass http://127.0.0.1:9000/uploads/;
	proxy_set_header X-Forwarded-For $remote_addr;
}
```
