### PR TITLE
Fix keep nick setting nick to undefined on socket close

### DIFF
--- a/src/plugins/irc-events/connection.js
+++ b/src/plugins/irc-events/connection.js
@@ -131,7 +131,7 @@ module.exports = function(irc, network) {
 			network.setNick(network.keepNick);
 			network.keepNick = null;
 
-			this.emit("nick", {
+			client.emit("nick", {
 				network: network.uuid,
 				nick: network.nick,
 			});


### PR DESCRIPTION
It emitted the event on `irc-framework` and ended up saying "You're now known as undefined"