### PR TITLE
Add maskable purpose & removes monochrome

### DIFF
--- a/client/thelounge.webmanifest
+++ b/client/thelounge.webmanifest
@@ -10,31 +10,37 @@
 		{
 			"src": "img/logo-grey-bg-120x120px.png",
 			"type": "image/png",
+			"purpose": "maskable any",
 			"sizes": "120x120"
 		},
 		{
 			"src": "img/logo-grey-bg-152x152px.png",
 			"type": "image/png",
+			"purpose": "maskable any",
 			"sizes": "152x152"
 		},
 		{
 			"src": "img/logo-grey-bg-167x167px.png",
 			"type": "image/png",
+			"purpose": "maskable any",
 			"sizes": "167x167"
 		},
 		{
 			"src": "img/logo-grey-bg-180x180px.png",
 			"type": "image/png",
+			"purpose": "maskable any",
 			"sizes": "180x180"
 		},
 		{
 			"src": "img/logo-grey-bg-192x192px.png",
 			"type": "image/png",
+			"purpose": "maskable any",
 			"sizes": "192x192"
 		},
 		{
 			"src": "img/logo-grey-bg-512x512px.png",
 			"type": "image/png",
+			"purpose": "maskable any",
 			"sizes": "512x512"
 		},
 		{
@@ -42,11 +48,6 @@
 			"type": "image/svg+xml",
 			"purpose": "maskable any",
 			"sizes": "513x513"
-		},
-		{
-			"src": "img/icon-black-transparent-bg.svg",
-			"type": "image/svg+xml",
-			"purpose": "monochrome"
 		}
 	]
 }


### PR DESCRIPTION
Preview: https://maskable.app/?demo=https://raw.githubusercontent.com/thelounge/thelounge/master/client/img/logo-grey-bg-512x512px.png

Adds the "maskable" purpose to PNG icons in addition to the SVG icon.

---

I appreciate the interest in monochrome icons but please don't start adding it to your manifests yet. The spec is still being worked on and behaviours could potentially change by the time the feature is added to browsers.

And thanks for making The Lounge, its my preferred IRC client 😄 