### PR TITLE
Pretend to be facebook and twitter bots in link prefetcher

### DIFF
--- a/src/plugins/irc-events/link.js
+++ b/src/plugins/irc-events/link.js
@@ -306,8 +306,11 @@ function removePreview(msg, preview) {
 
 function getRequestHeaders(headers) {
 	const formattedHeaders = {
+		// Certain websites like Amazon only add <meta> tags to known bots,
+		// lets pretend to be them to get the metadata
 		"User-Agent":
-			"Mozilla/5.0 (compatible; The Lounge IRC Client; +https://github.com/thelounge/thelounge)",
+			"Mozilla/5.0 (compatible; The Lounge IRC Client; +https://github.com/thelounge/thelounge)" +
+			" facebookexternalhit/1.1 Twitterbot/1.0",
 		Accept: headers.accept || "*/*",
 		"X-Purpose": "preview",
 	};


### PR DESCRIPTION
This is not my idea. Apple does this in iMessages.

When using lounge's UA, to get to the `<title>` tag, you have to download >600kb of content for some reason. Lounge limits to 50kb and cuts off so we don't get any previews on amazon.

Adding facebook to the UA makes amazon serve opengraph tags, and we get a proper preview.

See https://24ways.org/2019/microbrowsers-are-everywhere/
https://peter.upfold.org.uk/blog/2019/02/23/when-is-imessage-not-imessage-when-its-facebookexternalhit-1-1/

@thelounge/maintainers Do you think this is fine?