### PR TITLE
Improved web app support on iOS

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -105,6 +105,13 @@ body {
 	  * See http://stackoverflow.com/a/29313685/1935861
 	  */
 	overflow: hidden; /* iOS Safari requires overflow rather than overflow-y */
+
+	/* To support "viewport-fit=cover" */
+	padding:
+		env(safe-area-inset-top)
+		env(safe-area-inset-right)
+		env(safe-area-inset-bottom)
+		env(safe-area-inset-left);
 }
 
 a,
@@ -2476,6 +2483,13 @@ part/quit messages where we don't load previews (adds a blank line otherwise) */
 	font-size: 12px;
 }
 
+@media (display-mode: standalone) {
+	/* When running as a web app with "viewport-fit=cover" */
+	body {
+		height: 100vh;
+	}
+}
+
 @media (min-width: 480px) {
 	/* Fade out for long usernames */
 	#chat .from {
@@ -2515,6 +2529,22 @@ part/quit messages where we don't load previews (adds a blank line otherwise) */
 	.textcomplete-menu,
 	.messages .msg {
 		font-size: 15px;
+	}
+
+	@media (display-mode: standalone) {
+		#viewport > * {
+			padding-top: env(safe-area-inset-top);
+		}
+
+		#sidebar {
+			height: 100vh;
+			max-height: 100vh;
+		}
+
+		body {
+			height: 100vh;
+			padding-top: 0;
+		}
 	}
 
 	#sidebar {

--- a/client/index.html.tpl
+++ b/client/index.html.tpl
@@ -3,7 +3,7 @@
 	<head>
 
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, user-scalable=no">
+	<meta name="viewport" content="width=device-width, user-scalable=no, viewport-fit=cover">
 
 	<link rel="preload" as="script" href="js/loading-error-handlers.js?v=<%- cacheBust %>">
 	<link rel="preload" as="script" href="js/bundle.vendor.js?v=<%- cacheBust %>">


### PR DESCRIPTION
This improves the style when running as a web app on iOS.

Examples:
Current version: https://ibin.co/5Gkr15GfgtTp.jpg
New version: https://ibin.co/5Gkr5ldAE0hR.jpg
New version: https://ibin.co/5Gkr9pHK9QyE.jpg

It does this by adding `viewport-fit=cover` to the HTML and adding custom css to support this viewport setting. I tested this to make sure nothing broke on desktop (Firefox) and iPhone/iPad (Safari, Firefox, and as a web app). If it is to be merged, it should also be tested on other platforms/browsers.