### PR TITLE
Fix sidebar not opening when lounge is open in a background tab

### DIFF
--- a/client/components/App.vue
+++ b/client/components/App.vue
@@ -70,7 +70,7 @@ export default {
 			return tommorow - today;
 		},
 		prepareOpenStates() {
-			const viewportWidth = window.outerWidth;
+			const viewportWidth = window.innerWidth;
 			let isUserlistOpen = storage.get("thelounge.state.userlist");
 
 			if (viewportWidth > constants.mobileViewportPixels) {

--- a/client/js/vue.js
+++ b/client/js/vue.js
@@ -69,7 +69,7 @@ const vueApp = new Vue({
 store.watch(
 	(state) => state.sidebarOpen,
 	(sidebarOpen) => {
-		if (window.outerWidth > constants.mobileViewportPixels) {
+		if (window.innerWidth > constants.mobileViewportPixels) {
 			storage.set("thelounge.state.sidebar", sidebarOpen);
 			vueApp.$emit("resize");
 		}


### PR DESCRIPTION
Chrome has an issue where `window.outerWidth` reports 0 before document start if the tab is open in background.

Using `innerWidth` is more correct, as we don't need the size of the browser window itself, just the content. https://stackoverflow.com/a/12066186