### PR TITLE
Check if there are any packages installed in upgrade command

### DIFF
--- a/src/command-line/uninstall.js
+++ b/src/command-line/uninstall.js
@@ -2,7 +2,6 @@
 
 const log = require("../log");
 const colors = require("chalk");
-const path = require("path");
 const program = require("commander");
 const Helper = require("../helper");
 const Utils = require("./utils");
@@ -13,32 +12,20 @@ program
 	.on("--help", Utils.extraHelp)
 	.action(function(packageName) {
 		const fs = require("fs");
+		const path = require("path");
 
-		if (!fs.existsSync(Helper.getConfigPath())) {
-			log.error(`${Helper.getConfigPath()} does not exist.`);
-			return;
-		}
-
-		log.info(`Uninstalling ${colors.green(packageName)}...`);
-
-		const packagesPath = Helper.getPackagesPath();
-		const packagesConfig = path.join(packagesPath, "package.json");
-		const packageWasNotInstalled = `${colors.green(packageName)} was not installed.`;
-
-		if (!fs.existsSync(packagesConfig)) {
-			log.warn(packageWasNotInstalled);
-			process.exit(1);
-		}
-
-		const packages = JSON.parse(fs.readFileSync(packagesConfig, "utf-8"));
+		const packagesConfig = path.join(Helper.getPackagesPath(), "package.json");
+		const packages = JSON.parse(fs.readFileSync(packagesConfig, "utf-8")).dependencies;
 
 		if (
 			!packages.dependencies ||
 			!Object.prototype.hasOwnProperty.call(packages.dependencies, packageName)
 		) {
-			log.warn(packageWasNotInstalled);
+			log.warn(`${colors.green(packageName)} is not installed.`);
 			process.exit(1);
 		}
+
+		log.info(`Uninstalling ${colors.green(packageName)}...`);
 
 		return Utils.executeYarnCommand("remove", packageName)
 			.then(() => {

--- a/src/command-line/upgrade.js
+++ b/src/command-line/upgrade.js
@@ -15,15 +15,13 @@ program
 		const path = require("path");
 
 		// Get paths to the location of packages directory
-		const packagesPath = Helper.getPackagesPath();
-		const packagesConfig = path.join(packagesPath, "package.json");
-		const packagesList = JSON.parse(fs.readFileSync(packagesConfig)).dependencies;
+		const packagesConfig = path.join(Helper.getPackagesPath(), "package.json");
+		const packagesList = JSON.parse(fs.readFileSync(packagesConfig), "utf-8").dependencies;
 		const argsList = ["upgrade", "--latest"];
 
 		let count = 0;
 
-		// Check if the configuration file exists
-		if (!fs.existsSync(packagesConfig)) {
+		if (!Object.entries(packagesList).length) {
 			log.warn("There are no packages installed.");
 			return;
 		}
@@ -55,6 +53,7 @@ program
 				log.info("Package(s) have been successfully upgraded.");
 			})
 			.catch((code) => {
-				throw `Failed to upgrade package(s). Exit code ${code}`;
+				log.error(`Failed to upgrade package(s). Exit code ${code}`);
+				process.exit(1);
 			});
 	});

--- a/src/plugins/packages/index.js
+++ b/src/plugins/packages/index.js
@@ -172,6 +172,7 @@ async function outdated(cacheTimeout = TIME_TO_LIVE) {
 	// Get paths to the location of packages directory
 	const packagesPath = Helper.getPackagesPath();
 	const packagesConfig = path.join(packagesPath, "package.json");
+	const packagesList = JSON.parse(fs.readFileSync(packagesConfig), "utf-8").dependencies;
 	const argsList = [
 		"outdated",
 		"--latest",
@@ -184,7 +185,7 @@ async function outdated(cacheTimeout = TIME_TO_LIVE) {
 	];
 
 	// Check if the configuration file exists
-	if (!fs.existsSync(packagesConfig)) {
+	if (!Object.entries(packagesList).length) {
 		// CLI calls outdated with zero TTL, so we can print the warning there
 		if (!cacheTimeout) {
 			log.warn("There are no packages installed.");


### PR DESCRIPTION
Since package.json is always created now, yarn.lock may not exist and it did the following:
```
D:\GitHub\thelounge [master ≡]> node .\index.js upgrade
2019-12-24 09:14:53 [INFO] Upgrading all packages...
2019-12-24 09:14:53 [ERROR] No lockfile in this directory. Run `yarn install` to generate one.
(node:17964) UnhandledPromiseRejectionWarning: Failed to upgrade package(s). Exit code 1
(node:17964) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
```

I fixed up the error logging, added a check if there's actually any dependencies installed.

Also simplified the checks in `uninstall` command to be consistent with `upgrade`.