### PR TITLE
Add a configuration option to set the socket file permissions

### DIFF
--- a/defaults/config.js
+++ b/defaults/config.js
@@ -35,6 +35,13 @@ module.exports = {
 	// This value is set to `9000` by default.
 	port: 9000,
 
+	// ### `socketPermissions`
+	//
+	// Set the permissions of the UNIX domain socket.
+	//
+	// This value is set to `0o660` by default.
+	socketPermissions: 0o660,
+
 	// ### `bind`
 	//
 	// Set the local IP to bind to for outgoing connections.

--- a/defaults/config.js
+++ b/defaults/config.js
@@ -38,6 +38,7 @@ module.exports = {
 	// ### `socketPermissions`
 	//
 	// Set the permissions of the UNIX domain socket.
+	// Only applies if the `host` option is a UNIX domain socket.
 	//
 	// This value is set to `0o660` by default.
 	socketPermissions: 0o660,

--- a/src/server.js
+++ b/src/server.js
@@ -148,6 +148,12 @@ module.exports = function (options = {}) {
 	server.listen(listenParams, () => {
 		if (typeof listenParams === "string") {
 			log.info("Available on socket " + colors.green(listenParams));
+			fs.chmod(listenParams, Helper.config.socketPermissions, (err) => {
+				if (err) {
+					log.error(`fs chmod error: ${err}. Stopping server...`);
+					process.exit(1);
+				}
+			});
 		} else {
 			const protocol = Helper.config.https.enable ? "https" : "http";
 			const address = server.address();


### PR DESCRIPTION
In my FreeBSD Jail I have the problem that the UDS has wrong file permissions after starting this app.
`660` works such that the thelounge user can use the socket as well as the www group of the nginx proxy. 