### PR TITLE
Make usernames case-insensitive when logging in

### DIFF
--- a/src/clientManager.js
+++ b/src/clientManager.js
@@ -34,17 +34,39 @@ ClientManager.prototype.init = function (identHandler, sockets) {
 };
 
 ClientManager.prototype.findClient = function (name) {
-	return this.clients.find((u) => u.name === name);
+	name = name.toLowerCase();
+	return this.clients.find((u) => u.name.toLowerCase() === name);
 };
 
 ClientManager.prototype.loadUsers = function () {
-	const users = this.getUsers();
+	let users = this.getUsers();
 
 	if (users.length === 0) {
 		log.info(
 			`There are currently no users. Create one with ${colors.bold("thelounge add <name>")}.`
 		);
+
+		return;
 	}
+
+	const alreadySeenUsers = new Set();
+	users = users.filter((user) => {
+		user = user.toLowerCase();
+
+		if (alreadySeenUsers.has(user)) {
+			log.error(
+				`There is more than one user named "${colors.bold(
+					user
+				)}". Usernames are now case insensitive, duplicate users will not load.`
+			);
+
+			return false;
+		}
+
+		alreadySeenUsers.add(user);
+
+		return true;
+	});
 
 	// This callback is used by Auth plugins to load users they deem acceptable
 	const callbackLoadUser = (user) => {

--- a/src/server.js
+++ b/src/server.js
@@ -803,6 +803,10 @@ function performAuthentication(data) {
 		return;
 	}
 
+	if (typeof data.user !== "string") {
+		return;
+	}
+
 	const authCallback = (success) => {
 		// Authorization failed
 		if (!success) {


### PR DESCRIPTION
Fixes #2943

**What is the fix:**
For a new user, a profile will be created in thelounge and every time the same profile will be loaded irrespective of the username case.
For an existing user, one of his/her profile will be loaded irrespective of the username case. Further, duplicate profiles of the user will be removed.