### PR TITLE
Send 100 actual messages when requesting history with hidden or condensed status messages

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -9,6 +9,7 @@
 # Ignore client folder as it's being built into public/ folder
 # except for the specified files which are used by the server
 client/**
+!client/js/constants.js
 !client/js/helpers/ircmessageparser/findLinks.js
 !client/js/helpers/ircmessageparser/cleanIrcMessage.js
 !client/index.html.tpl

--- a/client/components/App.vue
+++ b/client/components/App.vue
@@ -10,8 +10,8 @@
 </template>
 
 <script>
+const constants = require("../js/constants");
 import throttle from "lodash/throttle";
-import constants from "../js/constants";
 import storage from "../js/localStorage";
 
 import Sidebar from "./Sidebar.vue";

--- a/client/components/Message.vue
+++ b/client/components/Message.vue
@@ -68,12 +68,12 @@
 </template>
 
 <script>
+const constants = require("../js/constants");
 import dayjs from "dayjs";
 import Username from "./Username.vue";
 import LinkPreview from "./LinkPreview.vue";
 import ParsedMessage from "./ParsedMessage.vue";
 import MessageTypes from "./MessageTypes";
-import constants from "../js/constants";
 
 MessageTypes.ParsedMessage = ParsedMessage;
 MessageTypes.LinkPreview = LinkPreview;

--- a/client/components/MessageCondensed.vue
+++ b/client/components/MessageCondensed.vue
@@ -18,7 +18,7 @@
 </template>
 
 <script>
-import constants from "../js/constants";
+const constants = require("../js/constants");
 import Message from "./Message.vue";
 
 export default {

--- a/client/components/MessageList.vue
+++ b/client/components/MessageList.vue
@@ -247,6 +247,7 @@ export default {
 			socket.emit("more", {
 				target: this.channel.id,
 				lastId: lastMessage,
+				condensed: this.$store.state.settings.statusMessages !== "shown",
 			});
 		},
 		onLoadButtonObserved(entries) {

--- a/client/components/MessageList.vue
+++ b/client/components/MessageList.vue
@@ -56,7 +56,7 @@
 <script>
 require("intersection-observer");
 
-import constants from "../js/constants";
+const constants = require("../js/constants");
 import clipboard from "../js/clipboard";
 import socket from "../js/socket";
 import Message from "./Message.vue";

--- a/client/js/autocompletion.js
+++ b/client/js/autocompletion.js
@@ -1,11 +1,12 @@
 "use strict";
 
+const constants = require("./constants");
+
 import Mousetrap from "mousetrap";
 import {Textcomplete, Textarea} from "textcomplete";
 import fuzzy from "fuzzy";
 
 import emojiMap from "./helpers/simplemap.json";
-import constants from "./constants";
 import store from "./store";
 
 export default enableAutocomplete;

--- a/client/js/constants.js
+++ b/client/js/constants.js
@@ -26,7 +26,8 @@ const timeFormats = {
 	msgWithSeconds: "HH:mm:ss",
 };
 
-export default {
+// This file is required by server, can't use es6 export
+module.exports = {
 	colorCodeMap,
 	commands: [],
 	condensedTypes,

--- a/client/js/router.js
+++ b/client/js/router.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const constants = require("./constants");
+
 import Vue from "vue";
 import VueRouter from "vue-router";
 
@@ -12,7 +14,6 @@ import Help from "../components/Windows/Help.vue";
 import Changelog from "../components/Windows/Changelog.vue";
 import NetworkEdit from "../components/Windows/NetworkEdit.vue";
 import RoutedChat from "../components/RoutedChat.vue";
-import constants from "./constants";
 import store from "./store";
 
 const router = new VueRouter({

--- a/client/js/socket-events/commands.js
+++ b/client/js/socket-events/commands.js
@@ -1,4 +1,4 @@
-import constants from "../constants";
+const constants = require("../constants");
 import socket from "../socket";
 
 socket.on("commands", function(commands) {

--- a/client/js/vue.js
+++ b/client/js/vue.js
@@ -1,12 +1,13 @@
 "use strict";
 
+const constants = require("./constants");
+
 import Vue from "vue";
 import store from "./store";
 import App from "../components/App.vue";
 import localetime from "./helpers/localetime";
 import storage from "./localStorage";
 import {router, navigate} from "./router";
-import constants from "./constants";
 import socket from "./socket";
 
 Vue.filter("localetime", localetime);

--- a/src/client.js
+++ b/src/client.js
@@ -11,6 +11,7 @@ const Helper = require("./helper");
 const UAParser = require("ua-parser-js");
 const uuidv4 = require("uuid/v4");
 const escapeRegExp = require("lodash/escapeRegExp");
+const constants = require("../client/js/constants.js");
 const inputs = require("./plugins/inputs");
 const PublicClient = require("./plugins/packages/publicClient");
 
@@ -466,7 +467,31 @@ Client.prototype.more = function(data) {
 
 	// If requested id is not found, an empty array will be sent
 	if (index > 0) {
-		messages = chan.messages.slice(Math.max(0, index - 100), index);
+		let startIndex = index;
+
+		if (data.condensed) {
+			// Limit to 1000 messages (that's 10x normal limit)
+			const indexToStop = Math.max(0, index - 1000);
+			let realMessagesLeft = 100;
+
+			for (let i = index - 1; i >= indexToStop; i--) {
+				startIndex--;
+
+				// Do not count condensed messages towards the 100 messages
+				if (constants.condensedTypes.has(chan.messages[i].type)) {
+					continue;
+				}
+
+				// Count up actual 100 visible messages
+				if (--realMessagesLeft === 0) {
+					break;
+				}
+			}
+		} else {
+			startIndex = Math.max(0, index - 100);
+		}
+
+		messages = chan.messages.slice(startIndex, index);
 	}
 
 	return {

--- a/test/client/js/constantsTest.js
+++ b/test/client/js/constantsTest.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const expect = require("chai").expect;
-const constants = require("../../../client/js/constants").default;
+const constants = require("../../../client/js/constants");
 
 describe("client-side constants", function() {
 	describe(".colorCodeMap", function() {


### PR DESCRIPTION
This works around the fact 100 status messages take practically no space on screen, so you may end up having to click the history button multiple times.

It searches up to 100 non-condensable messages, and hard limits to 1000 (that's 10x of normal history).

Practically speaking, this should remove the need to mash the load history button after a netsplit.