### PR TITLE
Implement left swipe to open the user list

### DIFF
--- a/client/components/Sidebar.vue
+++ b/client/components/Sidebar.vue
@@ -178,11 +178,13 @@ export default {
 					if (this.$store.state.sidebarOpen) {
 						distX += this.menuWidth;
 					}
+
 					if (distX > this.menuWidth) {
 						distX = this.menuWidth;
 					} else if (distX < 0) {
 						distX = 0;
 					}
+
 					this.$refs.sidebar.style.transform = "translate3d(" + distX + "px, 0, 0)";
 					this.overlay.style.opacity = distX / this.menuWidth;
 					break;
@@ -190,8 +192,7 @@ export default {
 				case 1:
 					this.$refs.sidebar.style.transform = "translate3d(0px, 0, 0)";
 					this.overlay.style.opacity = 0;
-					const userlistClosed = distX > this.userlistWidth / 2;
-					this.$store.commit("userlistOpen", !userlistClosed);
+					this.$store.commit("userlistOpen", distX <= this.userlistWidth / 2);
 					break;
 				// control both
 				case 2:
@@ -203,9 +204,11 @@ export default {
 						if (distX > this.menuWidth) {
 							distX = this.menuWidth;
 						}
+
 						this.$refs.sidebar.style.transform = "translate3d(" + distX + "px, 0, 0)";
 						this.overlay.style.opacity = distX / this.menuWidth;
 					}
+
 					break;
 				default:
 					break;
@@ -217,7 +220,7 @@ export default {
 			const absDiff = Math.abs(diff);
 
 			if (
-				this.controlCode != 1 &&
+				this.controlCode !== 1 &&
 				(absDiff > this.menuWidth / 2 ||
 					(Date.now() - this.touchStartTime < 180 && absDiff > 50))
 			) {


### PR DESCRIPTION
Closes #1110.

1. This solution is not as responsive as possible because it does not animate like the existing "swipe to open the menu" feature does. However, it serves as a proof of concept to determine whether this additional swipe behavior is desired at all; I can add an animation later if desired.
2. Any possible solution would collide with the existing "swipe to open the menu" feature. I determined that swipe to open the menu should take precedence within the app. So:

- If the menu is open, any swiping only controls the menu.
- If the menu is closed and the user list is open, any swiping only controls the user list.
- If the menu and the user list are both closed, swiping controls both the menu and the user list.

Let me know if there are any further changes or clarifications that are desired.