### PR TITLE
Improve wav audio detection

### DIFF
--- a/src/plugins/irc-events/link.js
+++ b/src/plugins/irc-events/link.js
@@ -221,6 +221,7 @@ function parse(msg, chan, preview, res, client) {
 		case "audio/mpeg3":
 		case "audio/ogg":
 		case "audio/wav":
+		case "audio/x-wav":
 		case "audio/x-mid":
 		case "audio/x-midi":
 		case "audio/x-mpeg":

--- a/src/plugins/uploader.js
+++ b/src/plugins/uploader.js
@@ -66,7 +66,7 @@ class Uploader {
 		const folder = name.substring(0, 2);
 		const uploadPath = Helper.getFileUploadPath();
 		const filePath = path.join(uploadPath, folder, name);
-		const detectedMimeType = await Uploader.getFileType(filePath);
+		let detectedMimeType = await Uploader.getFileType(filePath);
 
 		// doesn't exist
 		if (detectedMimeType === null) {
@@ -75,6 +75,12 @@ class Uploader {
 
 		// Force a download in the browser if it's not a whitelisted type (binary or otherwise unknown)
 		const contentDisposition = Uploader.isValidType(detectedMimeType) ? "inline" : "attachment";
+
+		if (detectedMimeType === "audio/vnd.wave") {
+			// Send a more common mime type for wave audio files
+			// so that browsers can play them correctly
+			detectedMimeType = "audio/wav";
+		}
 
 		res.setHeader("Content-Disposition", contentDisposition);
 		res.setHeader("Cache-Control", "max-age=86400");


### PR DESCRIPTION
`audio/vnd.wave` is the official mime type, but neither Firefox or Chrome support it, so we just send the more common `audio/wav` for uploaded files (this also fixes the mismatch in link previewer).