### PR TITLE
Improve inline audio file support

### DIFF
--- a/src/plugins/irc-events/link.js
+++ b/src/plugins/irc-events/link.js
@@ -249,6 +249,8 @@ function parse(msg, chan, preview, res, client) {
 		case "audio/x-midi":
 		case "audio/x-mpeg":
 		case "audio/x-mpeg-3":
+		case "audio/flac":
+		case "audio/x-m4a":
 			if (!preview.link.startsWith("https://")) {
 				break;
 			}

--- a/src/plugins/uploader.js
+++ b/src/plugins/uploader.js
@@ -21,7 +21,8 @@ const inlineContentDispositionTypes = {
 	"audio/mpeg": "audio.mp3",
 	"audio/ogg": "audio.ogg",
 	"audio/vnd.wave": "audio.wav",
-	"audio/flac": "audio.flac",
+	"audio/x-flac": "audio.flac",
+	"audio/x-m4a": "audio.m4a",
 	"image/bmp": "image.bmp",
 	"image/gif": "image.gif",
 	"image/jpeg": "image.jpg",
@@ -110,10 +111,12 @@ class Uploader {
 			});
 		}
 
+		// Send a more common mime type for audio files
+		// so that browsers can play them correctly
 		if (detectedMimeType === "audio/vnd.wave") {
-			// Send a more common mime type for wave audio files
-			// so that browsers can play them correctly
 			detectedMimeType = "audio/wav";
+		} else if (detectedMimeType === "audio/x-flac") {
+			detectedMimeType = "audio/flac";
 		}
 
 		res.setHeader("Content-Disposition", disposition);


### PR DESCRIPTION
Tested on latest Chromium / Firefox. In case of .m4a files they want audio/x-m4a and not audio/m4a, in case of .flac files they want audio/flac and not audio/x-flac. The module we used to detect the types however detects them only as audio/x-m4a and audio/x-flac as they are not official IANA supported mime types (not in IANA spec == "x-" prefix): https://www.iana.org/assignments/media-types/media-types.xhtml Though flac is not in the IANA spec many programs such as the file command (https://man7.org/linux/man-pages/man1/file.1.html) and Chromium (flac) / Firefox (x-flac and flac) support audio/flac only or both.