### PR TITLE
Add preview for text/plain urls

### DIFF
--- a/src/plugins/irc-events/link.js
+++ b/src/plugins/irc-events/link.js
@@ -92,6 +92,14 @@ function parseHtml(preview, res, client) {
 					$('link[rel="image_src"]').attr("href") ||
 					"";
 
+				if (preview.head.length) {
+					preview.head = preview.head.substr(0, 100);
+				}
+
+				if (preview.body.length) {
+					preview.body = preview.body.substr(0, 300);
+				}
+
 				// Make sure thumbnail is a valid and absolute url
 				if (thumb.length) {
 					thumb = normalizeURL(thumb, preview.link) || "";
@@ -185,6 +193,11 @@ function parse(msg, chan, preview, res, client) {
 		case "text/html":
 			preview.size = -1;
 			promise = parseHtml(preview, res, client);
+			break;
+
+		case "text/plain":
+			preview.type = "link";
+			preview.body = res.data.toString().substr(0, 300);
 			break;
 
 		case "image/png":


### PR DESCRIPTION
If url is `text/plain`, it will use the content as the description. This also adds truncation to head/body for html urls.

![19-1143-GenerousBlueandgoldmackaw](https://user-images.githubusercontent.com/613331/71171087-9b412300-2265-11ea-8770-e97e70e636d6.png)
