### PR TITLE
Fix sending unhandled numerics to target channel

### DIFF
--- a/src/plugins/irc-events/unhandled.js
+++ b/src/plugins/irc-events/unhandled.js
@@ -8,18 +8,19 @@ module.exports = function(irc, network) {
 	irc.on("unknown command", function(command) {
 		let target = network.channels[0];
 
-		if (command.params.length > 0) {
-			// Do not display users own name
-			if (command.params[0] === network.irc.user.nick) {
-				command.params.shift();
-			} else {
-				// If this numeric starts with a channel name that exists
-				// put this message in that channel
-				const channel = network.getChannel(command.params[0]);
+		// Do not display users own name
+		if (command.params.length > 0 && command.params[0] === network.irc.user.nick) {
+			command.params.shift();
+		}
 
-				if (typeof channel !== "undefined") {
-					target = channel;
-				}
+		// Check the length again because we may shift the nick above
+		if (command.params.length > 0) {
+			// If this numeric starts with a channel name that exists
+			// put this message in that channel
+			const channel = network.getChannel(command.params[0]);
+
+			if (typeof channel !== "undefined") {
+				target = channel;
 			}
 		}
 


### PR DESCRIPTION
Fixes #3788 

If an unhandled numeric begins with a channel name, we put that message in said channel.