### PR TITLE
Properly mute a channel

### DIFF
--- a/client/components/Channel.vue
+++ b/client/components/Channel.vue
@@ -1,9 +1,12 @@
 <template>
 	<ChannelWrapper ref="wrapper" v-bind="$props">
 		<span class="name">{{ channel.name }}</span>
-		<span v-if="channel.unread" :class="{highlight: channel.highlight}" class="badge">{{
-			unreadCount
-		}}</span>
+		<span
+			v-if="channel.unread"
+			:class="{highlight: channel.highlight && !channel.muted}"
+			class="badge"
+			>{{ unreadCount }}</span
+		>
 		<template v-if="channel.type === 'channel'">
 			<span
 				v-if="channel.state === 0"

--- a/client/components/Mentions.vue
+++ b/client/components/Mentions.vue
@@ -173,7 +173,7 @@ export default {
 				message.channel = this.$store.getters.findChannel(message.chanId);
 			}
 
-			return messages;
+			return messages.filter((message) => !message.channel.channel.muted);
 		},
 	},
 	watch: {

--- a/client/components/Windows/Help.vue
+++ b/client/components/Windows/Help.vue
@@ -595,6 +595,20 @@
 
 			<div class="help-item">
 				<div class="subject">
+					<code>/mute [...channel]</code>
+				</div>
+				<div class="description">
+					<p>
+						Prevent messages from generating any feedback for a channel. This turns off
+						the highlight indicator, hides mentions and inhibits push notifications.
+						Muting a network lobby mutes the whole network. Not specifying any channel
+						target mutes the current channel. Revert with <code>/unmute</code>
+					</p>
+				</div>
+			</div>
+
+			<div class="help-item">
+				<div class="subject">
 					<code>/nick newnick</code>
 				</div>
 				<div class="description">
@@ -724,6 +738,20 @@
 					<p>
 						Unblock messages from the specified user on the current network. This can be
 						a nickname or a hostmask.
+					</p>
+				</div>
+			</div>
+
+			<div class="help-item">
+				<div class="subject">
+					<code>/unmute channel [...channel]</code>
+				</div>
+				<div class="description">
+					<p>
+						Re-enable push notifications for a muted channel or private message,
+						activate the highlight indicator and show messages in the mention window.
+						Unmuting a network lobby mutes the whole network. Not specifying any channel
+						target unmutes the current channel. Mute a channel with <code>/mute</code>.
 					</p>
 				</div>
 			</div>


### PR DESCRIPTION
When a channel is muted it should neither generate a mention,
nor should it be highlighted specially.
This is done in a "soft" manner, meaning unmuting a channel brings it
back.