### PR TITLE
Disable settings sync for browser notifications and notification sound

### DIFF
--- a/client/js/settings.js
+++ b/client/js/settings.js
@@ -31,6 +31,7 @@ export const config = normalizeConfig({
 	},
 	desktopNotifications: {
 		default: false,
+		sync: "never",
 		apply(store, value) {
 			store.commit("refreshDesktopNotificationState", null, {root: true});
 
@@ -57,6 +58,7 @@ export const config = normalizeConfig({
 	},
 	notification: {
 		default: true,
+		sync: "never",
 	},
 	notifyAllMessages: {
 		default: false,


### PR DESCRIPTION
Closes #3144.

Not everyone wants notifications to come on all devices, and it makes sense to control them per-device (login) especially as they also require browser permission.

Yes this is already possible by disabling sync entirely, but that's not really user friendly.