### PR TITLE
Fix not overriding config options with -c

### DIFF
--- a/src/command-line/index.js
+++ b/src/command-line/index.js
@@ -34,7 +34,7 @@ try {
 createPackagesFolder();
 
 // Merge config key-values passed as CLI options into the main config
-Helper.mergeConfig(Helper.config, program.config);
+Helper.mergeConfig(Helper.config, program.opts().config);
 
 require("./start");
 


### PR DESCRIPTION
The options storage was changed in commander 7.0: https://github.com/tj/commander.js/pull/1409

