### PR TITLE
Disable copy hack in Firefox

### DIFF
--- a/client/js/clipboard.js
+++ b/client/js/clipboard.js
@@ -1,6 +1,11 @@
 "use strict";
 
 module.exports = function(chat) {
+	// Disable in Firefox as it already copies flex text correctly
+	if (typeof window.InstallTrigger !== "undefined") {
+		return;
+	}
+
 	const selection = window.getSelection();
 
 	// If selection does not span multiple elements, do nothing


### PR DESCRIPTION
Firefox already copies `flex` elements correctly as we need it to, and this fixes copy breaking on unselectable elements (toggle buttons, etc).