### PR TITLE
Toggle recent mentions popup with alt+m

### DIFF
--- a/client/components/App.vue
+++ b/client/components/App.vue
@@ -101,7 +101,9 @@ export default {
 			return false;
 		},
 		toggleMentions() {
-			eventbus.emit("mentions:toggle");
+			if (this.$store.state.networks.length !== 0) {
+				eventbus.emit("mentions:toggle");
+			}
 		},
 		msUntilNextDay() {
 			// Compute how many milliseconds are remaining until the next day starts

--- a/client/components/App.vue
+++ b/client/components/App.vue
@@ -51,6 +51,7 @@ export default {
 		Mousetrap.bind("esc", this.escapeKey);
 		Mousetrap.bind("alt+u", this.toggleUserList);
 		Mousetrap.bind("alt+s", this.toggleSidebar);
+		Mousetrap.bind("alt+m", this.toggleMentions);
 
 		// Make a single throttled resize listener available to all components
 		this.debouncedResize = throttle(() => {
@@ -72,6 +73,7 @@ export default {
 		Mousetrap.unbind("esc", this.escapeKey);
 		Mousetrap.unbind("alt+u", this.toggleUserList);
 		Mousetrap.unbind("alt+s", this.toggleSidebar);
+		Mousetrap.unbind("alt+m", this.toggleMentions);
 
 		window.removeEventListener("resize", this.debouncedResize);
 		clearTimeout(this.dayChangeTimeout);
@@ -97,6 +99,9 @@ export default {
 			this.$store.commit("toggleUserlist");
 
 			return false;
+		},
+		toggleMentions() {
+			eventbus.emit("mentions:toggle");
 		},
 		msUntilNextDay() {
 			// Compute how many milliseconds are remaining until the next day starts

--- a/client/components/Windows/Help.vue
+++ b/client/components/Windows/Help.vue
@@ -191,6 +191,16 @@
 
 			<div class="help-item">
 				<div class="subject">
+					<span v-if="!isApple"><kbd>Alt</kbd> <kbd>M</kbd></span>
+					<span v-else><kbd>⌥</kbd> <kbd>M</kbd></span>
+				</div>
+				<div class="description">
+					<p>Toggle recent mentions popup.</p>
+				</div>
+			</div>
+
+			<div class="help-item">
+				<div class="subject">
 					<span><kbd>Esc</kbd></span>
 				</div>
 				<div class="description">


### PR DESCRIPTION
This adds a keybind to toggle the recent mentions popup using `alt`+`m`(or `opt`+`m` on macOS). 

The top bar is only shown if the user is connected to at least one network. Only then it is possible to open the recent mentions popup so the keybind only toggles under the same conditions.

Relates to #4175 as it implements the first idea mentioned in that issue.