### PR TITLE
Move mentions loading text out of header

### DIFF
--- a/client/components/Mentions.vue
+++ b/client/components/Mentions.vue
@@ -8,10 +8,10 @@
 		<div class="mentions-popup">
 			<div class="mentions-popup-title">
 				Recent mentions
-				<span v-if="isLoading">- Loading…</span>
 			</div>
 			<template v-if="resolvedMessages.length === 0">
-				<p>There are no recent mentions.</p>
+				<p v-if="isLoading">Loading…</p>
+				<p v-else>There are no recent mentions.</p>
 			</template>
 			<template v-for="message in resolvedMessages" v-else>
 				<div :key="message.id" :class="['msg', message.type]">


### PR DESCRIPTION
Makes it less obvious when the text updates 