### PR TITLE
Configure server ping timeout to 60 seconds

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -167,6 +167,7 @@ module.exports = function (options = {}) {
 			cookie: false,
 			serveClient: false,
 			transports: Helper.config.transports,
+			pingTimeout: 60000,
 		});
 
 		sockets.on("connect", (socket) => {


### PR DESCRIPTION
The default socket.io server-side ping timeout was changed from 60 seconds to 5 seconds. In browsers based on Chrome, this is not enough time to respond when the browser is idle. The end result is that the server sets the user away and then back approximately once every minute if the client window is idle, which is undesirable.

This change restores the previous timeout value.

See https://github.com/socketio/socket.io/issues/3259#issuecomment-474523271.