### PR TITLE
Collapse prefetch errors by default, and correctly track user toggle

### DIFF
--- a/client/components/LinkPreview.vue
+++ b/client/components/LinkPreview.vue
@@ -231,19 +231,20 @@ export default {
 			});
 		},
 		updateShownState() {
-			let defaultState = true;
+			// User has manually toggled the preview, do not apply default
+			if (this.link.shown !== null) {
+				return;
+			}
+
+			let defaultState = false;
 
 			switch (this.link.type) {
 				case "error":
 					// Collapse all errors by default unless its a message about image being too big
-					defaultState =
-						this.link.error === "image-too-big"
-							? this.$store.state.settings.media
-							: false;
-					break;
+					if (this.link.error === "image-too-big") {
+						defaultState = this.$store.state.settings.media;
+					}
 
-				case "loading":
-					defaultState = false;
 					break;
 
 				case "link":
@@ -254,7 +255,7 @@ export default {
 					defaultState = this.$store.state.settings.media;
 			}
 
-			this.link.shown = this.link.shown && defaultState;
+			this.link.shown = defaultState;
 		},
 	},
 };

--- a/client/components/LinkPreview.vue
+++ b/client/components/LinkPreview.vue
@@ -235,10 +235,11 @@ export default {
 
 			switch (this.link.type) {
 				case "error":
+					// Collapse all errors by default unless its a message about image being too big
 					defaultState =
 						this.link.error === "image-too-big"
 							? this.$store.state.settings.media
-							: this.$store.state.settings.links;
+							: false;
 					break;
 
 				case "loading":

--- a/src/plugins/irc-events/link.js
+++ b/src/plugins/irc-events/link.js
@@ -45,7 +45,7 @@ module.exports = function(client, chan, msg) {
 			thumb: "",
 			size: -1,
 			link: link.link, // Send original matched link to the client
-			shown: true,
+			shown: null,
 		};
 
 		cleanLinks.push(preview);
@@ -58,7 +58,6 @@ module.exports = function(client, chan, msg) {
 				parse(msg, chan, preview, res, client);
 			})
 			.catch((err) => {
-				preview.shown = false;
 				preview.type = "error";
 				preview.error = "message";
 				preview.message = err.message;

--- a/src/plugins/irc-events/link.js
+++ b/src/plugins/irc-events/link.js
@@ -58,6 +58,7 @@ module.exports = function(client, chan, msg) {
 				parse(msg, chan, preview, res, client);
 			})
 			.catch((err) => {
+				preview.shown = false;
 				preview.type = "error";
 				preview.error = "message";
 				preview.message = err.message;

--- a/test/plugins/link.js
+++ b/test/plugins/link.js
@@ -59,7 +59,7 @@ Vivamus bibendum vulputate tincidunt. Sed vitae ligula felis.`;
 				thumb: "",
 				size: -1,
 				type: "loading",
-				shown: true,
+				shown: null,
 			},
 		]);
 
@@ -96,7 +96,7 @@ Vivamus bibendum vulputate tincidunt. Sed vitae ligula felis.`;
 				thumb: "",
 				size: -1,
 				type: "loading",
-				shown: true,
+				shown: null,
 			},
 		]);
 
@@ -394,7 +394,7 @@ Vivamus bibendum vulputate tincidunt. Sed vitae ligula felis.`;
 				thumb: "",
 				size: -1,
 				type: "loading",
-				shown: true,
+				shown: null,
 			},
 			{
 				body: "",
@@ -403,7 +403,7 @@ Vivamus bibendum vulputate tincidunt. Sed vitae ligula felis.`;
 				thumb: "",
 				size: -1,
 				type: "loading",
-				shown: true,
+				shown: null,
 			},
 		]);
 
@@ -570,7 +570,6 @@ Vivamus bibendum vulputate tincidunt. Sed vitae ligula felis.`;
 		this.irc.once("msg:preview", function(data) {
 			expect(data.preview.link).to.equal("http://localhost:" + port + "");
 			expect(data.preview.type).to.equal("error");
-			expect(data.preview.shown).to.equal(false);
 			done();
 		});
 	});
@@ -598,14 +597,13 @@ Vivamus bibendum vulputate tincidunt. Sed vitae ligula felis.`;
 				thumb: "",
 				size: -1,
 				link: "http://localhost:" + port + "",
-				shown: true,
+				shown: null,
 			},
 		]);
 
 		this.irc.once("msg:preview", function(data) {
 			expect(data.preview.link).to.equal("http://localhost:" + port + "");
 			expect(data.preview.type).to.equal("error");
-			expect(data.preview.shown).to.equal(false);
 			done();
 		});
 	});

--- a/test/plugins/link.js
+++ b/test/plugins/link.js
@@ -569,6 +569,8 @@ Vivamus bibendum vulputate tincidunt. Sed vitae ligula felis.`;
 
 		this.irc.once("msg:preview", function(data) {
 			expect(data.preview.link).to.equal("http://localhost:" + port + "");
+			expect(data.preview.type).to.equal("error");
+			expect(data.preview.shown).to.equal(false);
 			done();
 		});
 	});
@@ -602,6 +604,8 @@ Vivamus bibendum vulputate tincidunt. Sed vitae ligula felis.`;
 
 		this.irc.once("msg:preview", function(data) {
 			expect(data.preview.link).to.equal("http://localhost:" + port + "");
+			expect(data.preview.type).to.equal("error");
+			expect(data.preview.shown).to.equal(false);
 			done();
 		});
 	});


### PR DESCRIPTION
Changes server default of shown to `null` so if the user toggles the preview it will correctly persist through the page reload (no matter if false or true).

This defaults to collapsing error messages by default, except for `image-too-big` which still default to the `media` setting.

This is mostly to accommodate protocol-less urls which produce useless noise.