### PR TITLE
Remove code that aided upgrade to v3

### DIFF
--- a/src/command-line/index.js
+++ b/src/command-line/index.js
@@ -36,8 +36,6 @@ try {
 	// fs.statSync will throw if config.js does not exist (e.g. first run)
 }
 
-Utils.checkOldHome();
-
 // Merge config key-values passed as CLI options into the main config
 Helper.mergeConfig(Helper.config, program.config);
 

--- a/src/command-line/utils.js
+++ b/src/command-line/utils.js
@@ -23,31 +23,6 @@ class Utils {
 		].forEach((e) => log.raw(e));
 	}
 
-	// TODO: Remove in a couple of releases
-	static checkOldHome() {
-		const currentHome = Helper.getHomePath();
-		const oldHome = currentHome.replace(/\.thelounge$/, ".lounge");
-
-		if (currentHome === oldHome || !fs.existsSync(oldHome)) {
-			return;
-		}
-
-		console.log(); // eslint-disable-line no-console
-		log.warn(`Folder ${colors.bold.red(oldHome)} still exists.`);
-		log.warn(
-			`In v3, we renamed the default configuration folder to ${colors.bold.green(
-				".thelounge"
-			)} for consistency.`
-		);
-		log.warn(
-			`You might want to rename the folder from ${colors.bold.red(
-				".lounge"
-			)} to ${colors.bold.green(".thelounge")} to keep existing configuration.`
-		);
-		log.warn("Make sure to look at the release notes to see other breaking changes.");
-		console.log(); // eslint-disable-line no-console
-	}
-
 	static defaultHome() {
 		if (home) {
 			return home;

--- a/src/helper.js
+++ b/src/helper.js
@@ -162,35 +162,6 @@ function setHome(newPath) {
 	// Load theme color from the web manifest
 	const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
 	this.config.themeColor = manifest.theme_color;
-
-	// TODO: Remove in future release
-	if (["example", "crypto", "zenburn"].includes(this.config.theme)) {
-		if (this.config.theme === "example") {
-			log.warn(
-				`The default theme ${colors.red("example")} was renamed to ${colors.green(
-					"default"
-				)} as of The Lounge v3.`
-			);
-		} else {
-			log.warn(
-				`The theme ${colors.red(
-					this.config.theme
-				)} was moved to a separate theme as of The Lounge v3.`
-			);
-			log.warn(
-				`Install it with ${colors.bold(
-					"thelounge install thelounge-theme-" + this.config.theme
-				)}.`
-			);
-		}
-
-		log.warn(
-			`Falling back to theme ${colors.green("default")} will be removed in a future release.`
-		);
-		log.warn("Please update your configuration file accordingly.");
-
-		this.config.theme = "default";
-	}
 }
 
 function getHomePath() {

--- a/test/client/js/constantsTest.js
+++ b/test/client/js/constantsTest.js
@@ -12,12 +12,11 @@ describe("client-side constants", function() {
 		});
 
 		it("should be made of pairs of strings", function() {
-			constants.colorCodeMap.forEach((tuple) => {
-				// TODO: In Node v6+, use `[code, name]`
-				expect(tuple[0])
+			constants.colorCodeMap.forEach(([code, name]) => {
+				expect(code)
 					.to.be.a("string")
 					.that.match(/[0-9]{2}/);
-				expect(tuple[1]).to.be.a("string");
+				expect(name).to.be.a("string");
 			});
 		});
 	});


### PR DESCRIPTION
Since we're bumping the major version, this is a good time to get rid of this code.

The changes are already documented in https://thelounge.chat/docs/guides/upgrade