### PR TITLE
Replace all uses of `fs-extra` with native methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "express": "4.17.1",
     "file-type": "14.1.4",
     "filenamify": "4.1.0",
-    "fs-extra": "8.1.0",
     "got": "10.6.0",
     "irc-framework": "4.7.0",
     "is-utf8": "0.2.1",

--- a/src/command-line/index.js
+++ b/src/command-line/index.js
@@ -2,7 +2,6 @@
 
 const log = require("../log");
 const fs = require("fs");
-const fsextra = require("fs-extra");
 const path = require("path");
 const colors = require("chalk");
 const program = require("commander");
@@ -61,7 +60,7 @@ function createPackagesFolder() {
 	const packagesConfig = path.join(packagesPath, "package.json");
 
 	// Create node_modules folder, otherwise yarn will start walking upwards to find one
-	fsextra.ensureDirSync(path.join(packagesPath, "node_modules"));
+	fs.mkdirSync(path.join(packagesPath, "node_modules"), {recursive: true});
 
 	// Create package.json with private set to true, if it doesn't exist already
 	if (!fs.existsSync(packagesConfig)) {
@@ -71,7 +70,7 @@ function createPackagesFolder() {
 				{
 					private: true,
 					description:
-						"Packages for The Lounge. All packages in node_modules directory will be automatically loaded.",
+						"Packages for The Lounge. Use `thelounge install <package>` command to add a package.",
 					dependencies: {},
 				},
 				null,

--- a/src/command-line/start.js
+++ b/src/command-line/start.js
@@ -3,7 +3,6 @@
 const log = require("../log");
 const colors = require("chalk");
 const fs = require("fs");
-const fsextra = require("fs-extra");
 const path = require("path");
 const program = require("commander");
 const Helper = require("../helper");
@@ -23,14 +22,14 @@ program
 
 function initalizeConfig() {
 	if (!fs.existsSync(Helper.getConfigPath())) {
-		fsextra.ensureDirSync(Helper.getHomePath());
+		fs.mkdirSync(Helper.getHomePath(), {recursive: true});
 		fs.chmodSync(Helper.getHomePath(), "0700");
-		fsextra.copySync(
+		fs.copyFileSync(
 			path.resolve(path.join(__dirname, "..", "..", "defaults", "config.js")),
 			Helper.getConfigPath()
 		);
 		log.info(`Configuration file created at ${colors.green(Helper.getConfigPath())}.`);
 	}
 
-	fsextra.ensureDirSync(Helper.getUsersPath());
+	fs.mkdirSync(Helper.getUsersPath(), {recursive: true});
 }

--- a/src/plugins/messageStorage/sqlite.js
+++ b/src/plugins/messageStorage/sqlite.js
@@ -2,7 +2,7 @@
 
 const log = require("../../log");
 const path = require("path");
-const fsextra = require("fs-extra");
+const fs = require("fs");
 const Helper = require("../../helper");
 const Msg = require("../../models/msg");
 
@@ -39,7 +39,7 @@ class MessageStorage {
 		const sqlitePath = path.join(logsPath, `${this.client.name}.sqlite3`);
 
 		try {
-			fsextra.ensureDirSync(logsPath);
+			fs.mkdirSync(logsPath, {recursive: true});
 		} catch (e) {
 			log.error("Unable to create logs directory", e);
 

--- a/src/plugins/messageStorage/text.js
+++ b/src/plugins/messageStorage/text.js
@@ -2,7 +2,6 @@
 
 const log = require("../../log");
 const fs = require("fs");
-const fsextra = require("fs-extra");
 const path = require("path");
 const filenamify = require("filenamify");
 const Helper = require("../../helper");
@@ -38,7 +37,7 @@ class TextFileMessageStorage {
 		);
 
 		try {
-			fsextra.ensureDirSync(logPath);
+			fs.mkdirSync(logPath, {recursive: true});
 		} catch (e) {
 			log.error("Unable to create logs directory", e);
 			return;

--- a/src/plugins/storage.js
+++ b/src/plugins/storage.js
@@ -2,7 +2,6 @@
 
 const log = require("../log");
 const fs = require("fs");
-const fsextra = require("fs-extra");
 const path = require("path");
 const crypto = require("crypto");
 const helper = require("../helper");
@@ -16,7 +15,19 @@ class Storage {
 		// Ensures that a directory is empty.
 		// Deletes directory contents if the directory is not empty.
 		// If the directory does not exist, it is created.
-		fsextra.emptyDirSync(helper.getStoragePath());
+
+		const dir = helper.getStoragePath();
+		let items;
+
+		try {
+			items = fs.readdirSync(dir);
+		} catch (e) {
+			fs.mkdirSync(dir, {recursive: true});
+			return;
+		}
+
+		// TODO: Use `fs.rmdirSync(dir, {recursive: true});` when it's stable (node 13+)
+		items.forEach((item) => deleteFolder(path.join(dir, item)));
 	}
 
 	dereference(url) {
@@ -57,25 +68,38 @@ class Storage {
 			return callback(url);
 		}
 
-		fsextra
-			.ensureDir(folder)
-			.then(() => {
-				fs.writeFile(filePath, data, (err) => {
-					if (err) {
-						log.error("Failed to store a file", err);
-
-						return callback("");
-					}
-
-					callback(url);
-				});
-			})
-			.catch((err) => {
-				log.error("Failed to create storage folder", err);
+		fs.mkdir(folder, {recursive: true}, (mkdirErr) => {
+			if (mkdirErr) {
+				log.error("Failed to create storage folder", mkdirErr);
 
 				return callback("");
+			}
+
+			fs.writeFile(filePath, data, (err) => {
+				if (err) {
+					log.error("Failed to store a file", err);
+
+					return callback("");
+				}
+
+				callback(url);
 			});
+		});
 	}
 }
 
 module.exports = new Storage();
+
+function deleteFolder(dir) {
+	fs.readdirSync(dir).forEach((item) => {
+		item = path.join(dir, item);
+
+		if (fs.lstatSync(item).isDirectory()) {
+			deleteFolder(item);
+		} else {
+			fs.unlinkSync(item);
+		}
+	});
+
+	fs.rmdirSync(dir);
+}

--- a/src/plugins/uploader.js
+++ b/src/plugins/uploader.js
@@ -4,7 +4,6 @@ const Helper = require("../helper");
 const busboy = require("busboy");
 const {v4: uuidv4} = require("uuid");
 const path = require("path");
-const fsextra = require("fs-extra");
 const fs = require("fs");
 const fileType = require("file-type");
 const readChunk = require("read-chunk");
@@ -174,7 +173,7 @@ class Uploader {
 		// this helps avoid file system and certain tooling limitations when there are
 		// too many files on one folder
 		try {
-			fsextra.ensureDirSync(destDir);
+			fs.mkdirSync(destDir, {recursive: true});
 		} catch (err) {
 			log.err(`Error ensuring ${destDir} exists for uploads: ${err.message}`);
 			return abortWithError(err);

--- a/test/plugins/sqlite.js
+++ b/test/plugins/sqlite.js
@@ -16,18 +16,25 @@ describe("SQLite Message Storage", function () {
 	const expectedPath = path.join(Helper.getHomePath(), "logs", "testUser.sqlite3");
 	let store;
 
-	// Delete database file from previous test run
 	before(function (done) {
 		store = new MessageStorage({
 			name: "testUser",
 			idMsg: 1,
 		});
 
+		// Delete database file from previous test run
 		if (fs.existsSync(expectedPath)) {
 			fs.unlink(expectedPath, done);
 		} else {
 			done();
 		}
+	});
+
+	after(function (done) {
+		// After tests run, remove the logs folder
+		// so we return to the clean state
+		fs.unlinkSync(expectedPath);
+		fs.rmdir(path.join(Helper.getHomePath(), "logs"), done);
 	});
 
 	it("should resolve an empty array when disabled", function (done) {

--- a/test/plugins/storage.js
+++ b/test/plugins/storage.js
@@ -6,6 +6,7 @@ const crypto = require("crypto");
 const expect = require("chai").expect;
 const util = require("../util");
 const Helper = require("../../src/helper");
+const storage = require("../../src/plugins/storage");
 const link = require("../../src/plugins/irc-events/link.js");
 
 describe("Image storage", function () {
@@ -49,6 +50,13 @@ describe("Image storage", function () {
 
 	after(function (done) {
 		this.connection.close(done);
+	});
+
+	after(function (done) {
+		// After storage tests run, remove the remaining empty
+		// storage folder so we return to the clean state
+		const dir = Helper.getStoragePath();
+		fs.rmdir(dir, done);
 	});
 
 	beforeEach(function () {
@@ -124,5 +132,14 @@ describe("Image storage", function () {
 			expect(data.preview.thumb).to.equal(correctSvgURL);
 			done();
 		});
+	});
+
+	it("should clear storage folder", function () {
+		const dir = Helper.getStoragePath();
+
+		expect(fs.readdirSync(dir)).to.not.be.empty;
+		storage.emptyDir();
+		expect(fs.readdirSync(dir)).to.be.empty;
+		expect(fs.existsSync(dir)).to.be.true;
 	});
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3839,15 +3839,6 @@ fromentries@^1.2.0:
   resolved "https://registry.yarnpkg.com/fromentries/-/fromentries-1.2.0.tgz#e6aa06f240d6267f913cea422075ef88b63e7897"
   integrity sha512-33X7H/wdfO99GdRLLgkjUrD4geAFdq/Uv0kl3HD4da6HDixd2GUg8Mw7dahLCV9r/EARkmtYBB6Tch4EEokFTQ==
 
-fs-extra@8.1.0:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
-  integrity sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==
-  dependencies:
-    graceful-fs "^4.2.0"
-    jsonfile "^4.0.0"
-    universalify "^0.1.0"
-
 fs-minipass@^1.2.5:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.7.tgz#ccff8570841e7fe4265693da88936c55aed7f7c7"
@@ -4133,7 +4124,7 @@ got@^9.6.0:
     to-readable-stream "^1.0.0"
     url-parse-lax "^3.0.0"
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0:
+graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.3.tgz#4a12ff1b60376ef09862c2093edd908328be8423"
   integrity sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==
@@ -5125,13 +5116,6 @@ json5@^2.1.2:
   integrity sha512-MoUOQ4WdiN3yxhm7NEVJSJrieAo5hNSLQ5sj05OTRHPL9HOBy8u4Bu88jsC1jvqAdN+E1bJmsUcZH+1HQxliqQ==
   dependencies:
     minimist "^1.2.5"
-
-jsonfile@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
-  integrity sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=
-  optionalDependencies:
-    graceful-fs "^4.1.6"
 
 jsprim@^1.2.2:
   version "1.4.1"
@@ -9321,11 +9305,6 @@ unist-util-visit@^1.1.0:
   integrity sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==
   dependencies:
     unist-util-visit-parents "^2.0.0"
-
-universalify@^0.1.0:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
-  integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
 
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
The `recursive` option was added in Node 10.12.0.

https://github.com/jprichardson/node-fs-extra/blob/a149f822c387958caba7333ad2830615ab8b078f/lib/mkdirs/make-dir.js#L95-L106