### PR TITLE
Add proper filename to the content-disposition header

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "chalk": "4.1.0",
     "cheerio": "1.0.0-rc.5",
     "commander": "7.2.0",
+    "content-disposition": "0.5.3",
     "express": "4.17.1",
     "file-type": "16.2.0",
     "filenamify": "4.2.0",

--- a/src/plugins/uploader.js
+++ b/src/plugins/uploader.js
@@ -20,6 +20,7 @@ const inlineContentDispositionTypes = {
 	"audio/mpeg": "audio.mp3",
 	"audio/ogg": "audio.ogg",
 	"audio/vnd.wave": "audio.wav",
+	"audio/flac": "audio.flac",
 	"image/bmp": "image.bmp",
 	"image/gif": "image.gif",
 	"image/jpeg": "image.jpg",


### PR DESCRIPTION
By default we take the slug given in the request, if this is not set we try to give a filename from known types.
If we still have no filename we fallback to the previous method of setting no filename.

If the filename is non ascii we will only create the encoded "filename*" and not the ascii only "filename". This is to prevent other applications to save a file like "?????.png" if the filename contains non ascii chars.

For the browsers nothing will really change compared to the behaviour before this change as good fallbacks if no content-disposition filename is set. But that is not the case for all application, thus it makes sense to include the proper way to set the filename.

Examples: 
```
# Non-ASCII
http://localhost:9999/uploads/3dc8f9633fa0ef19/るしあちゃん　twitter落書き　まとめ_84551246_p1.jpg
inline; filename*=UTF-8''%E3%82%8B%E3%81%97%E3%81%82%E3%81%A1%E3%82%83%E3%82%93%E3%80%80twitter%E8%90%BD%E6%9B%B8%E3%81%8D%E3%80%80%E3%81%BE%E3%81%A8%E3%82%81_84551246_p1.jpg

# ASCII
http://localhost:9999/uploads/3dc8f9633fa0ef19/some_ascii_name.jpg
inline; filename="some_ascii_name.jpg"

# No name
http://localhost:9999/uploads/3dc8f9633fa0ef19/
inline; filename="image.png"

# Not known type without a name
http://localhost:9999/uploads/516bb50c9388dc1c/
attachment
```