### PR TITLE
Fix msg id order when loading from sqlite

### DIFF
--- a/src/plugins/messageStorage/sqlite.js
+++ b/src/plugins/messageStorage/sqlite.js
@@ -183,18 +183,16 @@ class MessageStorage {
 						}
 
 						resolve(
-							rows
-								.map((row) => {
-									const msg = JSON.parse(row.msg);
-									msg.time = row.time;
-									msg.type = row.type;
+							rows.reverse().map((row) => {
+								const msg = JSON.parse(row.msg);
+								msg.time = row.time;
+								msg.type = row.type;
 
-									const newMsg = new Msg(msg);
-									newMsg.id = this.client.idMsg++;
+								const newMsg = new Msg(msg);
+								newMsg.id = this.client.idMsg++;
 
-									return newMsg;
-								})
-								.reverse()
+								return newMsg;
+							})
 						);
 					}
 				)


### PR DESCRIPTION
Ids were incremented and then the mesage list was reversed. The fix is to reverse the list first.