### PR TITLE
Render sidebar over the mentions popup on mobile

### DIFF
--- a/client/components/Mentions.vue
+++ b/client/components/Mentions.vue
@@ -43,6 +43,10 @@
 </template>
 
 <style>
+#mentions-popup-container {
+	z-index: 8;
+}
+
 .mentions-popup {
 	background-color: var(--window-bg-color);
 	position: absolute;


### PR DESCRIPTION
You can swipe when mentions are open, and the sidebar would appear under the mentions.