### PR TITLE
Clean up global listener in Sidebar component.

### DIFF
--- a/client/components/Sidebar.vue
+++ b/client/components/Sidebar.vue
@@ -195,6 +195,9 @@ export default {
 
 		document.body.addEventListener("touchstart", this.onTouchStart, {passive: true});
 	},
+	destroyed() {
+		document.body.removeEventListener("touchstart", this.onTouchStart, {passive: true});
+	},
 	methods: {
 		isPublic: () => document.body.classList.contains("public"),
 	},


### PR DESCRIPTION
Every time the component was mounted it would add another listener.
Since old listeners would often error this could cause a lot of log
spam, particularly when using the hotloader on a mobile device.