### PR TITLE
Remove cyclical dependency in router<->webpush

### DIFF
--- a/client/js/router.js
+++ b/client/js/router.js
@@ -142,4 +142,18 @@ function switchToChannel(channel) {
 	return navigate("RoutedChat", {id: channel.id});
 }
 
+if ("serviceWorker" in navigator) {
+	navigator.serviceWorker.addEventListener("message", (event) => {
+		if (event.data && event.data.type === "open") {
+			const id = parseInt(event.data.channel.substr(5), 10); // remove "chan-" prefix
+
+			const channelTarget = store.getters.findChannel(id);
+
+			if (channelTarget) {
+				switchToChannel(channelTarget.channel);
+			}
+		}
+	});
+}
+
 export {initialize, router, navigate, switchToChannel};

--- a/client/js/webpush.js
+++ b/client/js/webpush.js
@@ -2,23 +2,8 @@
 
 import socket from "./socket";
 import store from "./store";
-import {switchToChannel} from "./router";
 
 export default {togglePushSubscription};
-
-if ("serviceWorker" in navigator) {
-	navigator.serviceWorker.addEventListener("message", (event) => {
-		if (event.data && event.data.type === "open") {
-			const id = parseInt(event.data.channel.substr(5), 10); // remove "chan-" prefix
-
-			const channelTarget = store.getters.findChannel(id);
-
-			if (channelTarget) {
-				switchToChannel(channelTarget.channel);
-			}
-		}
-	});
-}
 
 socket.once("push:issubscribed", function(hasSubscriptionOnServer) {
 	if (!isAllowedServiceWorkersHost()) {


### PR DESCRIPTION
Fixes this:
```
  error no-circular: client/js/webpush.js →
      client/js/router.js →
      client/components/Windows/Settings.vue →
      client/js/webpush.js
  error no-circular: client/js/router.js →
      client/components/Windows/Settings.vue →
      client/js/webpush.js →
      client/js/router.js
  error no-circular: client/components/Windows/Settings.vue →
      client/js/webpush.js →
      client/js/router.js →
      client/components/Windows/Settings.vue
```