### PR TITLE
Fix nick-less messages from servers

### DIFF
--- a/src/plugins/irc-events/message.js
+++ b/src/plugins/irc-events/message.js
@@ -11,12 +11,6 @@ module.exports = function (irc, network) {
 	const client = this;
 
 	irc.on("notice", function (data) {
-		// Some servers send notices without any nickname
-		if (!data.nick) {
-			data.from_server = true;
-			data.nick = data.hostname || network.host;
-		}
-
 		data.type = Msg.Type.NOTICE;
 		handleMessage(data);
 	});
@@ -27,12 +21,6 @@ module.exports = function (irc, network) {
 	});
 
 	irc.on("privmsg", function (data) {
-		// Some servers send messages without any nickname
-		if (!data.nick) {
-			data.from_server = true;
-			data.nick = data.hostname || network.host;
-		}
-
 		data.type = Msg.Type.MESSAGE;
 		handleMessage(data);
 	});
@@ -49,6 +37,12 @@ module.exports = function (irc, network) {
 		let highlight = false;
 		let showInActive = false;
 		const self = data.nick === irc.user.nick;
+
+		// Some servers send messages without any nickname
+		if (!data.nick) {
+			data.from_server = true;
+			data.nick = data.hostname || network.host;
+		}
 
 		// Check if the sender is in our ignore list
 		const shouldIgnore =

--- a/src/plugins/irc-events/message.js
+++ b/src/plugins/irc-events/message.js
@@ -27,6 +27,12 @@ module.exports = function (irc, network) {
 	});
 
 	irc.on("privmsg", function (data) {
+		// Some servers send messages without any nickname
+		if (!data.nick) {
+			data.from_server = true;
+			data.nick = data.hostname || network.host;
+		}
+
 		data.type = Msg.Type.MESSAGE;
 		handleMessage(data);
 	});


### PR DESCRIPTION
There are cases where it's slightly confusing from which server things like, for example, InspIRCd server notices, are sent from, since they are sent as messages, and there's not a handler for setting the nick in these cases (resulting in an empty sender).

This PR fixes it.