### PR TITLE
Set `-webkit-tap-highlight-color` to `transparent`

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -49,6 +49,7 @@
 
 html {
 	box-sizing: border-box;
+	-webkit-tap-highlight-color: transparent; /* remove tap highlight on touch devices */
 }
 
 *,


### PR DESCRIPTION
It was set by bootstrap css, and was removed unintentionally.

https://github.com/thelounge/thelounge/blob/v3.3.0/client/css/bootstrap.css#L208