### PR TITLE
Ignore Alt+<letter> keybinds when focused in chat input

### DIFF
--- a/client/components/App.vue
+++ b/client/components/App.vue
@@ -71,11 +71,27 @@ export default {
 		clearTimeout(this.dayChangeTimeout);
 	},
 	methods: {
-		toggleSidebar() {
+		toggleSidebar(e) {
+			// Do not handle this keybind in the chat input because
+			// it can be used to type letters with umlauts
+			if (e.target.tagName === "TEXTAREA") {
+				return true;
+			}
+
 			this.$store.commit("toggleSidebar");
+
+			return false;
 		},
-		toggleUserList() {
+		toggleUserList(e) {
+			// Do not handle this keybind in the chat input because
+			// it can be used to type letters with umlauts
+			if (e.target.tagName === "TEXTAREA") {
+				return true;
+			}
+
 			this.$store.commit("toggleUserlist");
+
+			return false;
 		},
 		msUntilNextDay() {
 			// Compute how many milliseconds are remaining until the next day starts

--- a/client/js/keybinds.js
+++ b/client/js/keybinds.js
@@ -71,7 +71,15 @@ Mousetrap.bind(["alt+shift+up", "alt+shift+down"], function(e, keys) {
 
 // Jump to the first window with a highlight in it, or the first with unread
 // activity if there are none with highlights.
-Mousetrap.bind(["alt+a"], function() {
+Mousetrap.bind(["alt+a"], function(e) {
+	// Do not handle this keybind in the chat input because
+	// it can be used to type letters with umlauts
+	// Normally this is not required, but since chat input has the "mousetrap"
+	// class for other keybinds to work, we need to add this check
+	if (e.target.tagName === "TEXTAREA") {
+		return true;
+	}
+
 	let targetChannel;
 
 	outer_loop: for (const network of store.state.networks) {


### PR DESCRIPTION
Fixes #3719.

Normally this is not required, but since chat input has the `mousetrap` class for other keybinds to work, these alt binds also get handled and prevent actual letters from being typed.