### PR TITLE
Settings: show label for nick autocompletion postfix

### DIFF
--- a/client/components/Windows/Settings.vue
+++ b/client/components/Windows/Settings.vue
@@ -172,8 +172,14 @@
 			</div>
 			<div v-if="$store.state.settings.advanced">
 				<label class="opt">
-					<label for="nickPostfix" class="sr-only">
-						Nick autocomplete postfix (for example a comma)
+					<label for="nickPostfix" class="opt">
+						Nick autocomplete postfix
+						<span
+							class="tooltipped tooltipped-n tooltipped-no-delay"
+							aria-label="Nick autocomplete postfix (for example a comma)"
+						>
+							<button class="extra-help" />
+						</span>
 					</label>
 					<input
 						id="nickPostfix"


### PR DESCRIPTION
Without a visible label it's impossible to determine what the option does, as the placeholder is not visible if there's anything in the input field.

The label now looks like the other options like the highlight settings:
![example](https://labrat.space/irc/58790ff40194ea91/withLabel.jpeg)