### PR TITLE
MessageSearchForm: do not focus input if search is closed

### DIFF
--- a/client/components/MessageSearchForm.vue
+++ b/client/components/MessageSearchForm.vue
@@ -4,7 +4,7 @@
 			<input
 				ref="searchInputField"
 				v-model="searchInput"
-				type="text"
+				type="search"
 				name="search"
 				class="input"
 				placeholder="Search messages…"
@@ -105,7 +105,7 @@ export default {
 		this.searchInput = this.$route.query.q;
 		this.searchOpened = this.onSearchPage;
 
-		if (!this.searchInput) {
+		if (!this.searchInput && this.searchOpened) {
 			this.$refs.searchInputField.focus();
 		}
 	},


### PR DESCRIPTION
Else whenever the element gets created (switch from server chan to a normal one)
the browser tries to focus the hidden element