### PR TITLE
Revert "Fix load more button hidden behind search form"

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -1195,7 +1195,6 @@ textarea.input {
 }
 
 #chat .show-more {
-	margin-top: 50px;
 	padding: 10px;
 	padding-top: 15px;
 	padding-bottom: 0;


### PR DESCRIPTION
This reverts commit 115d97 introduced by #4197. The majority of people [will support history observer ](https://caniuse.com/intersectionobserver) and won't be able to see the show more button while attempting to search. It's also noticeably out of place when loading messages. 

(you probably want to open the images in a new window)

|       |      Search open      |  Search closed |
|----------|:-------------:|------:|
| Without this PR |    ![withChangeSearchOpen](https://user-images.githubusercontent.com/8675906/121824917-6ea47680-cc64-11eb-9dd0-ed9da836a8ec.png)|  ![withChange](https://user-images.githubusercontent.com/8675906/121824916-6ea47680-cc64-11eb-8245-3a357d40dfb2.png) |
| With this PR| ![withoutChangeSearchOpen](https://user-images.githubusercontent.com/8675906/121824915-6e0be000-cc64-11eb-998c-46688081ed8d.png) | ![withoutChange](https://user-images.githubusercontent.com/8675906/121824914-6e0be000-cc64-11eb-9750-cdc59b865cdf.png)0 |

If anyone can think of a more elegant solution feel free to share. 