### PR TITLE
Visually distinguish channel names

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -1364,6 +1364,10 @@ textarea.input {
 
 /* Parsed nicks and channels */
 
+.inline-channel {
+	font-weight: bold;
+}
+
 #chat .user,
 .inline-channel {
 	cursor: pointer;


### PR DESCRIPTION
It's hard to distinguish inline channel mentions whereas users are highlighted with colours. Because channels don't have colours assigned I thought that making them bold is the most forward way to highlight them. 

Before
---
![image](https://user-images.githubusercontent.com/9467802/103215709-6eadf580-4914-11eb-8109-c27746e06801.png)

After
---
![image](https://user-images.githubusercontent.com/9467802/103215710-6f468c00-4914-11eb-9873-1b79cc855471.png)
