### PR TITLE
Undo username pattern

### DIFF
--- a/client/components/NetworkForm.vue
+++ b/client/components/NetworkForm.vue
@@ -105,7 +105,6 @@
 						ref="usernameInput"
 						class="input username"
 						name="username"
-						pattern="[^\s:!@]+"
 						:value="defaults.username"
 						maxlength="100"
 					/>

--- a/src/models/network.js
+++ b/src/models/network.js
@@ -75,7 +75,7 @@ Network.prototype.validate = function(client) {
 		this.username = this.nick.replace(/[^a-zA-Z0-9]/g, "");
 	}
 
-	this.username = cleanNick(this.username) || "thelounge";
+	this.username = cleanString(this.username) || "thelounge";
 	this.realname = cleanString(this.realname) || "The Lounge User";
 	this.password = cleanString(this.password);
 	this.host = cleanString(this.host);


### PR DESCRIPTION
This broke znc usernames, as they may contain `@`.