### PR TITLE
Remove `child-src` from CSP, add `base-uri 'none'`

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -296,12 +296,12 @@ function forceNoCacheRequest(req, res, next) {
 function indexRequest(req, res) {
 	const policies = [
 		"default-src 'none'", // default to nothing
+		"base-uri 'none'", // disallow <base>, has no fallback to default-src
 		"form-action 'self'", // 'self' to fix saving passwords in Firefox, even though login is handled in javascript
 		"connect-src 'self' ws: wss:", // allow self for polling; websockets
 		"style-src 'self' https: 'unsafe-inline'", // allow inline due to use in irc hex colors
 		"script-src 'self'", // javascript
 		"worker-src 'self'", // service worker
-		"child-src 'self'", // deprecated fall back for workers, Firefox <58, see #1902
 		"manifest-src 'self'", // manifest.json
 		"font-src 'self' https:", // allow loading fonts from secure sites (e.g. google fonts)
 		"media-src 'self' https:", // self for notification sound; allow https media (audio previews)


### PR DESCRIPTION
`child-src 'self` was there for old Firefox, which is outside of our support range now. It falls back to `default-src 'none'`.