### PR TITLE
Improved handling of empty userdata

### DIFF
--- a/client/components/MessageTypes/join.vue
+++ b/client/components/MessageTypes/join.vue
@@ -2,11 +2,11 @@
 	<span class="content">
 		<Username :user="message.from" />
 		<i class="hostmask"> ({{ message.hostmask }})</i>
-		<template v-if="message.account !== false">
+		<template v-if="message.account">
 			<i class="account"> [{{ message.account }}]</i>
 		</template>
-		<template v-if="message.gecos !== false">
-			<i class="realname"> {{ message.gecos }} -</i>
+		<template v-if="message.gecos">
+			<i class="realname"> {{ message.gecos }}</i>
 		</template>
 		has joined the channel
 	</span>


### PR DESCRIPTION
Does not show gecos and account data in join message if they are an empty string