### PR TITLE
Fix url in useragent when fetching releases from github

### DIFF
--- a/src/plugins/changelog.js
+++ b/src/plugins/changelog.js
@@ -26,7 +26,7 @@ async function fetch() {
 		const response = await got("https://api.github.com/repos/thelounge/thelounge/releases", {
 			headers: {
 				Accept: "application/vnd.github.v3.html", // Request rendered markdown
-				"User-Agent": pkg.name + "; +" + pkg.repository.git, // Identify the client
+				"User-Agent": pkg.name + "; +" + pkg.repository.url, // Identify the client
 			},
 		});
 


### PR DESCRIPTION
There's no `git`:

https://github.com/thelounge/thelounge/blob/84107ab516988dd0dc7adfd71667da5d813ecc5e/package.json#L9-L12