### PR TITLE
Exclude node 10 on macOS from build matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,9 @@ jobs:
             10.x, # EOL: April 2021
             12.x, # EOL: April 2022
           ]
+        exclude:
+          - os: macOS-latest
+            node_version: 10.x
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
macOS builds are slow, so let's consume less build slots.