### PR TITLE
Add option to disable media preview.

### DIFF
--- a/defaults/config.js
+++ b/defaults/config.js
@@ -110,6 +110,18 @@ module.exports = {
 	// This value is set to `false` by default.
 	prefetch: false,
 
+	// ### `disableMediaPreview`
+	//
+	// When set to `true`, The Lounge will not preview media (images, video and
+	// audio) hosted on third-party sites. This ensures the client does not
+	// make any requests to external sites. If `prefetchStorage` is enabled,
+	// images proxied via the The Lounge will be previewed.
+	//
+	// This has no effect if `prefetch` is set to `false`.
+	//
+	// This value is set to `false` by default.
+	disableMediaPreview: false,
+
 	// ### `prefetchStorage`
 
 	// When set to `true`, The Lounge will store and proxy prefetched images and


### PR DESCRIPTION
This disables image previews iff prefetchStorage is disabled. This
stops the client from making any requests to third-party sites.

The change is backwards comaptible. Existing config files will have
disableMediaPreview set to `undefined`, which is functionally equivalent
to `false`.

Help wih setting up tests would be appreciated. I couldn't figure out how to
test that a preview is *not* displayed.
