### PR TITLE
Prevent sporadic rounding of search input on iOS.

### DIFF
--- a/client/components/NetworkList.vue
+++ b/client/components/NetworkList.vue
@@ -141,6 +141,7 @@
 	color: #fff;
 	background-color: rgba(255, 255, 255, 0.1);
 	padding-right: 35px;
+	appearance: none;
 }
 
 .jump-to-input .input::placeholder {


### PR DESCRIPTION
Safari on iOS would sometimes override the styling of the search input
and set the `border-radius` much higher. The effect would then
dissappear if the DOM was changed.

--

Easiest way to reproduce this (on an iOS device) prior to this change is to open the sidebar, lock/turn your screen off, then turn your screen back on and take a look again. The search input will become rounded:

<img src="https://user-images.githubusercontent.com/367832/136715084-73568630-395f-44cf-94a4-bdc9dfa843f6.PNG" width="200" />

If you then hid and then reposed the sidebar, it would return to normal:

<img src="https://user-images.githubusercontent.com/367832/136715095-66868b2a-f50f-4608-acd2-67cc60760795.PNG" width="200" />