### PR TITLE
Turn off webpack hints

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,6 +19,9 @@ const config = {
 		filename: "[name]",
 		publicPath: "/",
 	},
+	performance: {
+		hints: false,
+	},
 	module: {
 		rules: [
 			{


### PR DESCRIPTION
We're well aware of our size, and it doesn't matter *that* much because we cache in the service worker.