### PR TITLE
Show which channels have drafts in the network list

### DIFF
--- a/client/components/ChannelWrapper.vue
+++ b/client/components/ChannelWrapper.vue
@@ -8,6 +8,7 @@
 			channel.type,
 			{active: activeChannel && channel === activeChannel.channel},
 			{'parted-channel': channel.type === 'channel' && channel.state === 0},
+			{'has-draft': channel.pendingMessage},
 		]"
 		:aria-label="getAriaLabel()"
 		:title="getAriaLabel()"

--- a/client/css/style.css
+++ b/client/css/style.css
@@ -324,6 +324,8 @@ kbd {
 
 #sidebar .chan.special::before { content: "\f03a"; /* http://fontawesome.io/icon/list/ */ }
 
+#sidebar .chan.has-draft:not(.active):not(.lobby)::before { content: "\f304"; /* https://fontawesome.com/icons/pen?style=solid */ }
+
 #footer .connect::before { content: "\f067"; /* http://fontawesome.io/icon/plus/ */ }
 #footer .settings::before { content: "\f013"; /* http://fontawesome.io/icon/cog/ */ }
 #footer .help::before { content: "\f059"; /* http://fontawesome.io/icon/question/ */ }


### PR DESCRIPTION
Show pen icon if channel has a pending message, unless it's the active channel. Looks like this on zenburn:
![image](https://user-images.githubusercontent.com/3417292/69678104-37d03500-10ad-11ea-9d5c-1a8aec07766c.png)
