### PR TITLE
Fix synchronizing settings on page load

### DIFF
--- a/client/js/settings.js
+++ b/client/js/settings.js
@@ -10,8 +10,9 @@ export const config = normalizeConfig({
 	syncSettings: {
 		default: true,
 		sync: "never",
-		apply(store, value) {
-			if (value) {
+		apply(store, value, auto = false) {
+			// If applied by settings/applyAll, do not emit to server
+			if (value && !auto) {
 				socket.emit("setting:get");
 			}
 		},

--- a/client/js/socket-events/configuration.js
+++ b/client/js/socket-events/configuration.js
@@ -10,7 +10,6 @@ socket.once("configuration", function(data) {
 	// 'theme' setting depends on serverConfiguration.themes so
 	// settings cannot be applied before this point
 	store.dispatch("settings/applyAll");
-	socket.emit("setting:get");
 
 	if (data.fileUpload) {
 		upload.initialize();

--- a/client/js/socket-events/init.js
+++ b/client/js/socket-events/init.js
@@ -22,6 +22,8 @@ socket.on("init", function(data) {
 
 		store.commit("appLoaded");
 
+		socket.emit("setting:get");
+
 		if (window.g_TheLoungeRemoveLoading) {
 			window.g_TheLoungeRemoveLoading();
 		}

--- a/client/js/store-settings.js
+++ b/client/js/store-settings.js
@@ -27,7 +27,7 @@ export function createSettingsStore(store) {
 			},
 			applyAll({state}) {
 				for (const settingName in config) {
-					config[settingName].apply(store, state[settingName]);
+					config[settingName].apply(store, state[settingName], true);
 				}
 			},
 			update({state, commit}, {name, value, sync = false}) {


### PR DESCRIPTION
It was sent too early (and twice!) before server bound the event, so it didn't work.