### PR TITLE
Pipe uploaded files through exif-be-gone

### DIFF
--- a/defaults/config.js
+++ b/defaults/config.js
@@ -154,6 +154,8 @@ module.exports = {
 	//   this limit will be prompted with an error message in their browser. A value of
 	//   `-1` disables the file size limit and allows files of any size. **Use at
 	//   your own risk.** This value is set to `10240` kilobytes by default.
+	// - `removeExif`: When set to `true`, [Exif data](https://en.wikipedia.org/wiki/Exif)
+	//   will be removed from uploaded files. This transformation runs on all uploaded files.
 	// - `baseUrl`: If you want change the URL where uploaded files are accessed,
 	//   you can set this option to `"https://example.com/folder/"` and the final URL
 	//   would look like `"https://example.com/folder/aabbccddeeff1234/name.png"`.
@@ -163,6 +165,7 @@ module.exports = {
 	fileUpload: {
 		enable: false,
 		maxFileSize: 10240,
+		removeExif: true,
 		baseUrl: null,
 	},
 

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "chalk": "3.0.0",
     "cheerio": "1.0.0-rc.3",
     "commander": "4.0.1",
+    "exif-be-gone": "1.0.0",
     "express": "4.17.1",
     "file-type": "12.4.2",
     "filenamify": "4.1.0",

--- a/src/plugins/uploader.js
+++ b/src/plugins/uploader.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const ExifTransformer = require("exif-be-gone");
 const Helper = require("../helper");
 const busboy = require("busboy");
 const uuidv4 = require("uuid/v4");
@@ -198,7 +199,12 @@ class Uploader {
 			});
 
 			// Attempt to write the stream to file
-			fileStream.pipe(streamWriter);
+			// If exif removal is enabled, pipe through exif-be-gone
+			if (Helper.config.fileUpload.removeExif) {
+				fileStream.pipe(new ExifTransformer()).pipe(streamWriter);
+			} else {
+				fileStream.pipe(streamWriter);
+			}
 		});
 
 		busboyInstance.on("finish", () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3299,6 +3299,11 @@ execall@^2.0.0:
   dependencies:
     clone-regexp "^2.1.0"
 
+exif-be-gone@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/exif-be-gone/-/exif-be-gone-1.0.0.tgz#aa793bcaa1e3db821eadd53e09e24114e7577904"
+  integrity sha512-Df3doT6MeJ5/+8u4rgZv1cndJEehVbXEBI/eBCb1faO63XLet/aJJZkzCr01f+JPUNnTn+HZydpzWZmPGlk0CQ==
+
 expand-brackets@^2.1.4:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/expand-brackets/-/expand-brackets-2.1.4.tgz#b77735e315ce30f6b6eff0f83b04151a22449622"


### PR DESCRIPTION
Fixes #3025

I'm not entirely sure how safe the `exif-be-gone` is. https://github.com/joshbuddy/exif-be-gone/blob/master/index.js

This will most likely also remove wanted data like rotation and color profiles.