### PR TITLE
Fix missing users in userlist after removing searchinput

### DIFF
--- a/client/components/ChatUserList.vue
+++ b/client/components/ChatUserList.vue
@@ -28,7 +28,7 @@
 				<template v-if="userSearchInput.length > 0">
 					<Username
 						v-for="user in users"
-						:key="user.original.nick"
+						:key="user.original.nick + '-search'"
 						:on-hover="hoverUser"
 						:active="user.original === activeUser"
 						:user="user.original"


### PR DESCRIPTION
Because the "Username" components still had the same ":key" vue tried to in-place update them. This doesn't quite work for objects (in this case "user" or "user.original"). Thus we change the key for the search so that it actually inits a new component and thus evaluates its content correctly.

fixes #4220