### PR TITLE
Do not generate and send client certificate unless SASL EXTERNAL is requested

### DIFF
--- a/src/models/network.js
+++ b/src/models/network.js
@@ -204,8 +204,7 @@ Network.prototype.setIrcFrameworkOptions = function (client) {
 	this.irc.options.tls = this.tls;
 	this.irc.options.rejectUnauthorized = this.rejectUnauthorized;
 	this.irc.options.webirc = this.createWebIrc(client);
-
-	this.irc.options.client_certificate = this.tls ? ClientCertificate.get(this.uuid) : null;
+	this.irc.options.client_certificate = null;
 
 	if (!this.sasl) {
 		delete this.irc.options.sasl_mechanism;
@@ -213,6 +212,7 @@ Network.prototype.setIrcFrameworkOptions = function (client) {
 	} else if (this.sasl === "external") {
 		this.irc.options.sasl_mechanism = "EXTERNAL";
 		this.irc.options.account = {};
+		this.irc.options.client_certificate = ClientCertificate.get(this.uuid);
 	} else if (this.sasl === "plain") {
 		delete this.irc.options.sasl_mechanism;
 		this.irc.options.account = {


### PR DESCRIPTION
Fixes #4092

Disabling SASL EXTERNAL will not remove the certificate, in case user wants to re-enable it again.

@stevenengler care to test?