### PR TITLE
Fix DOMRect coordinates in Safari

### DIFF
--- a/client/components/ChatUserList.vue
+++ b/client/components/ChatUserList.vue
@@ -137,8 +137,8 @@ export default {
 				view: window,
 				bubbles: true,
 				cancelable: true,
-				clientX: rect.x,
-				clientY: rect.y + rect.height,
+				clientX: rect.left,
+				clientY: rect.top + rect.height,
 			});
 			el.dispatchEvent(ev);
 		},

--- a/client/js/vue.js
+++ b/client/js/vue.js
@@ -35,8 +35,8 @@ const vueApp = new Vue({
 				const rect = el.getBoundingClientRect();
 				const event = new MouseEvent("click", {
 					view: window,
-					clientX: rect.x + 10,
-					clientY: rect.y,
+					clientX: rect.left + 10,
+					clientY: rect.top,
 				});
 
 				this.$root.$emit("contextmenu:removenetwork", {


### PR DESCRIPTION
This fixes network removal confirmation not showing up.

Ref https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect