### PR TITLE
allow setting permissions bits of created UNIX sockets

### DIFF
--- a/defaults/config.js
+++ b/defaults/config.js
@@ -35,6 +35,18 @@ module.exports = {
 	// This value is set to `9000` by default.
 	port: 9000,
 
+	// ### `socketPermissions`
+	//
+	// Set the permissions for the UNIX domain socket. Ignored when `host` is set
+	// to an IP address or hostname.
+	// When the value is not set (i.e. `undefined`) the permissions will not be
+	// changed and will default to whatever permissions the operating system uses.
+	//
+	// Example: Set this to `0o660` to allow read/write access for the owner and
+	//          the group and disallow access for anyone else.
+	//
+	socketPermissions: undefined,
+
 	// ### `bind`
 	//
 	// Set the local IP to bind to for outgoing connections.

--- a/src/server.js
+++ b/src/server.js
@@ -132,6 +132,7 @@ module.exports = function (options = {}) {
 	}
 
 	let listenParams;
+	const socketPermissions = Helper.config.socketPermissions;
 
 	if (typeof Helper.config.host === "string" && Helper.config.host.startsWith("unix:")) {
 		listenParams = Helper.config.host.replace(/^unix:/, "");
@@ -140,12 +141,20 @@ module.exports = function (options = {}) {
 			port: Helper.config.port,
 			host: Helper.config.host,
 		};
+
+		if (socketPermissions !== undefined) {
+			log.warn("socketPermissions has no effect when a HTTP(S) socket is used.");
+		}
 	}
 
 	server.on("error", (err) => log.error(`${err}`));
 
 	server.listen(listenParams, () => {
 		if (typeof listenParams === "string") {
+			if (socketPermissions !== undefined) {
+				fs.chmodSync(listenParams, socketPermissions);
+			}
+
 			log.info("Available on socket " + colors.green(listenParams));
 		} else {
 			const protocol = Helper.config.https.enable ? "https" : "http";


### PR DESCRIPTION
This PR adds a new configuration option `socketPermissions` which can be used to change the permissions bits on created UNIX sockets.
I personally run thelounge behind an nginx proxy through a UNIX socket and would like to lock down its permissions to 0660. I can then add the `nginx` user to the `thelounge` group. Right now the socket is created with 0776 by default my machine.

This change is backwards compatible since a default value of `undefined` for `socketPermissions` will just skip the chmod. I have additionally added a warning if someone tries to configure `socketPermissions` together with a HTTP(S) socket.

This has originally been requested in #3626.