### PR TITLE
NetworkForm: s/away message/leave message/

### DIFF
--- a/client/components/NetworkForm.vue
+++ b/client/components/NetworkForm.vue
@@ -168,7 +168,7 @@
 				/>
 			</div>
 			<div class="connect-row">
-				<label for="connect:leaveMessage">Away message</label>
+				<label for="connect:leaveMessage">Leave message</label>
 				<input
 					id="connect:leaveMessage"
 					v-model="defaults.leaveMessage"


### PR DESCRIPTION
877e4acf7d8f397b64ac76cdb1504fa0bd9fda43 - Add network specific leave message
introduced the wrong label for the leave message.