### PR TITLE
Skip video/audio embeds if og:type exists but does not specify it

### DIFF
--- a/src/plugins/irc-events/link.js
+++ b/src/plugins/irc-events/link.js
@@ -131,6 +131,7 @@ function parseHtmlMedia($, preview, client) {
 	return new Promise((resolve, reject) => {
 		if (Helper.config.disableMediaPreview) {
 			reject();
+			return;
 		}
 
 		let foundMedia = false;

--- a/src/plugins/irc-events/link.js
+++ b/src/plugins/irc-events/link.js
@@ -134,6 +134,19 @@ function parseHtmlMedia($, preview, client) {
 		}
 
 		let foundMedia = false;
+		const openGraphType = $('meta[property="og:type"]').attr("content");
+
+		// Certain news websites may include video and audio tags,
+		// despite actually being an article (as indicated by og:type).
+		// If there is og:type tag, we will only select video or audio if it matches
+		if (
+			openGraphType &&
+			!openGraphType.startsWith("video") &&
+			!openGraphType.startsWith("music")
+		) {
+			reject();
+			return;
+		}
 
 		["video", "audio"].forEach((type) => {
 			if (foundMedia) {


### PR DESCRIPTION
This removes daily embeds for dailymail, which has video tags, but also all other tags and og:type is article.