### PR TITLE
Do not condense single messages

### DIFF
--- a/client/components/MessageList.vue
+++ b/client/components/MessageList.vue
@@ -138,7 +138,15 @@ export default {
 				}
 			}
 
-			return condensed;
+			return condensed.map((message) => {
+				// Skip condensing single messages, it doesn't save any
+				// space but makes useful information harder to see
+				if (message.type === "condensed" && message.messages.length === 1) {
+					return message.messages[0];
+				}
+
+				return message;
+			});
 		},
 	},
 	watch: {


### PR DESCRIPTION
Skip condensing into groups of one message. It doesn't save much (if any) space but makes the mode changes harder to see without clicking.

Old:
![Screenshot from 2021-09-18 18-08-58](https://user-images.githubusercontent.com/9721638/133893464-10e46e53-4496-482b-92bd-f06aa8a92258.png)
New:
![Screenshot from 2021-09-18 18-06-24](https://user-images.githubusercontent.com/9721638/133893467-a3654307-1271-4007-a302-ccd8b1a62643.png)

