### PR TITLE
Add prefetchMaxSearchSize to override limit for link previews

### DIFF
--- a/defaults/config.js
+++ b/defaults/config.js
@@ -150,6 +150,14 @@ module.exports = {
 	// This value is set to `2048` kilobytes by default.
 	prefetchMaxImageSize: 2048,
 
+	// ### prefetchMaxSearchSize
+	//
+	// This value controls the maximum request size made to find the link preview
+	// Open Graph tags. For some sites like YouTube this can easily exceed 300 kilobytes.
+	//
+	// This value is set to 50 kilobytes by default.
+	prefetchMaxSearchSize: 50,
+
 	// ### `fileUpload`
 	//
 	// Allow uploading files to the server hosting The Lounge.

--- a/defaults/config.js
+++ b/defaults/config.js
@@ -152,10 +152,11 @@ module.exports = {
 
 	// ### prefetchMaxSearchSize
 	//
-	// This value controls the maximum request size made to find the link preview
-	// Open Graph tags. For some sites like YouTube this can easily exceed 300 kilobytes.
+	// This value sets the maximum request size made to find the Open Graph tags
+	// for link previews. For some sites like YouTube this can easily exceed 300
+	// kilobytes.
 	//
-	// This value is set to 50 kilobytes by default.
+	// This value is set to `50` kilobytes by default.
 	prefetchMaxSearchSize: 50,
 
 	// ### `fileUpload`

--- a/src/plugins/irc-events/link.js
+++ b/src/plugins/irc-events/link.js
@@ -407,9 +407,14 @@ function fetch(uri, headers) {
 						// We don't need to download the file any further after we received content-type header
 						gotStream.destroy();
 					} else {
-						// if not image, limit download to 50kb, since we need only meta tags
-						// twitter.com sends opengraph meta tags within ~20kb of data for individual tweets
-						limit = 1024 * 50;
+						// if not image, limit download to the max search size, since we need only meta tags
+						// twitter.com sends opengraph meta tags within ~20kb of data for individual tweets, the default is set to 50.
+						// for sites like Youtube the og tags are in the first 300K and hence this is configurable by the admin
+						limit =
+							"prefetchMaxSearchSize" in Helper.config
+								? Helper.config.prefetchMaxSearchSize * 1024
+								: // set to the previous size if config option is unset
+								  50 * 1024;
 					}
 				})
 				.on("error", (e) => reject(e))


### PR DESCRIPTION
YouTube puts the opengraph tags needed for the preview after ~300KB in the body
instead of the beginning of the <head> tag.
Instead of hardcoding the value, allow the server admin to set the policy as
they prefer.

Youtube was also kind enough to put the tags in the body instead of the header, so we can't stop once we reach \</head\> either