### PR TITLE
Enable Android's context menus in network list.

### DIFF
--- a/client/components/ChannelWrapper.vue
+++ b/client/components/ChannelWrapper.vue
@@ -82,15 +82,11 @@ export default {
 			this.$root.switchToChannel(this.channel);
 		},
 		openContextMenu(event) {
-			// events.buttons will be 0 when the event is caused by a long
-			// touch on Android.
-			if (event.buttons !== 0) {
-				eventbus.emit("contextmenu:channel", {
-					event: event,
-					channel: this.channel,
-					network: this.network,
-				});
-			}
+			eventbus.emit("contextmenu:channel", {
+				event: event,
+				channel: this.channel,
+				network: this.network,
+			});
 		},
 	},
 };

--- a/client/css/style.css
+++ b/client/css/style.css
@@ -2252,6 +2252,14 @@ part/quit messages where we don't load previews (adds a blank line otherwise) */
 	background: transparent;
 }
 
+#context-menu-container.passthrough {
+	pointer-events: none;
+}
+
+#context-menu-container.passthrough > * {
+	pointer-events: auto;
+}
+
 .mentions-popup,
 #context-menu,
 .textcomplete-menu {

--- a/client/js/helpers/distance.js
+++ b/client/js/helpers/distance.js
@@ -1,0 +1,5 @@
+function distance([x1, y1], [x2, y2]) {
+	return Math.hypot(x1 - x2, y1 - y2);
+}
+
+export default distance;

--- a/client/js/helpers/listenForTwoFingerSwipes.js
+++ b/client/js/helpers/listenForTwoFingerSwipes.js
@@ -1,5 +1,7 @@
 "use strict";
 
+import distance from "./distance";
+
 // onTwoFingerSwipe will be called with a cardinal direction ("n", "e", "s" or
 // "w") as its only argument.
 function listenForTwoFingerSwipes(onTwoFingerSwipe) {
@@ -87,10 +89,6 @@ function getSwipe(hist) {
 	}
 
 	return getCardinalDirection(hist[0].center, hist[hist.length - 1].center);
-}
-
-function distance([x1, y1], [x2, y2]) {
-	return Math.hypot(x1 - x2, y1 - y2);
 }
 
 function getCardinalDirection([x1, y1], [x2, y2]) {

--- a/package.json
+++ b/package.json
@@ -127,6 +127,6 @@
     }
   },
   "resolutions": {
-    "sortablejs": "1.14.0"
+    "sortablejs": "git+https://github.com/itsjohncs/Sortable.git"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7527,10 +7527,9 @@ socks@^2.6.1:
     ip "^1.1.5"
     smart-buffer "^4.1.0"
 
-sortablejs@1.10.2, sortablejs@1.14.0:
+sortablejs@1.10.2, "sortablejs@git+https://github.com/itsjohncs/Sortable.git":
   version "1.14.0"
-  resolved "https://registry.yarnpkg.com/sortablejs/-/sortablejs-1.14.0.tgz#6d2e17ccbdb25f464734df621d4f35d4ab35b3d8"
-  integrity sha512-pBXvQCs5/33fdN1/39pPL0NZF20LeRbLQ5jtnheIPN9JQAaufGjKdWduZn4U7wCtVuzKhmRkI0DFYHYRbB2H1w==
+  resolved "git+https://github.com/itsjohncs/Sortable.git#21053e18ea6501e2aac8cac9029872115ab82844"
 
 source-list-map@^2.0.0, source-list-map@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
After #4326 Android users could no longer long-touch to bring up the
context menu for channels in the network list. Now they can again.

--

@brunnre8 was concerned with flashing the drag styles for users who are just trying to get the context menu. Implementing the basic functionality in this commit took me awhile unfortunately so I haven't been able to work on that.

But I'll play around with the design to address the flashing problem and I'll share a followup change if I succeed.