### PR TITLE
Assign `preview.thumb` only after it is processed

### DIFF
--- a/src/models/chan.js
+++ b/src/models/chan.js
@@ -112,7 +112,7 @@ Chan.prototype.dereferencePreviews = function(messages) {
 			message.previews.forEach((preview) => {
 				if (preview.thumb) {
 					storage.dereference(preview.thumb);
-					preview.thumb = null;
+					preview.thumb = "";
 				}
 			});
 		}


### PR DESCRIPTION
This removes a possible race condition where `preview.thumb` may be accessed before it is verified or stored locally (if prefetchStorage is enabled).

