### PR TITLE
Adjust sizeUnits names to correspond with LinkPreviews

### DIFF
--- a/client/js/constants.js
+++ b/client/js/constants.js
@@ -27,7 +27,7 @@ const timeFormats = {
 	msgWithSeconds: "HH:mm:ss",
 };
 
-const sizeUnits = ["B", "KiB", "MiB", "GiB", "TiB"];
+const sizeUnits = ["B", "KB", "MB", "GB", "TB"];
 
 export default {
 	colorCodeMap,


### PR DESCRIPTION
Adjusting sizeUnits names to correspond with client/components/LinkPreview.vue#L103, as they are not consistent with each others. Also would argue KB, MB, GB and TB are more familiar for most people.

KB, MB, GB and TB, instead of KiB, MiB, GiB and TiB.

Example:
![image](https://user-images.githubusercontent.com/11909212/70901481-29fe3780-1ffb-11ea-9035-306c3ca7cb12.png)