### PR TITLE
Add shorcut to navigate between channels with undread msgs

### DIFF
--- a/client/components/Windows/Help.vue
+++ b/client/components/Windows/Help.vue
@@ -181,6 +181,26 @@
 
 			<div class="help-item">
 				<div class="subject">
+					<span v-if="!isApple"><kbd>Alt</kbd> <kbd>Ctrl</kbd> <kbd>↓</kbd></span>
+					<span v-else><kbd>⌥</kbd> <kbd>⌘</kbd> <kbd>↓</kbd></span>
+				</div>
+				<div class="description">
+					<p>Switch to the next window with unread messages in the channel list.</p>
+				</div>
+			</div>
+
+			<div class="help-item">
+				<div class="subject">
+					<span v-if="!isApple"><kbd>Alt</kbd> <kbd>Ctrl</kbd> <kbd>↑</kbd></span>
+					<span v-else><kbd>⌥</kbd> <kbd>⌘</kbd> <kbd>↑</kbd></span>
+				</div>
+				<div class="description">
+					<p>Switch to the previous window with unread messages in the channel list.</p>
+				</div>
+			</div>
+
+			<div class="help-item">
+				<div class="subject">
 					<span v-if="!isApple"><kbd>Alt</kbd> <kbd>A</kbd></span>
 					<span v-else><kbd>⌥</kbd> <kbd>A</kbd></span>
 				</div>

--- a/client/js/keybinds.ts
+++ b/client/js/keybinds.ts
@@ -83,6 +83,35 @@ Mousetrap.bind(["alt+shift+up", "alt+shift+down"], function (e, keys) {
 	return false;
 });
 
+// Switch to the next/previous unread chat
+Mousetrap.bind(["alt+mod+up", "alt+mod+down"], function (e, keys) {
+	if (isIgnoredKeybind(e)) {
+		return true;
+	}
+
+	const channels = store.state.networks
+		.map((net) =>
+			net.channels.filter(
+				(chan) => chan.unread || chan === store.state.activeChannel?.channel
+			)
+		)
+		.flat();
+
+	if (channels.length === 0) {
+		return;
+	}
+
+	let index = channels.findIndex((chan) => chan === store.state.activeChannel?.channel);
+
+	const length = channels.length;
+	const direction = keys.split("+").pop() === "up" ? -1 : 1;
+	index = (((index + direction) % length) + length) % length;
+
+	jumpToChannel(channels[index]);
+
+	return false;
+});
+
 // Jump to the first window with a highlight in it, or the first with unread
 // activity if there are none with highlights.
 Mousetrap.bind(["alt+a"], function (e) {


### PR DESCRIPTION
IMHO this makes `alt`+`a` obsolete and is easier to familiarize with as the other navigation shortcuts also go directed through the list and not solely from the top down. 

https://user-images.githubusercontent.com/9467802/119032666-bbba6300-b9ac-11eb-90c8-711f8e0b03d6.mp4

