### PR TITLE
Fix spacing in kick reason

### DIFF
--- a/client/components/MessageTypes/kick.vue
+++ b/client/components/MessageTypes/kick.vue
@@ -3,8 +3,8 @@
 		<Username :user="message.from" />
 		has kicked
 		<Username :user="message.target" />
-		<i v-if="message.text" class="part-reason">
-			(<ParsedMessage :network="network" :message="message" />)</i
+		<i v-if="message.text" class="part-reason"
+			>&#32;(<ParsedMessage :network="network" :message="message" />)</i
 		>
 	</span>
 </template>


### PR DESCRIPTION
Fixes this:
![image](https://user-images.githubusercontent.com/613331/69749417-2477a500-1153-11ea-8bd5-525c26f29bb1.png)

Have to use `&#32;` so prettier doesn't insert a new line (we do the same trick elsewhere)