### PR TITLE
Chat input link preview 

### DIFF
--- a/client/components/ChatInput.vue
+++ b/client/components/ChatInput.vue
@@ -1,5 +1,14 @@
 <template>
 	<form id="form" method="post" action="" @submit.prevent="onSubmit">
+		<div v-if="channel.pendingMessagePreviews.length > 0" id="input-previews">
+			<LinkPreview
+				v-for="preview in channel.pendingMessagePreviews"
+				:key="preview.link"
+				:keep-scroll-position="() => {}"
+				:link="preview"
+				:channel="channel"
+			/>
+		</div>
 		<span id="upload-progressbar" />
 		<span id="nick">{{ network.nick }}</span>
 		<textarea
@@ -59,6 +68,9 @@ import commands from "../js/commands/index";
 import socket from "../js/socket";
 import upload from "../js/upload";
 import eventbus from "../js/eventbus";
+import {findLinks} from "../js/helpers/ircmessageparser/findLinks";
+import throttle from "lodash/throttle";
+import LinkPreview from "./LinkPreview.vue";
 
 const formattingHotkeys = {
 	"mod+k": "\x03",
@@ -89,6 +101,9 @@ let autocompletionRef = null;
 
 export default {
 	name: "ChatInput",
+	components: {
+		LinkPreview,
+	},
 	props: {
 		network: Object,
 		channel: Object,
@@ -101,10 +116,14 @@ export default {
 		},
 		"channel.pendingMessage"() {
 			this.setInputSize();
+			this.requestLinkPreview();
 		},
 	},
 	mounted() {
 		eventbus.on("escapekey", this.blurInput);
+		this.setInputSize();
+
+		this.requestLinkPreview = throttle(this._requestLinkPreview, 1500);
 
 		if (this.$store.state.settings.autocomplete) {
 			autocompletionRef = autocompletion(this.$refs.input);
@@ -176,6 +195,26 @@ export default {
 		upload.abort();
 	},
 	methods: {
+		_requestLinkPreview() {
+			const links = findLinks(this.channel.pendingMessage);
+			const rawLinks = links.map((obj) => obj.link);
+			const currentLinks = this.channel.pendingMessagePreviews.map((obj) => obj.link);
+			const toRequest = links.filter((link) => !currentLinks.includes(link.link));
+			this.channel.pendingMessagePreviews = this.channel.pendingMessagePreviews.filter(
+				(preview) => rawLinks.includes(preview.link)
+			);
+
+			if (toRequest.length === 0) {
+				return;
+			}
+
+			while (toRequest.length > 0) {
+				socket.emit("input:preview", {
+					links: toRequest.splice(0, 4),
+					target: this.channel.id,
+				});
+			}
+		},
 		setPendingMessage(e) {
 			this.channel.pendingMessage = e.target.value;
 			this.channel.inputHistoryPosition = 0;
@@ -227,6 +266,7 @@ export default {
 
 			this.channel.inputHistoryPosition = 0;
 			this.channel.pendingMessage = "";
+			this.channel.pendingMessagePreviews = [];
 			this.$refs.input.value = "";
 			this.setInputSize();
 

--- a/client/components/LinkPreview.vue
+++ b/client/components/LinkPreview.vue
@@ -48,6 +48,7 @@
 							:aria-label="moreButtonLabel"
 							dir="auto"
 							class="more"
+							type="button"
 							@click="onMoreClick"
 						>
 							<span class="more-caret" />
@@ -119,6 +120,7 @@
 						:aria-expanded="isContentShown"
 						:aria-label="moreButtonLabel"
 						class="more"
+						type="button"
 						@click="onMoreClick"
 					>
 						<span class="more-caret" />

--- a/client/css/style.css
+++ b/client/css/style.css
@@ -318,7 +318,7 @@ p {
 #chat .msg-statusmsg span::before,
 #chat .msg-shown-in-active span::before,
 #chat .toggle-button::after,
-#chat .toggle-content .more-caret::before,
+.preview .toggle-content .more-caret::before,
 #chat .scroll-down-arrow::after,
 #chat .topic-container .save-topic span::before,
 #version-checker::before,
@@ -639,6 +639,7 @@ p {
 #sidebar {
 	display: none;
 	flex-direction: column;
+	flex-shrink: 0;
 	width: 220px;
 	max-height: 100%;
 	will-change: transform;
@@ -1536,22 +1537,23 @@ textarea.input {
 	border-left: 1px solid var(--highlight-bg-color);
 }
 
-#chat .preview-size {
+.preview-size {
 	margin-left: 5px;
 	user-select: none;
 }
 
-#chat .toggle-content.opened .more-caret, /* Expand/Collapse link previews */
-#chat .toggle-button.opened, /* Thumbnail toggle */
-#chat .msg:not(.closed)[data-type="condensed"] .toggle-button { /* Expanded status message toggle */
+.preview .toggle-content.opened .more-caret, /* Expand/Collapse link previews */
+.preview .toggle-button.opened, /* Thumbnail toggle */
+.msg:not(.closed)[data-type="condensed"] .preview .toggle-button { /* Expanded status message toggle */
 	transform: rotate(90deg);
 }
 
-#chat .preview {
+.preview {
 	display: flex; /* Fix odd margin added by inline-flex in .toggle-content */
+	user-select: text;
 }
 
-#chat .toggle-content {
+.preview .toggle-content {
 	background: #f6f6f6;
 	border-radius: 5px;
 	max-width: 100%;
@@ -1565,111 +1567,111 @@ textarea.input {
 }
 
 /* This applies to images of preview-type-image and thumbnails of preview-type-link */
-#chat .toggle-content img {
+.preview .toggle-content img {
 	max-width: 100%;
 	max-height: 128px;
 	display: block;
 	cursor: zoom-in;
 }
 
-#chat .toggle-content pre.prefetch-error {
+.preview .toggle-content pre.prefetch-error {
 	padding: 0;
 	margin: 0;
 	color: inherit;
 	background-color: transparent;
 }
 
-#chat .toggle-content .prefetch-error {
+.preview .toggle-content .prefetch-error {
 	display: none;
 }
 
-#chat .toggle-content.opened .prefetch-error {
+.preview .toggle-content.opened .prefetch-error {
 	display: inline;
 }
 
 /* This applies to thumbnails of preview-type-link only */
-#chat .toggle-content .thumb {
+.preview .toggle-content .thumb {
 	max-height: 54px;
 	max-width: 96px;
 }
 
-#chat .toggle-type-error,
-#chat .toggle-content .toggle-text {
+.preview .toggle-type-error,
+.preview .toggle-content .toggle-text {
 	padding: 8px 10px;
 }
 
-#chat .toggle-content .toggle-text {
+.preview .toggle-content .toggle-text {
 	white-space: nowrap;
 	overflow: hidden;
 	text-align: initial;
 }
 
-#chat .toggle-content.opened .toggle-text {
+.preview .toggle-content.opened .toggle-text {
 	white-space: normal;
 }
 
-#chat .toggle-content .head {
+.preview .toggle-content .head {
 	display: flex;
 	align-items: flex-start;
 	font-weight: bold;
 }
 
-#chat .toggle-type-error,
-#chat .toggle-text .body {
+.preview .toggle-type-error,
+.preview .toggle-text .body {
 	color: #717171;
 }
 
-#chat .toggle-text a {
+.preview .toggle-text a {
 	color: inherit;
 }
 
-#chat .toggle-text .overflowable {
+.preview .toggle-text .overflowable {
 	text-overflow: ellipsis;
 	overflow: hidden;
 	flex-grow: 1;
 }
 
-#chat .toggle-content .more {
+.preview .toggle-content .more {
 	color: var(--link-color);
 	font-weight: normal;
 	margin-left: 10px;
 	flex-shrink: 0;
 }
 
-#chat .toggle-content .more:hover {
+.preview .toggle-content .more:hover {
 	text-decoration: underline;
 }
 
-#chat .toggle-content .more::after {
+.preview .toggle-content .more::after {
 	content: " " attr(aria-label);
 }
 
-#chat .toggle-content .more-caret {
+.preview .toggle-content .more-caret {
 	display: inline-block;
 	transition: transform 0.2s;
 }
 
-#chat .toggle-content .more-caret::before {
+.preview .toggle-content .more-caret::before {
 	content: "\f0da"; /* https://fontawesome.com/icons/caret-right?style=solid */
 }
 
-#chat audio {
+.preview audio {
 	width: 600px;
 	max-width: 100%;
 }
 
-#chat .toggle-type-video {
+.preview .toggle-type-video {
 	max-width: 640px;
 }
 
-#chat video {
+.preview video {
 	max-width: 100%;
 	max-height: 240px;
 }
 
 /* Do not display an empty div when there are no previews. Useful for example in
 part/quit messages where we don't load previews (adds a blank line otherwise) */
-#chat .preview:empty {
+.preview:empty {
 	display: none;
 }
 
@@ -2147,6 +2149,40 @@ part/quit messages where we don't load previews (adds a blank line otherwise) */
 	display: flex;
 	align-items: flex-end;
 	position: relative;
+	flex-wrap: wrap;
+}
+
+#input-previews {
+	width: 100%;
+	border-bottom: 1px solid #e7e7e7;
+	padding-bottom: 6px;
+	margin-bottom: 6px;
+	display: flex;
+	flex-wrap: wrap;
+}
+
+#input-previews .preview {
+	max-width: calc(25% - 10px);
+	margin: 5px;
+	flex: 0 0 auto;
+	height: auto;
+	max-height: 128px;
+}
+
+@media (max-width: 768px) {
+	#input-previews .preview {
+		max-width: calc(50% - 10px);
+	}
+}
+
+@media (max-width: 479px) {
+	#input-previews .preview {
+		max-width: calc(100% - 10px);
+	}
+}
+
+#input-previews .toggle-content {
+	margin: 0;
 }
 
 #user-visible-error {
@@ -2634,7 +2670,7 @@ part/quit messages where we don't load previews (adds a blank line otherwise) */
 		padding-left: 6px;
 	}
 
-	#chat .toggle-content .thumb {
+	.preview .toggle-content .thumb {
 		max-height: 58px;
 		max-width: 104px;
 	}

--- a/client/js/socket-events/index.js
+++ b/client/js/socket-events/index.js
@@ -4,6 +4,7 @@ import "./connection";
 import "./auth";
 import "./commands";
 import "./init";
+import "./input_preview";
 import "./join";
 import "./more";
 import "./msg";

--- a/client/js/socket-events/input_preview.js
+++ b/client/js/socket-events/input_preview.js
@@ -1,0 +1,19 @@
+"use strict";
+
+import socket from "../socket";
+import store from "../store";
+import {findLinks} from "../helpers/ircmessageparser/findLinks";
+
+socket.on("input:preview", function (data) {
+	const {channel} = store.getters.findChannel(data.target);
+	const currentLinks = channel.pendingMessagePreviews.map((obj) => obj.link);
+
+	if (currentLinks.includes(data.preview.link)) {
+		return;
+	}
+
+	const links = findLinks(channel.pendingMessage).map((obj) => obj.link);
+
+	channel.pendingMessagePreviews.push(data.preview);
+	channel.pendingMessagePreviews.sort((a, b) => links.indexOf(a.link) - links.indexOf(b.link));
+});

--- a/client/js/store.js
+++ b/client/js/store.js
@@ -189,6 +189,7 @@ const store = new Vuex.Store({
 		initChannel: () => (channel) => {
 			// TODO: This should be a mutation
 			channel.pendingMessage = "";
+			channel.pendingMessagePreviews = [];
 			channel.inputHistoryPosition = 0;
 			channel.inputHistory = [""];
 			channel.historyLoading = false;

--- a/client/themes/morning.css
+++ b/client/themes/morning.css
@@ -106,6 +106,10 @@ body {
 	color: #f3f3f3;
 }
 
+#input-previews {
+	border-bottom-color: #242a33;
+}
+
 .window {
 	box-shadow: 0 0 25px rgba(0, 0, 0, 0.75);
 }

--- a/src/server.js
+++ b/src/server.js
@@ -18,6 +18,7 @@ const Identification = require("./identification");
 const changelog = require("./plugins/changelog");
 const inputs = require("./plugins/inputs");
 const Auth = require("./plugins/auth");
+const LinkPrefetch = require("./plugins/irc-events/link");
 
 const themes = require("./plugins/packages/themes");
 themes.loadLocalThemes();
@@ -366,6 +367,18 @@ function initializeClient(socket, client, token, lastMessage, openChannel) {
 	socket.on("input", (data) => {
 		if (_.isPlainObject(data)) {
 			client.input(data);
+		}
+	});
+
+	socket.on("input:preview", (data) => {
+		if (_.isPlainObject(data)) {
+			const chan = client.find(data.target);
+			LinkPrefetch(client, chan, {}, data.links, (a, b, c, preview) => {
+				socket.emit("input:preview", {
+					target: data.target,
+					preview: preview,
+				});
+			});
 		}
 	});
 


### PR DESCRIPTION
Show link preview like in other instant messengers like Telegram. For each link, we try to get a preview (with our usual method) and show them sorted in a quick popup above the chat input. We reuse the already existing previews with slightly different size boundaries.  

![localhost_9990_](https://user-images.githubusercontent.com/9467802/118892986-06cb6c00-b902-11eb-9476-611255f10d60.png)
![localhost_9990_ (3)](https://user-images.githubusercontent.com/9467802/118892988-07640280-b902-11eb-86cd-8ec16560d2d7.png)
![localhost_9990_ (2)](https://user-images.githubusercontent.com/9467802/118892991-07640280-b902-11eb-9177-c7e88017b4c8.png)
![localhost_9990_ (1)](https://user-images.githubusercontent.com/9467802/118892994-07fc9900-b902-11eb-9caf-41d3f2877d77.png)

https://user-images.githubusercontent.com/9467802/118892969-ff0bc780-b901-11eb-95ec-e56d54ff99f6.mp4

