### PR TITLE
Restrict image viewer bounds while moving

### DIFF
--- a/client/components/ImageViewer.vue
+++ b/client/components/ImageViewer.vue
@@ -197,7 +197,6 @@ export default {
 			const touchMove = (moveEvent) => {
 				touch = this.reduceTouches(moveEvent.touches);
 
-				// TODO: There's bugs with multi finger interactions, needs more testing
 				if (currentTouches.length !== moveEvent.touches.length) {
 					currentTransform.x = touch.x;
 					currentTransform.y = touch.y;
@@ -221,16 +220,10 @@ export default {
 					startTransform.y
 				);
 
-				if (newScale > 1) {
-					this.transform.x = fixedPosition.x + deltaX;
-					this.transform.y = fixedPosition.y + deltaY;
-				} else if (Math.abs(deltaX) > Math.abs(deltaY)) {
-					this.transform.x = fixedPosition.x + deltaX;
-				} else {
-					this.transform.y = fixedPosition.y + deltaY;
-				}
-
+				this.transform.x = fixedPosition.x + deltaX;
+				this.transform.y = fixedPosition.y + deltaY;
 				this.transform.scale = newScale;
+				this.correctPosition();
 			};
 
 			const touchEnd = (endEvent) => {
@@ -302,6 +295,8 @@ export default {
 				if (centerY < 0 || heightScaled + centerY > containerHeight) {
 					this.transform.y = startTransformY + newY;
 				}
+
+				this.correctPosition();
 			};
 
 			const mouseUp = (upEvent) => {


### PR DESCRIPTION
This fixes the unwanted jump when you remove finger of the screen, as you can't move the image out of view anymore.

Also unlocks x/y moving so you can move freely in both directions with one finger at the same time.