### PR TITLE
Add warning for HTTPS requirement on notifications

### DIFF
--- a/client/components/Windows/Settings.vue
+++ b/client/components/Windows/Settings.vue
@@ -306,6 +306,7 @@
 					<input
 						id="desktopNotifications"
 						:checked="$store.state.settings.desktopNotifications"
+						:disabled="$store.state.desktopNotificationState === 'nohttps'"
 						type="checkbox"
 						name="desktopNotifications"
 					/>
@@ -315,6 +316,14 @@
 						class="error"
 					>
 						<strong>Warning</strong>: Notifications are not supported by your browser.
+					</div>
+					<div
+						v-if="$store.state.desktopNotificationState === 'nohttps'"
+						id="warnBlockedDesktopNotifications"
+						class="error"
+					>
+						<strong>Warning</strong>: Notifications are only supported over HTTPS
+						connections.
 					</div>
 					<div
 						v-if="$store.state.desktopNotificationState === 'blocked'"

--- a/client/js/store.js
+++ b/client/js/store.js
@@ -12,6 +12,8 @@ function detectDesktopNotificationState() {
 		return "unsupported";
 	} else if (Notification.permission === "granted") {
 		return "granted";
+	} else if (!window.isSecureContext) {
+		return "nohttps";
 	}
 
 	return "blocked";


### PR DESCRIPTION
Notifications [are not allowed from insecure origins](https://sites.google.com/a/chromium.org/dev/Home/chromium-security/deprecating-powerful-features-on-insecure-origins), and right now, there's no check for it and just fallbacks to "being blocked by the browser". This applies consistency with push notifications: it disables the checkbox and displays a warning in case the user is using an insecure origin.