### PR TITLE
Connect on lobby disconnected icon click

### DIFF
--- a/client/components/NetworkLobby.vue
+++ b/client/components/NetworkLobby.vue
@@ -20,13 +20,15 @@
 			>
 				<span class="not-secure-icon" />
 			</span>
-			<span
+			<button
 				v-if="!network.status.connected"
 				class="not-connected-tooltip tooltipped tooltipped-w"
-				aria-label="Disconnected"
+				aria-label="Reconnect"
+				:aria-controls="'network-connection-' + network.uuid"
+				@click.stop="onDisconnectedClick"
 			>
 				<span class="not-connected-icon" />
-			</span>
+			</button>
 			<span v-if="channel.unread" :class="{highlight: channel.highlight}" class="badge">{{
 				unreadCount
 			}}</span>
@@ -49,6 +51,7 @@
 import collapseNetwork from "../js/helpers/collapseNetwork";
 import roundBadgeNumber from "../js/helpers/roundBadgeNumber";
 import ChannelWrapper from "./ChannelWrapper.vue";
+import socket from "../js/socket";
 
 export default {
 	name: "Channel",
@@ -75,6 +78,14 @@ export default {
 	methods: {
 		onCollapseClick() {
 			collapseNetwork(this.network, !this.network.isCollapsed);
+		},
+		onDisconnectedClick() {
+			socket.emit("input", {
+				target: this.network.channels.find((channel) => {
+					return channel.type === "lobby";
+				}).id,
+				text: "/connect",
+			});
 		},
 		getExpandLabel(network) {
 			return network.isCollapsed ? "Expand" : "Collapse";


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9467802/113493016-2e927c00-94dc-11eb-874a-98c70eed7866.png)
Us the little disconnected icon to reconnect instead of "right-click => connect"