### PR TITLE
Open last channel in the list when creating a network

### DIFF
--- a/client/js/socket-events/network.js
+++ b/client/js/socket-events/network.js
@@ -14,7 +14,9 @@ socket.on("network", function(data) {
 	network.channels.forEach(store.getters.initChannel);
 
 	store.commit("networks", [...store.state.networks, network]);
-	switchToChannel(network.channels[0]);
+
+	// Open last channel specified in `join`
+	switchToChannel(network.channels[network.channels.length - 1]);
 });
 
 socket.on("network:options", function(data) {


### PR DESCRIPTION
Fixes #3699. This restores the behaviour that existed before 4.0.