### PR TITLE
Implement native app badges for highlights (Chrome 81+)

### DIFF
--- a/client/js/vue.js
+++ b/client/js/vue.js
@@ -100,6 +100,14 @@ store.watch(
 	(_, getters) => getters.highlightCount,
 	(highlightCount) => {
 		favicon.setAttribute("href", highlightCount > 0 ? faviconAlerted : faviconNormal);
+
+		if (navigator.setAppBadge) {
+			if (highlightCount > 0) {
+				navigator.setAppBadge(highlightCount);
+			} else {
+				navigator.clearAppBadge();
+			}
+		}
 	}
 );
 


### PR DESCRIPTION
This needs some testing to see whether the app badge clears out when expected and stuff like that.

~~I'm unsure if app badge over service worker works correctly, will probably remove it later (especially because we have no way to clear it at the moment).~~

Fixes #2933