### PR TITLE
Optimise modes based on ISUPPORT

### DIFF
--- a/src/plugins/inputs/mode.js
+++ b/src/plugins/inputs/mode.js
@@ -42,7 +42,7 @@ exports.input = function ({irc, nick}, chan, cmd, args) {
 			devoice: "-v",
 		}[cmd];
 
-		const limit = parseInt(irc.network.supports("MODES")) || 1;
+		const limit = parseInt(irc.network.supports("MODES")) || target.length;
 
 		for (let i = 0; i < target.length; i += limit) {
 			const targets = target.slice(i, i + limit);

--- a/src/plugins/inputs/mode.js
+++ b/src/plugins/inputs/mode.js
@@ -42,7 +42,7 @@ exports.input = function ({irc, nick}, chan, cmd, args) {
 			devoice: "-v",
 		}[cmd];
 
-		const limit = parseInt(irc.network.supports("modes")) || 1;
+		const limit = parseInt(irc.network.supports("MODES")) || 1;
 
 		for (let i = 0; i < target.length; i += limit) {
 			const targets = target.slice(i, i + limit);

--- a/src/plugins/inputs/mode.js
+++ b/src/plugins/inputs/mode.js
@@ -19,7 +19,9 @@ exports.input = function ({irc, nick}, chan, cmd, args) {
 			return;
 		}
 
-		if (args.length === 0) {
+		const target = args.filter((arg) => arg !== "");
+
+		if (target.length === 0) {
 			chan.pushMessage(
 				this,
 				new Msg({
@@ -40,9 +42,13 @@ exports.input = function ({irc, nick}, chan, cmd, args) {
 			devoice: "-v",
 		}[cmd];
 
-		args.forEach(function (target) {
-			irc.raw("MODE", chan.name, mode, target);
-		});
+		const limit = parseInt(irc.network.supports("modes")) || 1;
+
+		for (let i = 0; i < target.length; i += limit) {
+			const targets = target.slice(i, i + limit);
+			const amode = `${mode[0]}${mode[1].repeat(targets.length)}`;
+			irc.raw("MODE", chan.name, amode, ...targets);
+		}
 
 		return;
 	}

--- a/test/commands/mode.js
+++ b/test/commands/mode.js
@@ -20,6 +20,13 @@ describe("Commands", function () {
 			lastCommand: null,
 			nick: "xPaw",
 			irc: {
+				network: {
+					supports(type) {
+						if (type.toUpperCase() === "MODES") {
+							return "4";
+						}
+					},
+				},
 				raw(...args) {
 					testableNetwork.lastCommand = args.join(" ");
 				},
@@ -82,9 +89,18 @@ describe("Commands", function () {
 			ModeCommand.input(testableNetwork, channel, "devoice", ["xPaw"]);
 			expect(testableNetwork.lastCommand).to.equal("MODE #thelounge -v xPaw");
 
-			// Multiple arguments are supported, sent as separate commands
-			ModeCommand.input(testableNetwork, channel, "devoice", ["xPaw", "Max-P"]);
-			expect(testableNetwork.lastCommand).to.equal("MODE #thelounge -v Max-P");
+			ModeCommand.input(testableNetwork, channel, "voice", ["xPaw", "Max-P"]);
+			expect(testableNetwork.lastCommand).to.equal("MODE #thelounge +vv xPaw Max-P");
+
+			// since the limit for modes on tests is 4, it should send two commands
+			ModeCommand.input(testableNetwork, channel, "devoice", [
+				"xPaw",
+				"Max-P",
+				"hey",
+				"idk",
+				"thelounge",
+			]);
+			expect(testableNetwork.lastCommand).to.equal("MODE #thelounge -v thelounge");
 		});
 	});
 });

--- a/test/commands/mode.js
+++ b/test/commands/mode.js
@@ -118,12 +118,14 @@ describe("Commands", function () {
 			expect(testableNetwork.lastCommand).to.equal("MODE #thelounge -v thelounge");
 		});
 
-		it("should fallback to default limit of 1 mode for shorthand commands", function () {
+		it("should fallback to all modes at once for shorthand commands", function () {
 			ModeCommand.input(testableNetworkNoSupports, channel, "voice", ["xPaw"]);
 			expect(testableNetworkNoSupports.lastCommand).to.equal("MODE #thelounge +v xPaw");
 
 			ModeCommand.input(testableNetworkNoSupports, channel, "devoice", ["xPaw", "Max-P"]);
-			expect(testableNetworkNoSupports.lastCommand).to.equal("MODE #thelounge -v Max-P");
+			expect(testableNetworkNoSupports.lastCommand).to.equal(
+				"MODE #thelounge -vv xPaw Max-P"
+			);
 		});
 	});
 });

--- a/test/commands/mode.js
+++ b/test/commands/mode.js
@@ -17,6 +17,7 @@ describe("Commands", function () {
 		});
 
 		const testableNetwork = {
+			firstCommand: null,
 			lastCommand: null,
 			nick: "xPaw",
 			irc: {
@@ -28,6 +29,7 @@ describe("Commands", function () {
 					},
 				},
 				raw(...args) {
+					testableNetwork.firstCommand = testableNetwork.lastCommand;
 					testableNetwork.lastCommand = args.join(" ");
 				},
 			},
@@ -41,6 +43,7 @@ describe("Commands", function () {
 					},
 				},
 				raw(...args) {
+					testableNetworkNoSupports.firstCommand = testableNetworkNoSupports.lastCommand;
 					testableNetworkNoSupports.lastCommand = args.join(" ");
 				},
 			},
@@ -115,6 +118,9 @@ describe("Commands", function () {
 				"idk",
 				"thelounge",
 			]);
+			expect(testableNetwork.firstCommand).to.equal(
+				"MODE #thelounge -vvvv xPaw Max-P hey idk"
+			);
 			expect(testableNetwork.lastCommand).to.equal("MODE #thelounge -v thelounge");
 		});
 


### PR DESCRIPTION
This will see the maximum allowed of modes that are allowed at once as sent in RPL_ISUPPORT and will send multiple batches while using /op, /voice, etc.

This also fixes a minor issue where it would try sending an empty voice if it had an extra space on arguments (such as using `/voice  `)