### PR TITLE
Fix userlist's wrong position on mobile devices

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -2635,6 +2635,7 @@ part/quit messages where we don't load previews (adds a blank line otherwise) */
 		right: 0;
 		transform: translateX(180px);
 		transition: transform 0.2s;
+		z-index: 1;
 	}
 
 	#viewport.userlist-open #chat .userlist {


### PR DESCRIPTION
Commit 867fff33c093144965c4a3ded552a2313f1574c9 introduced an issue for mobile devices and small windows, where the user list's element position would make it show below the messages.

A simple `z-index: 1;` should do the trick for those cases.

Example of mentioned issue:
![image](https://user-images.githubusercontent.com/7420695/124369313-81ddad00-dc38-11eb-988e-e05ea7cc9b60.png)
