### PR TITLE
Add more plugin functionality

### DIFF
--- a/src/plugins/packages/index.js
+++ b/src/plugins/packages/index.js
@@ -47,6 +47,12 @@ const packageApis = function (packageInfo) {
 		Config: {
 			getConfig: () => Helper.config,
 		},
+		Logger: {
+			error: (...args) => log.error(...args),
+			warn: (...args) => log.warn(...args),
+			info: (...args) => log.info(...args),
+			debug: (...args) => log.debug(...args),
+		},
 	};
 };
 

--- a/src/plugins/packages/index.js
+++ b/src/plugins/packages/index.js
@@ -46,6 +46,7 @@ const packageApis = function (packageInfo) {
 		},
 		Config: {
 			getConfig: () => Helper.config,
+			getPersistentStorageDir: getPersistentStorageDir.bind(this, packageInfo.packageName),
 		},
 		Logger: {
 			error: (...args) => log.error(...args),
@@ -85,6 +86,12 @@ function getEnabledPackages(packageJson) {
 	}
 
 	return [];
+}
+
+function getPersistentStorageDir(packageName) {
+	const dir = path.join(Helper.getPackagesPath(), packageName);
+	fs.mkdirSync(dir, {recursive: true}); // we don't care if it already exists or not
+	return dir;
 }
 
 function loadPackage(packageName) {

--- a/src/plugins/packages/index.js
+++ b/src/plugins/packages/index.js
@@ -49,10 +49,10 @@ const packageApis = function (packageInfo) {
 			getPersistentStorageDir: getPersistentStorageDir.bind(this, packageInfo.packageName),
 		},
 		Logger: {
-			error: (...args) => log.error(...args),
-			warn: (...args) => log.warn(...args),
-			info: (...args) => log.info(...args),
-			debug: (...args) => log.debug(...args),
+			error: (...args) => log.error(`[${packageInfo.packageName}]`, ...args),
+			warn: (...args) => log.warn(`[${packageInfo.packageName}]`, ...args),
+			info: (...args) => log.info(`[${packageInfo.packageName}]`, ...args),
+			debug: (...args) => log.debug(`[${packageInfo.packageName}]`, ...args),
 		},
 	};
 };


### PR DESCRIPTION
The plugin functionality has some gaps that need to be fixed.
Our usual recommended plugin to look at is minidiggers thelounge-plugin-shortcut, however that thing was buggy and accessed TL internals as the official plugin API didn't expose the necessary methods.

That can be fixed :) https://github.com/MiniDigger/thelounge-plugin-shortcuts/pull/31

Feedback appreciated if this is the proper way of doing it