### PR TITLE
Fix off-by-one color error in webmanifest

### DIFF
--- a/client/index.html.tpl
+++ b/client/index.html.tpl
@@ -22,7 +22,7 @@
 	<link id="favicon" rel="icon" sizes="16x16 32x32 64x64" href="favicon.ico" data-other="img/favicon-alerted.ico" type="image/x-icon">
 
 	<!-- Safari pinned tab icon -->
-	<link rel="mask-icon" href="img/icon-black-transparent-bg.svg" color="#415363">
+	<link rel="mask-icon" href="img/icon-black-transparent-bg.svg" color="#415364">
 
 	<link rel="manifest" href="thelounge.webmanifest">
 

--- a/client/thelounge.webmanifest
+++ b/client/thelounge.webmanifest
@@ -4,8 +4,8 @@
 	"description": "Self-hosted web IRC client",
 	"start_url": ".",
 	"display": "standalone",
-	"theme_color": "#415363",
-	"background_color": "#415363",
+	"theme_color": "#415364",
+	"background_color": "#415364",
 	"icons": [
 		{
 			"src": "img/logo-grey-bg-120x120px.png",


### PR DESCRIPTION
I don't know why that came to be and why it haven't been noticed before, but the color in the manifest is one shade of blue off from the icon, leaving a visible square around the logo while the app is loading:

![Screenshot_20200419-175024_Chrome](https://user-images.githubusercontent.com/5481612/79701264-af278080-8269-11ea-9cfb-9146ae50d95d.jpg)

I've recently started noticing it, and other users of my instance did too. Checking the colors in an image editor shows that the values are way off. Maybe Chrome added something that causes images to get a bit oversaturated to make them more vivid?

Anyway, that fixes it to the right color, and the square is now gone.