### PR TITLE
Add X-Frame-Options header

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -283,6 +283,7 @@ function getClientSecure(socket) {
 
 function allRequests(req, res, next) {
 	res.setHeader("X-Content-Type-Options", "nosniff");
+	res.setHeader("X-Frame-Options", "DENY");
 	return next();
 }
 


### PR DESCRIPTION
Protects against clickjacking attacks.

For more information see https://scotthelme.co.uk/hardening-your-http-response-headers/#x-frame-options