### PR TITLE
Fix breaking GIFs while removing metadata

### DIFF
--- a/client/js/upload.js
+++ b/client/js/upload.js
@@ -141,7 +141,8 @@ class Uploader {
 		if (
 			store.state.settings.uploadCanvas &&
 			file.type.startsWith("image/") &&
-			!file.type.includes("svg")
+			!file.type.includes("svg") &&
+			file.type !== "image/gif"
 		) {
 			this.renderImage(file, (newFile) => this.performUpload(token, newFile));
 		} else {


### PR DESCRIPTION
Closes #4109
GIFs can't contain EXIF data and do not contain any other metadata that isn't operational