### PR TITLE
Add support for JPEG XL image previews

### DIFF
--- a/src/plugins/irc-events/link.js
+++ b/src/plugins/irc-events/link.js
@@ -222,6 +222,7 @@ function parse(msg, chan, preview, res, client) {
 		case "image/gif":
 		case "image/jpg":
 		case "image/jpeg":
+		case "image/jxl":
 		case "image/webp":
 		case "image/avif":
 			if (!Helper.config.prefetchStorage && Helper.config.disableMediaPreview) {

--- a/src/plugins/uploader.js
+++ b/src/plugins/uploader.js
@@ -28,6 +28,7 @@ const inlineContentDispositionTypes = {
 	"image/png": "image.png",
 	"image/webp": "image.webp",
 	"image/avif": "image.avif",
+	"image/jxl": "image.jxl",
 	"text/plain": "text.txt",
 	"video/mp4": "video.mp4",
 	"video/ogg": "video.ogv",


### PR DESCRIPTION
Instead of just as a generic link.

It's supported by Chrome 90+ and Firefox 90+ (both behind flags), it's still rather early but I doubt they're going to abandon it.