### PR TITLE
Show an icon for "show in active" messages

### DIFF
--- a/client/components/Message.vue
+++ b/client/components/Message.vue
@@ -58,6 +58,12 @@
 				</template>
 			</span>
 			<span class="content" dir="auto">
+				<span
+					v-if="message.showInActive"
+					aria-label="This message was shown in your active channel"
+					class="msg-shown-in-active tooltipped tooltipped-e"
+					><span></span
+				></span>
 				<ParsedMessage :network="network" :message="message" />
 				<LinkPreview
 					v-for="preview in message.previews"

--- a/client/css/style.css
+++ b/client/css/style.css
@@ -309,6 +309,7 @@ p {
 #chat .msg[data-type="action"] .from::before,
 #chat .msg[data-type="plugin"] .from::before,
 #chat .msg[data-type="raw"] .from::before,
+#chat .msg-shown-in-active span::before,
 #chat .toggle-button::after,
 #chat .toggle-content .more-caret::before,
 #chat .scroll-down-arrow::after,
@@ -484,6 +485,16 @@ p {
 	transform: rotate(45deg);
 	display: inline-block;
 	padding: 1px;
+}
+
+#chat .msg-shown-in-active {
+	cursor: help;
+	margin-right: 5px;
+}
+
+#chat .msg-shown-in-active span::before {
+	font-size: 10px;
+	content: "\f06e"; /* https://fontawesome.com/icons/eye?style=solid */
 }
 
 #chat .toggle-button {

--- a/client/js/socket-events/msg.js
+++ b/client/js/socket-events/msg.js
@@ -29,25 +29,29 @@ socket.on("msg", function(data) {
 
 	// Display received notices and errors in currently active channel.
 	// Reloading the page will put them back into the lobby window.
-	// We only want to put errors/notices in active channel if they arrive on the same network
-	if (
-		data.msg.showInActive &&
-		store.state.activeChannel &&
-		store.state.activeChannel.network === receivingChannel.network
-	) {
-		channel = store.state.activeChannel.channel;
+	if (data.msg.showInActive) {
+		// We only want to put errors/notices in active channel if they arrive on the same network
+		if (
+			store.state.activeChannel &&
+			store.state.activeChannel.network === receivingChannel.network
+		) {
+			channel = store.state.activeChannel.channel;
 
-		if (data.chan === channel.id) {
-			// If active channel is the intended channel for this message,
-			// remove the showInActive flag
-			data.msg.showInActive = false;
+			if (data.chan === channel.id) {
+				// If active channel is the intended channel for this message,
+				// remove the showInActive flag
+				delete data.msg.showInActive;
+			} else {
+				data.chan = channel.id;
+			}
 		} else {
-			data.chan = channel.id;
+			delete data.msg.showInActive;
 		}
-	} else if (!isActiveChannel) {
-		// Do not set unread counter for channel if it is currently active on this client
-		// It may increase on the server before it processes channel open event from this client
+	}
 
+	// Do not set unread counter for channel if it is currently active on this client
+	// It may increase on the server before it processes channel open event from this client
+	if (!isActiveChannel) {
 		if (typeof data.highlight !== "undefined") {
 			channel.highlight = data.highlight;
 		}


### PR DESCRIPTION
![05-1626-BurlywoodCavy](https://user-images.githubusercontent.com/613331/71783010-8e545b80-2fe9-11ea-9da6-4edc2e93a3f6.png)

Hopefully this removes some of the hidden magic, so the user understands the behaviour of notices and errors.