### PR TITLE
Add extended join information to join message

### DIFF
--- a/client/components/MessageTypes/join.vue
+++ b/client/components/MessageTypes/join.vue
@@ -2,6 +2,12 @@
 	<span class="content">
 		<Username :user="message.from" />
 		<i class="hostmask"> ({{ message.hostmask }})</i>
+		<template v-if="message.account !== false">
+			<i class="account"> [{{ message.account }}]</i>
+		</template>
+		<template v-if="message.gecos !== false">
+			<i class="realname"> {{ message.gecos }} -</i>
+		</template>
 		has joined the channel
 	</span>
 </template>

--- a/src/plugins/irc-events/join.js
+++ b/src/plugins/irc-events/join.js
@@ -41,6 +41,8 @@ module.exports = function (irc, network) {
 			time: data.time,
 			from: user,
 			hostmask: data.ident + "@" + data.hostname,
+			gecos: data.gecos,
+			account: data.account,
 			type: Msg.Type.JOIN,
 			self: data.nick === irc.user.nick,
 		});


### PR DESCRIPTION
PR adds extended join information to join messages. Order can be changed if desired. 

Fixes https://github.com/thelounge/thelounge/issues/3700

![image](https://user-images.githubusercontent.com/29105935/99600948-b4ff6300-29fe-11eb-8027-90fb037d1a71.png)
