### PR TITLE
Always chmod home dir on startup

### DIFF
--- a/src/command-line/start.js
+++ b/src/command-line/start.js
@@ -23,7 +23,6 @@ program
 function initalizeConfig() {
 	if (!fs.existsSync(Helper.getConfigPath())) {
 		fs.mkdirSync(Helper.getHomePath(), {recursive: true});
-		fs.chmodSync(Helper.getHomePath(), "0700");
 		fs.copyFileSync(
 			path.resolve(path.join(__dirname, "..", "..", "defaults", "config.js")),
 			Helper.getConfigPath()
@@ -31,5 +30,6 @@ function initalizeConfig() {
 		log.info(`Configuration file created at ${colors.green(Helper.getConfigPath())}.`);
 	}
 
+	fs.chmodSync(Helper.getHomePath(), "0700");
 	fs.mkdirSync(Helper.getUsersPath(), {recursive: true});
 }


### PR DESCRIPTION
Helps to prevent and retrospectively address issues like
thelounge/thelounge-deb#72

Obviously some sysadmins may want the directory to be world-readable,
but presently, that isn't safe.

This commit could be omitted or later reverted if sensitive data
protection is ensured through other means - e.g. with patches for
existing files, and an emphasis at review time to catch over-exposure in
the future ✌

Currently world-readable without this patch are: logs/**/*, vapid.json