### PR TITLE
Fix /away handling no arguments

### DIFF
--- a/src/plugins/inputs/away.js
+++ b/src/plugins/inputs/away.js
@@ -6,7 +6,7 @@ exports.input = function (network, chan, cmd, args) {
 	let reason = "";
 
 	if (cmd === "away") {
-		reason = args.join(" ") || " ";
+		reason = args.join(" ") || "";
 
 		network.irc.raw("AWAY", reason);
 	} else {


### PR DESCRIPTION
/away with no arguments removes a users away status. Currently, we're setting the status to an empty string if no arguments are passed.