### PR TITLE
Write prettier error messages for certain errors

### DIFF
--- a/client/components/MessageTypes/error.vue
+++ b/client/components/MessageTypes/error.vue
@@ -1,0 +1,58 @@
+<template>
+	<span class="content">
+		<ParsedMessage :network="network" :message="message" :text="errorMessage" />
+	</span>
+</template>
+
+<script>
+import ParsedMessage from "../ParsedMessage.vue";
+
+export default {
+	name: "MessageTypeError",
+	components: {
+		ParsedMessage,
+	},
+	props: {
+		network: Object,
+		message: Object,
+	},
+	computed: {
+		errorMessage() {
+			switch (this.message.error) {
+				case "bad_channel_key":
+					return `Cannot join ${this.message.channel} - Bad channel key.`;
+				case "banned_from_channel":
+					return `Cannot join ${this.message.channel} - You have been banned from the channel.`;
+				case "cannot_send_to_channel":
+					return `Cannot send to channel ${this.message.channel}`;
+				case "channel_is_full":
+					return `Cannot join ${this.message.channel} - Channel is full.`;
+				case "chanop_privs_needed":
+					return "Cannot perform action: You're not a channel operator.";
+				case "invite_only_channel":
+					return `Cannot join ${this.message.channel} - Channel is invite only.`;
+				case "no_such_nick":
+					return `User ${this.message.nick} hasn't logged in or does not exist.`;
+				case "not_on_channel":
+					return "Cannot perform action: You're not on the channel.";
+				case "password_mismatch":
+					return "Password mismatch.";
+				case "too_many_channels":
+					return `Cannot join ${this.message.channel} - You've already reached the maximum number of channels allowed.`;
+				case "unknown_command":
+					return `Unknown command: ${this.message.command}`;
+				case "user_not_in_channel":
+					return `User ${this.message.nick} is not on the channel.`;
+				case "user_on_channel":
+					return `User ${this.message.nick} is already on the channel.`;
+				default:
+					if (this.message.reason) {
+						return `${this.message.reason} (${this.message.error})`;
+					}
+
+					return this.message.error;
+			}
+		},
+	},
+};
+</script>

--- a/src/plugins/irc-events/error.js
+++ b/src/plugins/irc-events/error.js
@@ -7,24 +7,14 @@ module.exports = function(irc, network) {
 	const client = this;
 
 	irc.on("irc error", function(data) {
-		let text = "";
-
-		if (data.channel) {
-			text = `${data.channel}: `;
-		}
-
-		if (data.error === "user_on_channel") {
-			text += `User (${data.nick}) is already on channel`;
-		} else if (data.reason) {
-			text += `${data.reason} (${data.error})`;
-		} else {
-			text += data.error;
-		}
-
 		const msg = new Msg({
 			type: Msg.Type.ERROR,
-			text: text,
+			error: data.error,
 			showInActive: true,
+			nick: data.nick,
+			channel: data.channel,
+			reason: data.reason,
+			command: data.command,
 		});
 
 		let target = network.channels[0];


### PR DESCRIPTION
Closes #251.
Closes #797.

[Inspired by KiwiIRC's implementation](https://github.com/prawnsalad/KiwiIRC/blob/master/client/src/models/network.js#L849), though there are some messages that Kiwi didn't include, and some that I skipped because they aren't used by Freenode.

I'd like to ask, is the current format good? `#[channel]: The channel is full`, or would it be better to display it as `#[channel] is full`, `You have been banned from #[channel]`? I.e., removing the line that appends the channel to the error message.