### PR TITLE
Add /umode support

### DIFF
--- a/src/plugins/inputs/mode.js
+++ b/src/plugins/inputs/mode.js
@@ -3,10 +3,14 @@
 const Chan = require("../../models/chan");
 const Msg = require("../../models/msg");
 
-exports.commands = ["mode", "op", "deop", "hop", "dehop", "voice", "devoice"];
+exports.commands = ["mode", "umode", "op", "deop", "hop", "dehop", "voice", "devoice"];
 
 exports.input = function ({irc, nick}, chan, cmd, args) {
-	if (cmd !== "mode") {
+	if (cmd === "umode") {
+		irc.raw("MODE", nick, ...args);
+
+		return;
+	} else if (cmd !== "mode") {
 		if (chan.type !== Chan.Type.CHANNEL) {
 			chan.pushMessage(
 				this,


### PR DESCRIPTION
This PR adds the `/umode` command to set user modes without needing to be focused in the server tab.