### PR TITLE
Fix body overscroll and overflow on iOS Safari

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -104,7 +104,7 @@ body {
 	  * Disable pull-to-refresh on mobile that conflicts with scrolling the message list.
 	  * See http://stackoverflow.com/a/29313685/1935861
 	  */
-	overflow-y: hidden;
+	overflow: hidden; /* iOS Safari requires overflow rather than overflow-y */
 }
 
 a,


### PR DESCRIPTION
In order to prevent scrolling past the edges of the body (overscroll) in Safari on iOS, the overflow must be hidden (not only overflow-y). The new behavior fixes the top bar and the text input bar to the top and bottom of the window respectively.

Standard view: https://ibin.co/5Gda9ZtZROs7.jpg
View while scrolling down (latest version): https://ibin.co/5Gdb7DBJALRM.jpg
View while scrolling down (this PR): https://ibin.co/5GdbSRUbiaqS.jpg
