### PR TITLE
Fix beforeunload not working

### DIFF
--- a/client/js/socket-events/configuration.js
+++ b/client/js/socket-events/configuration.js
@@ -26,9 +26,9 @@ socket.once("configuration", function(data) {
 	}
 
 	if (document.body.classList.contains("public")) {
-		window.addEventListener(
-			"beforeunload",
-			() => "Are you sure you want to navigate away from this page?"
-		);
+		window.addEventListener("beforeunload", (e) => {
+			e.preventDefault();
+			e.returnValue = "Are you sure you want to navigate away from this page?";
+		});
 	}
 });


### PR DESCRIPTION
We used `onbeforeunload` before, so the mechanism was slightly different.

See https://developer.mozilla.org/en-US/docs/Web/API/WindowEventHandlers/onbeforeunload#Example

Tested in Chrome, Firefox and Edge.