### PR TITLE
Allow changing network name in private mode with lockNetwork

### DIFF
--- a/client/components/NetworkForm.vue
+++ b/client/components/NetworkForm.vue
@@ -11,7 +11,9 @@
 				</template>
 				<template v-else>
 					Connect
-					<template v-if="config.lockNetwork">to {{ defaults.name }}</template>
+					<template v-if="config.lockNetwork && $store.state.serverConfiguration.public">
+						to {{ defaults.name }}
+					</template>
 				</template>
 			</h1>
 			<template v-if="!config.lockNetwork">
@@ -95,6 +97,19 @@
 							Only allow trusted certificates
 						</label>
 					</div>
+				</div>
+			</template>
+			<template v-else-if="config.lockNetwork && !$store.state.serverConfiguration.public">
+				<h2>Network settings</h2>
+				<div class="connect-row">
+					<label for="connect:name">Name</label>
+					<input
+						id="connect:name"
+						v-model="defaults.name"
+						class="input"
+						name="name"
+						maxlength="100"
+					/>
 				</div>
 			</template>
 

--- a/client/components/NetworkForm.vue
+++ b/client/components/NetworkForm.vue
@@ -111,6 +111,23 @@
 						maxlength="100"
 					/>
 				</div>
+				<div class="connect-row">
+					<label for="connect:password">Password</label>
+					<RevealPassword
+						v-slot:default="slotProps"
+						class="input-wrap password-container"
+					>
+						<input
+							id="connect:password"
+							v-model="defaults.password"
+							class="input"
+							:type="slotProps.isVisible ? 'text' : 'password'"
+							placeholder="Server password (optional)"
+							name="password"
+							maxlength="300"
+						/>
+					</RevealPassword>
+				</div>
 			</template>
 
 			<h2>User preferences</h2>

--- a/src/models/network.js
+++ b/src/models/network.js
@@ -120,7 +120,12 @@ Network.prototype.validate = function (client) {
 			return false;
 		}
 
-		this.name = Helper.config.defaults.name;
+		if (Helper.config.public) {
+			this.name = Helper.config.defaults.name;
+			// Sync lobby channel name
+			this.channels[0].name = Helper.config.defaults.name;
+		}
+
 		this.host = Helper.config.defaults.host;
 		this.port = Helper.config.defaults.port;
 		this.tls = Helper.config.defaults.tls;


### PR DESCRIPTION
People use bouncers like ZNC which allow multiple networks on same hostname (localhost), so makes sense to allow renaming it.
In 4.1.0 network name was not enforced, this only changed in master.

Also brings back the server password field.

@Jay2k1 pls test