### PR TITLE
Lower node version to 10.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   ],
   "license": "MIT",
   "engines": {
-    "node": ">=10.16.3"
+    "node": ">=10.15.0"
   },
   "dependencies": {
     "bcryptjs": "2.4.3",


### PR DESCRIPTION
ldapjs did lower their version requirement to 10.13.

Ubuntu and Debian currently hajve 10.15.2 in stable:
https://packages.ubuntu.com/disco/nodejs
https://packages.debian.org/buster/nodejs

Let's lower it so the upgrade is easier.