### PR TITLE
Optimize user file updates

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -54,7 +54,6 @@ function Client(manager, name, config = {}) {
 		idMsg: 1,
 		name: name,
 		networks: [],
-		sockets: manager.sockets,
 		manager: manager,
 		messageStorage: [],
 		highlightRegex: null,
@@ -145,8 +144,8 @@ Client.prototype.createChannel = function(attr) {
 };
 
 Client.prototype.emit = function(event, data) {
-	if (this.sockets !== null) {
-		this.sockets.in(this.id).emit(event, data);
+	if (this.manager !== null) {
+		this.manager.sockets.in(this.id).emit(event, data);
 	}
 };
 
@@ -574,7 +573,7 @@ Client.prototype.names = function(data) {
 };
 
 Client.prototype.quit = function(signOut) {
-	const sockets = this.sockets.sockets;
+	const sockets = this.manager.sockets.sockets;
 	const room = sockets.adapter.rooms[this.id];
 
 	if (room && room.sockets) {

--- a/src/client.js
+++ b/src/client.js
@@ -132,6 +132,8 @@ function Client(manager, name, config = {}) {
 
 			delay += 1000 + Math.floor(Math.random() * 1000);
 		});
+
+		client.fileHash = manager.getDataToSave(client).newHash;
 	}
 }
 
@@ -679,6 +681,6 @@ Client.prototype.save = _.debounce(
 		const client = this;
 		client.manager.saveUser(client);
 	},
-	1000,
-	{maxWait: 10000}
+	5000,
+	{maxWait: 20000}
 );

--- a/src/client.js
+++ b/src/client.js
@@ -316,6 +316,7 @@ Client.prototype.updateSession = function(token, ip, request) {
 	});
 
 	client.manager.updateUser(client.name, {
+		browser: client.config.browser,
 		sessions: client.config.sessions,
 	});
 };

--- a/src/client.js
+++ b/src/client.js
@@ -62,6 +62,9 @@ function Client(manager, name, config = {}) {
 
 	const client = this;
 
+	client.config.log = Boolean(client.config.log);
+	client.config.password = String(client.config.password);
+
 	if (!Helper.config.public && client.config.log) {
 		if (Helper.config.messageStorage.includes("sqlite")) {
 			client.messageStorage.push(new MessageStorage(client));

--- a/src/clientManager.js
+++ b/src/clientManager.js
@@ -190,8 +190,10 @@ ClientManager.prototype.updateUser = function(name, opts, callback) {
 	_.assign(user, opts);
 	const newUser = JSON.stringify(user, null, "\t");
 
+
 	// Do not touch the disk if object has not changed
 	if (currentUser === newUser) {
+		console.log("same");
 		return callback ? callback() : true;
 	}
 

--- a/src/clientManager.js
+++ b/src/clientManager.js
@@ -179,25 +179,13 @@ ClientManager.prototype.addUser = function(name, password, enableLog) {
 	return true;
 };
 
-ClientManager.prototype.updateUser = function(name, opts, callback) {
-	const user = readUserConfig(name);
+ClientManager.prototype.saveUser = function(client, callback) {
+	const json = Object.assign({}, client.config, {
+		networks: client.networks.map((n) => n.export()),
+	});
+	const newUser = JSON.stringify(json, null, "\t");
 
-	if (!user) {
-		return callback ? callback(true) : false;
-	}
-
-	const currentUser = JSON.stringify(user, null, "\t");
-	_.assign(user, opts);
-	const newUser = JSON.stringify(user, null, "\t");
-
-
-	// Do not touch the disk if object has not changed
-	if (currentUser === newUser) {
-		console.log("same");
-		return callback ? callback() : true;
-	}
-
-	const pathReal = Helper.getUserConfigPath(name);
+	const pathReal = Helper.getUserConfigPath(client.name);
 	const pathTemp = pathReal + ".tmp";
 
 	try {
@@ -208,7 +196,7 @@ ClientManager.prototype.updateUser = function(name, opts, callback) {
 
 		return callback ? callback() : true;
 	} catch (e) {
-		log.error(`Failed to update user ${colors.green(name)} (${e})`);
+		log.error(`Failed to update user ${colors.green(client.name)} (${e})`);
 
 		if (callback) {
 			callback(e);

--- a/src/clientManager.js
+++ b/src/clientManager.js
@@ -195,8 +195,15 @@ ClientManager.prototype.updateUser = function(name, opts, callback) {
 		return callback ? callback() : true;
 	}
 
+	const pathReal = Helper.getUserConfigPath(name);
+	const pathTemp = pathReal + ".tmp";
+
 	try {
-		fs.writeFileSync(Helper.getUserConfigPath(name), newUser);
+		// Write to a temp file first, in case the write fails
+		// we do not lose the original file (for example when disk is full)
+		fs.writeFileSync(pathTemp, newUser);
+		fs.renameSync(pathTemp, pathReal);
+
 		return callback ? callback() : true;
 	} catch (e) {
 		log.error(`Failed to update user ${colors.green(name)} (${e})`);

--- a/src/clientManager.js
+++ b/src/clientManager.js
@@ -134,10 +134,6 @@ ClientManager.prototype.addUser = function(name, password, enableLog) {
 	const user = {
 		password: password || "",
 		log: enableLog,
-		networks: [],
-		sessions: {},
-		clientSettings: {},
-		browser: {},
 	};
 
 	try {

--- a/src/command-line/users/reset.js
+++ b/src/command-line/users/reset.js
@@ -30,8 +30,10 @@ program
 			return;
 		}
 
-		const file = Helper.getUserConfigPath(name);
-		const user = require(file);
+		const pathReal = Helper.getUserConfigPath(name);
+		const pathTemp = pathReal + ".tmp";
+		const user = JSON.parse(fs.readFileSync(pathReal, "utf-8"));
+
 		log.prompt(
 			{
 				text: "Enter new password:",
@@ -44,7 +46,14 @@ program
 
 				user.password = Helper.password.hash(password);
 				user.sessions = {};
-				fs.writeFileSync(file, JSON.stringify(user, null, "\t"));
+
+				const newUser = JSON.stringify(user, null, "\t");
+
+				// Write to a temp file first, in case the write fails
+				// we do not lose the original file (for example when disk is full)
+				fs.writeFileSync(pathTemp, newUser);
+				fs.renameSync(pathTemp, pathReal);
+
 				log.info(`Successfully reset password for ${colors.bold(name)}.`);
 			}
 		);

--- a/src/server.js
+++ b/src/server.js
@@ -664,15 +664,19 @@ function initializeClient(socket, client, token, lastMessage, openChannel) {
 		socket.emit("commands", inputs.getCommands());
 	};
 
-	if (!Helper.config.public && token === null) {
+	if (Helper.config.public) {
+		sendInitEvent(null);
+	} else if (token === null) {
 		client.generateToken((newToken) => {
-			client.attachedClients[socket.id].token = token = client.calculateTokenHash(newToken);
+			token = client.calculateTokenHash(newToken);
+			client.attachedClients[socket.id].token = token;
 
 			client.updateSession(token, getClientIp(socket), socket.request);
 
 			sendInitEvent(newToken);
 		});
 	} else {
+		client.updateSession(token, getClientIp(socket), socket.request);
 		sendInitEvent(null);
 	}
 }
@@ -734,15 +738,8 @@ function performAuthentication(data) {
 	let client;
 	let token = null;
 
-	const finalInit = () => {
+	const finalInit = () =>
 		initializeClient(socket, client, token, data.lastMessage || -1, data.openChannel);
-
-		if (!Helper.config.public) {
-			client.manager.updateUser(client.name, {
-				browser: client.config.browser,
-			});
-		}
-	};
 
 	const initClient = () => {
 		// Configuration does not change during runtime of TL,
@@ -826,8 +823,6 @@ function performAuthentication(data) {
 
 		if (Object.prototype.hasOwnProperty.call(client.config.sessions, providedToken)) {
 			token = providedToken;
-
-			client.updateSession(providedToken, getClientIp(socket), socket.request);
 
 			return authCallback(true);
 		}

--- a/src/server.js
+++ b/src/server.js
@@ -591,9 +591,7 @@ function initializeClient(socket, client, token, lastMessage, openChannel) {
 					value: newSetting.value,
 				});
 
-				client.manager.updateUser(client.name, {
-					clientSettings: client.config.clientSettings,
-				});
+				client.save();
 
 				if (newSetting.name === "highlights") {
 					client.compileCustomHighlights();
@@ -630,9 +628,7 @@ function initializeClient(socket, client, token, lastMessage, openChannel) {
 
 		delete client.config.sessions[tokenToSignOut];
 
-		client.manager.updateUser(client.name, {
-			sessions: client.config.sessions,
-		});
+		client.save();
 
 		_.map(client.attachedClients, (attachedClient, socketId) => {
 			if (attachedClient.token !== tokenToSignOut) {

--- a/test/tests/customhighlights.js
+++ b/test/tests/customhighlights.js
@@ -13,6 +13,12 @@ describe("Custom highlights", function() {
 	const client = new Client(
 		{
 			clients: [],
+			getDataToSave() {
+				return {
+					newUser: "",
+					newHash: "",
+				};
+			},
 		},
 		"test",
 		{


### PR DESCRIPTION
- No longer reads from disk whenever updating the file (it used to re-assign updated key), takes from memory now.
- Write to a temp file first and then rename, in case the write fails we do not lose the original file (for example when disk is full).
- Debounced more file updates.