### PR TITLE
Support file uploads to dumpinen.com

### DIFF
--- a/client/js/socket-events/configuration.js
+++ b/client/js/socket-events/configuration.js
@@ -12,7 +12,7 @@ socket.once("configuration", function (data) {
 	store.dispatch("settings/applyAll");
 
 	if (data.fileUpload) {
-		upload.initialize();
+		upload.initialize(data.fileUploadOptions);
 	}
 
 	// If localStorage contains a theme that does not exist on this server, switch

--- a/defaults/config.js
+++ b/defaults/config.js
@@ -172,10 +172,13 @@ module.exports = {
 	//   If you use this option, you must have a reverse proxy configured,
 	//   to correctly proxy the uploads URLs back to The Lounge.
 	//   This value is set to `null` by default.
+	// - `useDumpinen`: The client will upload the file to
+	//   https://dumpinen.com if set to `true`.
 	fileUpload: {
 		enable: false,
 		maxFileSize: 10240,
 		baseUrl: null,
+		useDumpinen: false,
 	},
 
 	// ### `transports`


### PR DESCRIPTION
This PR makes it possible to configure the clients to upload files to dumpinen.com instead of the self hosted file storage in the lounge.

dumpinen.com is a lightweight file dumping service, kind of like pastebin.com but without ads and the ability to dump all kind of files.