### PR TITLE
Fix client crash when opening a user context menu in query

### DIFF
--- a/client/js/helpers/contextMenu.js
+++ b/client/js/helpers/contextMenu.js
@@ -245,8 +245,8 @@ export function generateUserContextMenu($root, channel, network, user) {
 		},
 	];
 
-	// Bail because we don't have a special mode.
-	if (currentChannelUser.modes.length < 1) {
+	// Bail because we're in a query or we don't have a special mode.
+	if (!currentChannelUser.modes || currentChannelUser.modes.length < 1) {
 		return items;
 	}
 


### PR DESCRIPTION
Introduced in #4176. Users in queries don't have the`modes` property.