### PR TITLE
Provide the option to hide NSFW previews

### DIFF
--- a/client/components/LinkPreview.vue
+++ b/client/components/LinkPreview.vue
@@ -132,6 +132,7 @@
 <script>
 import eventbus from "../js/eventbus";
 import friendlysize from "../js/helpers/friendlysize";
+import messageMatchFilters from "../js/helpers/messageMatchFilters";
 
 export default {
 	name: "LinkPreview",
@@ -233,22 +234,16 @@ export default {
 					this.$refs.content.offsetWidth >= this.$refs.container.offsetWidth;
 			});
 		},
+		shouldHidePreview() {
+			return messageMatchFilters(
+				this.$parent.message.text,
+				this.$store.state.settings.hidePreviewFilters
+			);
+		},
 		updateShownState() {
-			// Ensure we don't have empty strings in the list of preview filters
-			const filterTokens = this.$store.state.settings.hidePreviewFilters
-				.split(",")
-				.map((filter) => filter.trim())
-				.filter((filter) => filter.length > 0);
-
-			const messageText = this.$parent.message.text.toLowerCase();
-
-			const caughtFilter = filterTokens.some((filter) => {
-				return messageText.includes(filter.toLowerCase());
-			});
-
 			// User has manually toggled the preview, or the message has been filtered
 			// by the preview filter settings, do not apply default
-			if (this.link.shown !== null || caughtFilter) {
+			if (this.link.shown !== null || this.shouldHidePreview()) {
 				return;
 			}
 

--- a/client/components/LinkPreview.vue
+++ b/client/components/LinkPreview.vue
@@ -234,8 +234,13 @@ export default {
 			});
 		},
 		updateShownState() {
-			// User has manually toggled the preview, do not apply default
-			if (this.link.shown !== null) {
+			// User has manually toggled the preview, or the image is marked as nsfw
+			// and the setting has been enabled do not apply default
+			const hideNsfw =
+				this.$parent.message.text.toLowerCase().includes("nsfw") &&
+				this.$store.state.settings.hideNsfw;
+
+			if (this.link.shown !== null || hideNsfw) {
 				return;
 			}
 

--- a/client/components/LinkPreview.vue
+++ b/client/components/LinkPreview.vue
@@ -132,7 +132,6 @@
 <script>
 import eventbus from "../js/eventbus";
 import friendlysize from "../js/helpers/friendlysize";
-const escapeRegExp = require("lodash/escapeRegExp");
 
 export default {
 	name: "LinkPreview",
@@ -238,7 +237,7 @@ export default {
 			// Ensure we don't have empty strings in the list of preview filters
 			const filterTokens = this.$store.state.settings.hidePreviewFilters
 				.split(",")
-				.map((filter) => escapeRegExp(filter.trim()))
+				.map((filter) => filter.trim())
 				.filter((filter) => filter.length > 0);
 
 			const messageText = this.$parent.message.text.toLowerCase();

--- a/client/components/Windows/Settings.vue
+++ b/client/components/Windows/Settings.vue
@@ -246,7 +246,7 @@
 							type="checkbox"
 							name="hideNsfw"
 						/>
-						Hide NSFW
+						Hide previews for links containing "NSFW"
 					</label>
 				</div>
 			</template>

--- a/client/components/Windows/Settings.vue
+++ b/client/components/Windows/Settings.vue
@@ -240,14 +240,24 @@
 					</label>
 				</div>
 				<div>
-					<label class="opt">
-						<input
-							:checked="$store.state.settings.hideNsfw"
-							type="checkbox"
-							name="hideNsfw"
-						/>
-						Hide previews for links containing "NSFW"
+					<label for="hidePreviewFilters" class="opt">
+						Media filters
+						<span
+							class="tooltipped tooltipped-n tooltipped-no-delay"
+							aria-label="If a message contains any of these comma-separated
+expressions, it will hide the preview."
+						>
+							<button class="extra-help" />
+						</span>
 					</label>
+					<input
+						id="hidePreviewFilters"
+						:value="$store.state.settings.hidePreviewFilters"
+						type="text"
+						name="hidePreviewFilters"
+						class="input"
+						placeholder="Comma-separated, e.g.: word, some more words, anotherword"
+					/>
 				</div>
 			</template>
 

--- a/client/components/Windows/Settings.vue
+++ b/client/components/Windows/Settings.vue
@@ -239,6 +239,16 @@
 						Auto-expand websites
 					</label>
 				</div>
+				<div>
+					<label class="opt">
+						<input
+							:checked="$store.state.settings.hideNsfw"
+							type="checkbox"
+							name="hideNsfw"
+						/>
+						Hide NSFW
+					</label>
+				</div>
 			</template>
 
 			<div

--- a/client/js/helpers/messageMatchFilters.js
+++ b/client/js/helpers/messageMatchFilters.js
@@ -1,0 +1,20 @@
+"use strict";
+
+export default (message, filters) => {
+	// If a message was blank or we have no filters, don't hide the preview
+	if (!message || !filters) {
+		return false;
+	}
+
+	// Ensure we don't have empty strings in the list filters
+	const filterTokens = filters
+		.split(",")
+		.map((filter) => filter.trim().toLowerCase())
+		.filter((filter) => filter.length > 0);
+
+	const messageText = message.toLowerCase();
+
+	return filterTokens.some((filter) => {
+		return messageText.includes(filter);
+	});
+};

--- a/client/js/settings.js
+++ b/client/js/settings.js
@@ -29,8 +29,9 @@ export const config = normalizeConfig({
 	coloredNicks: {
 		default: true,
 	},
-	hideNsfw: {
-		default: false,
+	hidePreviewFilters: {
+		default: "",
+		sync: "always",
 	},
 	desktopNotifications: {
 		default: false,

--- a/client/js/settings.js
+++ b/client/js/settings.js
@@ -29,6 +29,9 @@ export const config = normalizeConfig({
 	coloredNicks: {
 		default: true,
 	},
+	hideNsfw: {
+		default: false,
+	},
 	desktopNotifications: {
 		default: false,
 		sync: "never",

--- a/test/client/js/helpers/messageMatchFilters.js
+++ b/test/client/js/helpers/messageMatchFilters.js
@@ -1,0 +1,41 @@
+"use strict";
+
+const expect = require("chai").expect;
+const messageMatchFilters = require("../../../../client/js/helpers/messageMatchFilters").default;
+
+describe("messageMatchFilters helper", function () {
+	const hidePreviewFilters = "foo, bar,   ns fw   , 고";
+
+	it("should NOT match a filter", function () {
+		const teststrings = [
+			"http://url.com/nsfw.png", // Only "ns fw" was provided, the space was not removed
+			"nsfw http://url.com/image.gif",
+			"ns http://url.com/pic.png fw",
+			"http://url.com/link.png",
+			"hey check this out http://url.com/link.ogg",
+			"this is sfw http://url.com/sfw.mp4",
+			"foö http://url.com/link.mp4",
+			"win http://url.com/song.mp3 dows",
+		];
+
+		for (const teststring of teststrings) {
+			expect(messageMatchFilters(teststring, hidePreviewFilters)).to.be.false;
+		}
+	});
+
+	it("should match a filter", function () {
+		const teststrings = [
+			"this http://www.bar.com/link.png should be filtered",
+			"foo http://url.com/image.gif bar",
+			"고 http://url.com/pic.png",
+			"ns fw http://url.com/video.mp4",
+			"http://url.com/pic.png bar",
+			"this is a long string lets talk about foo and also paste in http://url.com/pic.gif this gif",
+			"foö http://url.com/bar.mp4",
+		];
+
+		for (const teststring of teststrings) {
+			expect(messageMatchFilters(teststring, hidePreviewFilters)).to.be.true;
+		}
+	});
+});


### PR DESCRIPTION
Many times people post NSFW images in IRC and they are usually marked as such otherwise they could be reprimanded. We should provide an option to disable showing NSFW previews while still allowing SFW previews