### PR TITLE
Increase buffer size for active and scrolled down channels

### DIFF
--- a/client/js/socket-events/msg.js
+++ b/client/js/socket-events/msg.js
@@ -75,8 +75,9 @@ socket.on("msg", function(data) {
 		// If message arrives in non active channel, keep only 100 messages
 		messageLimit = 100;
 	} else if (channel.scrolledToBottom) {
-		// If message arrives in active channel, keep 500 messages if scroll is currently at the bottom
-		messageLimit = 500;
+		// If message arrives in active channel, keep 1500 messages if scroll is currently at the bottom
+		// One history load may load up to 1000 messages at once if condendesed or hidden events are enabled
+		messageLimit = 1500;
 	}
 
 	if (messageLimit > 0 && channel.messages.length > messageLimit) {


### PR DESCRIPTION
This should technically fix #3726.

Since #3603, one history load may get 1000 messages, and when any new messages arrive the channel would be trimmed to 500 messages. This may look wonky if majority of these messages are condensed events.