### PR TITLE
Classes for channels in list with unread counts and highlights

### DIFF
--- a/client/components/ChannelWrapper.vue
+++ b/client/components/ChannelWrapper.vue
@@ -8,6 +8,8 @@
 			{active: active},
 			{'parted-channel': channel.type === 'channel' && channel.state === 0},
 			{'has-draft': channel.pendingMessage},
+			{'has-unread': channel.unread},
+			{'has-highlight': channel.highlight},
 			{
 				'not-secure':
 					channel.type === 'lobby' && network.status.connected && !network.status.secure,


### PR DESCRIPTION
This adds `has-unread` class to the channel classes in the list if the channel has unread messages, and `has-highlight` if the channel has an active highlight.

Resloves #4161 