### PR TITLE
Remove "The Lounge" from connect in public

### DIFF
--- a/client/components/NetworkForm.vue
+++ b/client/components/NetworkForm.vue
@@ -10,10 +10,9 @@
 					Edit {{ defaults.name }}
 				</template>
 				<template v-else>
-					<template v-if="config.public">The Lounge - </template>
 					Connect
-					<template v-if="!config.displayNetwork">
-						<template v-if="config.lockNetwork"> to {{ defaults.name }} </template>
+					<template v-if="!config.displayNetwork && config.lockNetwork">
+						to {{ defaults.name }}
 					</template>
 				</template>
 			</h1>


### PR DESCRIPTION
There's a logo in the sidebar, this is not necessary.