### PR TITLE
Refresh notification permission state when push is enabled

### DIFF
--- a/client/js/webpush.js
+++ b/client/js/webpush.js
@@ -73,11 +73,13 @@ function togglePushSubscription() {
 					.then((subscription) => {
 						socket.emit("push:register", subscription.toJSON());
 						store.commit("pushNotificationState", "subscribed");
+						store.commit("refreshDesktopNotificationState");
 					});
 			})
 		)
 		.catch((err) => {
 			store.commit("pushNotificationState", "unsupported");
+			store.commit("refreshDesktopNotificationState");
 			console.error(err); // eslint-disable-line no-console
 		});
 }


### PR DESCRIPTION
When you subscribe to push notifications, you have to grant the notification permission, and with that we can hide the "your browser blocks notifs" under deskop notifications checkbox.