### PR TITLE
Use `friendlysize` helper consistently

### DIFF
--- a/client/components/LinkPreviewFileSize.vue
+++ b/client/components/LinkPreviewFileSize.vue
@@ -3,7 +3,7 @@
 </template>
 
 <script>
-import constants from "../js/constants";
+import friendlysize from "../js/helpers/friendlysize";
 
 export default {
 	name: "LinkPreviewFileSize",
@@ -12,22 +12,7 @@ export default {
 	},
 	computed: {
 		previewSize() {
-			let size = this.size;
-
-			// Threshold for SI units
-			const thresh = 1024;
-
-			let u = 0;
-
-			do {
-				size /= thresh;
-				++u;
-			} while (size >= thresh && u < constants.sizeUnits.length - 1);
-
-			const displaySize = size.toFixed(1);
-			const unit = constants.sizeUnits[u];
-
-			return `${displaySize} ${unit}`;
+			return friendlysize(this.size);
 		},
 	},
 };

--- a/client/js/constants.js
+++ b/client/js/constants.js
@@ -27,15 +27,12 @@ const timeFormats = {
 	msgWithSeconds: "HH:mm:ss",
 };
 
-const sizeUnits = ["B", "KiB", "MiB", "GiB", "TiB"];
-
 export default {
 	colorCodeMap,
 	commands: [],
 	condensedTypes,
 	condensedTypesQuery,
 	timeFormats,
-	sizeUnits,
 	// Same value as media query in CSS that forces sidebars to become overlays
 	mobileViewportPixels: 768,
 };

--- a/client/js/helpers/friendlysize.js
+++ b/client/js/helpers/friendlysize.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const sizes = ["Bytes", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"];
+const sizes = ["Bytes", "KiB", "MiB", "GiB", "TiB", "PiB"];
 
 export default (size) => {
 	// Loosely inspired from https://stackoverflow.com/a/18650828/1935861

--- a/test/client/js/helpers/friendlysizeTest.js
+++ b/test/client/js/helpers/friendlysizeTest.js
@@ -4,15 +4,26 @@ const expect = require("chai").expect;
 const friendlysize = require("../../../../client/js/helpers/friendlysize").default;
 
 describe("friendlysize helper", function() {
-	it("should render big values in human-readable version", function() {
-		expect(friendlysize(51200)).to.equal("50 KB");
+	it("should render human-readable version", function() {
+		expect(friendlysize(51200)).to.equal("50 KiB");
+		expect(friendlysize(2)).to.equal("2 Bytes");
+		expect(friendlysize(1023)).to.equal("1023 Bytes");
+		expect(friendlysize(1024)).to.equal("1 KiB");
+		expect(friendlysize(Math.pow(1024, 2))).to.equal("1 MiB");
+		expect(friendlysize(Math.pow(1024, 3))).to.equal("1 GiB");
+		expect(friendlysize(Math.pow(1024, 4))).to.equal("1 TiB");
+		expect(friendlysize(Math.pow(1024, 5))).to.equal("1 PiB");
 	});
 
 	it("should round with 1 digit", function() {
-		expect(friendlysize(1234567)).to.equal("1.2 MB");
+		expect(friendlysize(1234567)).to.equal("1.2 MiB");
 	});
 
 	it("should render special case 0 as 0 Bytes", function() {
 		expect(friendlysize(0)).to.equal("0 Bytes");
+	});
+
+	it("should render max safe integer as petabytes", function() {
+		expect(friendlysize(Number.MAX_SAFE_INTEGER)).to.equal("8 PiB");
 	});
 });


### PR DESCRIPTION
Pointed out by @fnutt in #3595