### PR TITLE
Fix format of IPv6 URI

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -154,6 +154,10 @@ module.exports = function(options = {}) {
 			const protocol = Helper.config.https.enable ? "https" : "http";
 			const address = server.address();
 
+			if (address.family === "IPv6") {
+				address.address = "[" + address.address + "]";
+			}
+
 			log.info(
 				"Available at " +
 					colors.green(`${protocol}://${address.address}:${address.port}/`) +


### PR DESCRIPTION
This fixes the formatting of IPv6 URIs in the console. The URI now will work in most browsers' location bars. In some terminals, it will become clickable as well.

Before:
`[INFO] Available at http://:::9000/ in private mode`

After:
`[INFO] Available at http://[::]:9000/ in private mode`

See: [RFC 2732](https://tools.ietf.org/html/rfc2732#section-2)