### PR TITLE
client/Mentions: change button copy to "Dismiss all"

### DIFF
--- a/client/components/Mentions.vue
+++ b/client/components/Mentions.vue
@@ -13,7 +13,7 @@
 					class="btn hide-all-mentions"
 					@click="hideAllMentions()"
 				>
-					Hide all
+					Dismiss all
 				</button>
 			</div>
 			<template v-if="resolvedMessages.length === 0">


### PR DESCRIPTION
```
14:56 <williamboman> Minor nitpick of mine: Am I the only one who finds the copy for the "Hide all" button in the Recent mentions popup a bit misleading? In my mind, hiding something suggests you can unhide it. What about "Dismiss all"?
15:00 <+bookworm> makes sense to me
15:00 <+bookworm> (s/hide/dismiss/ that is)
15:07 <xnaas> I concur on dismiss vs hide as well
```