### PR TITLE
Replace control codes with a space

### DIFF
--- a/client/js/helpers/ircmessageparser/parseStyle.js
+++ b/client/js/helpers/ircmessageparser/parseStyle.js
@@ -67,7 +67,7 @@ function parseStyle(text) {
 		const textPart = text.slice(start, position);
 
 		// Filters out all non-style related control codes present in this text
-		const processedText = textPart.replace(controlCodesRx, "");
+		const processedText = textPart.replace(controlCodesRx, " ");
 
 		if (processedText.length) {
 			// Current fragment starts where the previous one ends, or at 0 if none

--- a/test/client/js/helpers/ircmessageparser/parseStyle.js
+++ b/test/client/js/helpers/ircmessageparser/parseStyle.js
@@ -4,7 +4,7 @@ const expect = require("chai").expect;
 const parseStyle = require("../../../../../client/js/helpers/ircmessageparser/parseStyle").default;
 
 describe("parseStyle", () => {
-	it("should skip control codes", () => {
+	it("should replace control codes", () => {
 		const input = "text\x01with\x04control\x05codes";
 		const expected = [
 			{
@@ -17,10 +17,10 @@ describe("parseStyle", () => {
 				underline: false,
 				strikethrough: false,
 				monospace: false,
-				text: "textwithcontrolcodes",
+				text: "text withcontrol codes",
 
 				start: 0,
-				end: 20,
+				end: 22,
 			},
 		];
 

--- a/test/client/js/helpers/parse.js
+++ b/test/client/js/helpers/parse.js
@@ -48,7 +48,7 @@ describe("IRC formatted message parser", () => {
 				input:
 					"\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0B\x0C\x0D\x0E\x0F\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1A\x1B\x1C\x1B\x1D\x1D\x1E\x1Ftext\x0Awithcontrolcodestest",
 				expected:
-					'<span class="irc-underline irc-strikethrough irc-monospace">text\nwithcontrolcodestest</span>',
+					' <span class="irc-bold">         </span> <span class="irc-monospace">           </span><span class="irc-underline irc-strikethrough irc-monospace">text\nwithcontrolcodestest</span>',
 			},
 		];
 
@@ -604,6 +604,16 @@ describe("IRC formatted message parser", () => {
 			'<span dir="auto" role="button" tabindex="0" class="inline-channel">' +
 				"#test-https://example.com" +
 				"</span>"
+		);
+	});
+
+	it("should find links separated by tab character", async () => {
+		const input = "example.com\texample.org";
+		const actual = await getParsedMessageContents(input);
+
+		expect(actual).to.equal(
+			'<a href="http://example.com" dir="auto" target="_blank" rel="noopener">example.com</a>' +
+				' <a href="http://example.org" dir="auto" target="_blank" rel="noopener">example.org</a>'
 		);
 	});
 });


### PR DESCRIPTION
We were replacing tab character with nothing, so link parser slightly disagreed.