### PR TITLE
Run /topic when clicking on topic

### DIFF
--- a/client/components/Chat.vue
+++ b/client/components/Chat.vue
@@ -33,7 +33,7 @@
 							<span type="button" aria-label="Save topic"></span>
 						</span>
 					</div>
-					<span v-else :title="channel.topic" class="topic" @dblclick="editTopic"
+					<span v-else :title="channel.topic" class="topic" @click.self="showTopic"
 						><ParsedMessage
 							v-if="channel.topic"
 							:network="network"
@@ -183,10 +183,14 @@ export default {
 		hideUserVisibleError() {
 			this.$store.commit("currentUserVisibleError", null);
 		},
-		editTopic() {
-			if (this.channel.type === "channel") {
-				this.channel.editTopic = true;
+		showTopic() {
+			if (this.channel.type !== "channel" || !this.channel.topic) {
+				return;
 			}
+
+			const target = this.channel.id;
+			const text = `/raw TOPIC ${this.channel.name}`;
+			socket.emit("input", {target, text});
 		},
 		saveTopic() {
 			this.channel.editTopic = false;

--- a/client/css/style.css
+++ b/client/css/style.css
@@ -1045,6 +1045,7 @@ textarea.input {
 	flex-grow: 1;
 	overflow: hidden;
 	font-size: 14px;
+	cursor: pointer;
 }
 
 .header .topic-input {


### PR DESCRIPTION
Closes #276.

This came as a result from some discussion on IRC. Click to show dialog/prompt is somewhat bulky. `:hover` based solution is rather hacky in itself. Click-to-expand would require quite a bit of changes because we wouldn't want to make the topic squished between channel name and buttons.

Do we want to implement some timer code to keep double click to edit functionality? You can still edit from the context menu.