### PR TITLE
Vertically center topic editing input in Safari.

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -1067,6 +1067,7 @@ textarea.input {
 	height: 35px;
 	overflow: hidden;
 	font-size: 14px;
+	line-height: normal;
 	outline: none;
 }
 


### PR DESCRIPTION
It was significantly misaligned. Change tested on recent Chrome,
Safari, and Firefox on Mac OS X.

--

**Before**

<img width="756" alt="Screenshot of topic bar. The bounds of the text input is vertically off center, pushed upwards significantly." src="https://user-images.githubusercontent.com/367832/136651938-159fec08-3d58-42e2-ab33-a9567b5b55cb.png">

**After**

<img width="778" alt="Screenshot of topic bar without alignment issues" src="https://user-images.githubusercontent.com/367832/136651908-25f2baea-ed93-4a18-90f2-5f90b244e40f.png">
