### PR TITLE
Intercept ZNC *buffextras join messages

### DIFF
--- a/src/plugins/irc-events/message.js
+++ b/src/plugins/irc-events/message.js
@@ -60,6 +60,27 @@ module.exports = function (irc, network) {
 				return;
 			}
 
+			// Intercept ZNC *buffextras messages and turn them into native messages
+			if (data.type === Msg.Type.MESSAGE && data.nick === "*buffextras") {
+				const joinMatch = data.message.match(/^(.+) joined$/);
+
+				if (joinMatch) {
+					const parsedHostmask = Helper.parseHostmask(joinMatch[1]);
+					irc.emit("join", {
+						nick: parsedHostmask.nick,
+						ident: parsedHostmask.ident,
+						hostname: parsedHostmask.hostname,
+						channel: data.target,
+						gecos: false, // Gets rid of " -" after the hostmask in the web UI
+						account: false, // Ditto "[]" in the same place
+						time: data.time,
+						tags: data.tags,
+					});
+
+					return;
+				}
+			}
+
 			let target = data.target;
 
 			// If the message is targeted at us, use sender as target instead


### PR DESCRIPTION
This PR begins implementing the feature suggested in #4123. It only does join messages for now because it's actually surprisingly tedious to write these conversions (I had to read a bunch of ZNC source code) and I wanted feedback on whether this is a good direction to go. If yes, then I'll polish up the WIP code I have to handle mode change messages, look into writing some tests, and maybe write a few more conversions if I have time.

Note that despite (because of?) the lack of test suite updates, this code _has_ been manually tested.