### PR TITLE
Print package versions on startup

### DIFF
--- a/src/plugins/packages/index.js
+++ b/src/plugins/packages/index.js
@@ -97,8 +97,10 @@ function loadPackages() {
 			return;
 		}
 
+		const version = packageInfo.version;
 		packageInfo = packageInfo.thelounge;
 		packageInfo.packageName = packageName;
+		packageInfo.version = version;
 
 		packageMap.set(packageName, packageFile);
 
@@ -116,7 +118,7 @@ function loadPackages() {
 			packageFile.onServerStart(packageApis(packageInfo));
 		}
 
-		log.info(`Package ${colors.bold(packageName)} loaded`);
+		log.info(`Package ${colors.bold(packageName)} ${colors.green("v" + version)} loaded`);
 	});
 
 	if (anyPlugins) {

--- a/test/fixtures/.thelounge/packages/node_modules/thelounge-package-foo/package.json
+++ b/test/fixtures/.thelounge/packages/node_modules/thelounge-package-foo/package.json
@@ -2,6 +2,7 @@
   "name": "thelounge-package-foo",
   "private": true,
   "main": "index.js",
+  "version": "dummy",
   "thelounge": {
     "type": "package"
   },

--- a/test/plugins/packages/indexTest.js
+++ b/test/plugins/packages/indexTest.js
@@ -53,7 +53,7 @@ describe("packages", function() {
 			packages.loadPackages();
 
 			expect(stdout).to.deep.equal(
-				"Package thelounge-package-foo loaded\nThere are packages using the experimental plugin API. Be aware that this API is not yet stable and may change in future The Lounge releases.\n"
+				"Package thelounge-package-foo vdummy loaded\nThere are packages using the experimental plugin API. Be aware that this API is not yet stable and may change in future The Lounge releases.\n"
 			);
 		});
 	});


### PR DESCRIPTION
I opted for storing the version in the packageInfo, since thats passed to public client and might be of use later somewhere else.
![https://i.imgur.com/uVkKexg.png](https://i.imgur.com/uVkKexg.png)