### PR TITLE
Wrap stdout parsing from yarn into try/catch

### DIFF
--- a/src/command-line/utils.js
+++ b/src/command-line/utils.js
@@ -132,10 +132,16 @@ class Utils {
 					.trim()
 					.split("\n")
 					.forEach((line) => {
-						line = JSON.parse(line);
+						try {
+							line = JSON.parse(line);
 
-						if (line.type === "success") {
-							success = true;
+							if (line.type === "success") {
+								success = true;
+							}
+						} catch (e) {
+							// Stdout buffer has limitations and yarn may print
+							// big package trees, for example in the upgrade command
+							// See https://github.com/thelounge/thelounge/issues/3679
 						}
 					});
 			});


### PR DESCRIPTION
cc @Mikaela for test

Since we only parse it for `success:true`, it should arrive in a separate `data` event, andwe should be fine.