### PR TITLE
Optimize user list updates for quit/part/kick events

### DIFF
--- a/client/js/socket-events/msg.js
+++ b/client/js/socket-events/msg.js
@@ -85,12 +85,8 @@ socket.on("msg", function(data) {
 		channel.moreHistoryAvailable = true;
 	}
 
-	if ((data.msg.type === "message" || data.msg.type === "action") && channel.type === "channel") {
-		const user = channel.users.find((u) => u.nick === data.msg.from.nick);
-
-		if (user) {
-			user.lastMessage = new Date(data.msg.time).getTime() || Date.now();
-		}
+	if (channel.type === "channel") {
+		updateUserList(channel, data.msg);
 	}
 });
 
@@ -166,6 +162,28 @@ function notifyMessage(targetId, channel, activeChannel, msg) {
 					// `new Notification(...)` is not supported and should be silenced.
 				}
 			}
+		}
+	}
+}
+
+function updateUserList(channel, msg) {
+	if (msg.type === "message" || msg.type === "action") {
+		const user = channel.users.find((u) => u.nick === msg.from.nick);
+
+		if (user) {
+			user.lastMessage = new Date(msg.time).getTime() || Date.now();
+		}
+	} else if (msg.type === "quit" || msg.type === "part") {
+		const idx = channel.users.findIndex((u) => u.nick === msg.from.nick);
+
+		if (idx > -1) {
+			channel.users.splice(idx, 1);
+		}
+	} else if (msg.type === "kick") {
+		const idx = channel.users.findIndex((u) => u.nick === msg.target.nick);
+
+		if (idx > -1) {
+			channel.users.splice(idx, 1);
 		}
 	}
 }

--- a/src/plugins/irc-events/kick.js
+++ b/src/plugins/irc-events/kick.js
@@ -35,9 +35,5 @@ module.exports = function(irc, network) {
 		} else {
 			chan.removeUser(msg.target);
 		}
-
-		client.emit("users", {
-			chan: chan.id,
-		});
 	});
 };

--- a/src/plugins/irc-events/part.js
+++ b/src/plugins/irc-events/part.js
@@ -33,9 +33,6 @@ module.exports = function(irc, network) {
 			});
 		} else {
 			chan.removeUser(user);
-			client.emit("users", {
-				chan: chan.id,
-			});
 		}
 	});
 };

--- a/src/plugins/irc-events/quit.js
+++ b/src/plugins/irc-events/quit.js
@@ -23,9 +23,6 @@ module.exports = function(irc, network) {
 			chan.pushMessage(client, msg);
 
 			chan.removeUser(user);
-			client.emit("users", {
-				chan: chan.id,
-			});
 		});
 
 		// If user with the nick we are trying to keep has quit, try to get this nick


### PR DESCRIPTION
Instead of requesting the user list again, it just removes the target user from the list.