### PR TITLE
Allow animated webp

### DIFF
--- a/client/js/upload.js
+++ b/client/js/upload.js
@@ -2,6 +2,7 @@
 
 import {update as updateCursor} from "undate";
 
+import ExifReader from "exifreader";
 import socket from "./socket";
 import store from "./store";
 
@@ -141,10 +142,18 @@ class Uploader {
 		if (
 			store.state.settings.uploadCanvas &&
 			file.type.startsWith("image/") &&
-			!file.type.includes("svg") &&
-			file.type !== "image/gif"
+			!file.type.includes("svg")
 		) {
-			this.renderImage(file, (newFile) => this.performUpload(token, newFile));
+			file.arrayBuffer().then((buffer) => {
+				try {
+					ExifReader.load(buffer);
+				} catch (e) {
+					this.performUpload(token, file);
+					return;
+				}
+
+				this.renderImage(file, (newFile) => this.performUpload(token, newFile));
+			});
 		} else {
 			this.performUpload(token, file);
 		}

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "chalk": "4.1.0",
     "cheerio": "1.0.0-rc.5",
     "commander": "7.1.0",
+    "exifreader": "3.14.1",
     "express": "4.17.1",
     "file-type": "16.2.0",
     "filenamify": "4.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3294,6 +3294,13 @@ execall@^2.0.0:
   dependencies:
     clone-regexp "^2.1.0"
 
+exifreader@3.14.1:
+  version "3.14.1"
+  resolved "https://registry.yarnpkg.com/exifreader/-/exifreader-3.14.1.tgz#3c2a81600bce04044cb01030399b6c01f2f605b7"
+  integrity sha512-SUxpOk39IvFc+KqglisSy42P8nNTrX/8HC6VijSQUzDRBolqa0ps7M8patMWCZ4NKuleLVq6qR41pOvF5ITdKg==
+  optionalDependencies:
+    xmldom "^0.1.31"
+
 express@4.17.1:
   version "4.17.1"
   resolved "https://registry.yarnpkg.com/express/-/express-4.17.1.tgz#4491fc38605cf51f8629d39c2b5d026f98a4c134"
@@ -8403,6 +8410,11 @@ ws@~7.4.2:
   version "7.4.3"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.3.tgz#1f9643de34a543b8edb124bdcbc457ae55a6e5cd"
   integrity sha512-hr6vCR76GsossIRsr8OLR9acVVm1jyfEWvhbNjtgPOrfvAlKzvyeg/P6r8RuDjRyrcQoPQT7K0DGEPc7Ae6jzA==
+
+xmldom@^0.1.31:
+  version "0.1.31"
+  resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.1.31.tgz#b76c9a1bd9f0a9737e5a72dc37231cf38375e2ff"
+  integrity sha512-yS2uJflVQs6n+CyjHoaBmVSqIDevTAWrzMmjG1Gc7h1qQ7uVozNhEPJAwZXWyGQ/Gafo3fCwrcaokezLPupVyQ==
 
 xmlhttprequest-ssl@~1.5.4:
   version "1.5.5"


### PR DESCRIPTION
Webp can be animated (just like gifs but better) but up until now, they were run through a canvas and thus the animation was lost. Webp can contain exif/xmp/icc etc (https://developers.google.com/speed/webp/docs/webpmux). and thus we want to be able to remove the data. The problem here is, there is no js library out there to remove the metadata from the, only read. So instead we read the metadata from the image and then decide wether or not we want to run in through a canvas. So this means if:
- animated / metadata => static / no metadata
- animate / no metadata => animated / no metadata

Examples:
animated / metadata: https://files.catbox.moe/lap1sg.webp
animated / no metadata: https://files.catbox.moe/pvdscf.webp

ℹ️ If you know about a JS Metadata removal tool that supports webp please tell me so I can replace this PR. 