### PR TITLE
Fix potential issue of history not loading when `showInActive` is the first message

### DIFF
--- a/client/components/MessageList.vue
+++ b/client/components/MessageList.vue
@@ -232,8 +232,16 @@ export default {
 				return;
 			}
 
-			let lastMessage = this.channel.messages[0];
-			lastMessage = lastMessage ? lastMessage.id : -1;
+			let lastMessage = -1;
+
+			// Find the id of first message that isn't showInActive
+			// If showInActive is set, this message is actually in another channel
+			for (const message of this.channel.messages) {
+				if (!message.showInActive) {
+					lastMessage = message.id;
+					break;
+				}
+			}
 
 			this.channel.historyLoading = true;
 

--- a/client/js/socket-events/msg.js
+++ b/client/js/socket-events/msg.js
@@ -39,7 +39,13 @@ socket.on("msg", function(data) {
 	) {
 		channel = vueApp.activeChannel.channel;
 
-		data.chan = channel.id;
+		if (data.chan === channel.id) {
+			// If active channel is the intended channel for this message,
+			// remove the showInActive flag
+			data.msg.showInActive = false;
+		} else {
+			data.chan = channel.id;
+		}
 	} else if (!isActiveChannel) {
 		// Do not set unread counter for channel if it is currently active on this client
 		// It may increase on the server before it processes channel open event from this client

--- a/src/models/chan.js
+++ b/src/models/chan.js
@@ -84,6 +84,11 @@ Chan.prototype.pushMessage = function(client, msg, increasesUnread) {
 		return;
 	}
 
+	// showInActive is only processed on "msg", don't need it on page reload
+	if (msg.showInActive) {
+		delete msg.showInActive;
+	}
+
 	this.writeUserLog(client, msg);
 
 	if (Helper.config.maxHistory >= 0 && this.messages.length > Helper.config.maxHistory) {


### PR DESCRIPTION
I was working on adding an icon to "show in active" messages so users can know which messages will me moved to lobby on page reload and found a couple of issues with the code.

I cherry picked the fixes to this PR separately.

See https://github.com/thelounge/thelounge/compare/xpaw/show-in-active