### PR TITLE
Display server-originated notices to channels in the channel window

### DIFF
--- a/src/plugins/irc-events/message.js
+++ b/src/plugins/irc-events/message.js
@@ -51,8 +51,13 @@ module.exports = function (irc, network) {
 				return Helper.compareHostmask(entry, data);
 			});
 
-		// Server messages go to server window, no questions asked
-		if (data.from_server) {
+		// Server messages that aren't targeted at a channel go to the server window
+		if (
+			data.from_server &&
+			(!data.target ||
+				!network.getChannel(data.target) ||
+				network.getChannel(data.target).type !== Chan.Type.CHANNEL)
+		) {
 			chan = network.channels[0];
 			from = chan.getUser(data.nick);
 		} else {


### PR DESCRIPTION
Closes #4180 

This should preserve the current behaviour of displaying all server-originated messages to the status window with the exception of those targeted at a channel which will now be displayed in the channel window