### PR TITLE
Allow dismissing unread marker

### DIFF
--- a/client/components/MessageList.vue
+++ b/client/components/MessageList.vue
@@ -29,7 +29,9 @@
 					:key="message.id + '-unread'"
 					class="unread-marker"
 				>
-					<span class="unread-marker-text" />
+					<span class="tooltipped tooltipped-n" aria-label="Dismiss">
+						<span class="unread-marker-text" @click="clearUnreadMarker" />
+					</span>
 				</div>
 
 				<MessageCondensed
@@ -332,6 +334,9 @@ export default {
 
 			const el = this.$refs.chat;
 			el.scrollTop = el.scrollHeight;
+		},
+		clearUnreadMarker() {
+			this.channel.firstUnread = this.channel.messages[this.channel.messages.length - 1].id;
 		},
 	},
 };

--- a/client/css/style.css
+++ b/client/css/style.css
@@ -1244,6 +1244,10 @@ textarea.input {
 	border-top: 1px solid var(--unread-marker-color);
 }
 
+#chat .unread-marker-text {
+	cursor: pointer;
+}
+
 #chat .unread-marker-text::before {
 	content: "New messages";
 	background-color: var(--window-bg-color);


### PR DESCRIPTION
Hovering the marker shows the tooltip, and clicking the marker resets the unread marker (hides it). Effectively this is a "mark as read" feature. See https://github.com/thelounge/thelounge/issues/3666
![image](https://user-images.githubusercontent.com/3417292/71769975-0b22ff00-2f30-11ea-89a5-ebf7fcad51a3.png)
