### PR TITLE
Fix sporadic rounding on message search bar.

### DIFF
--- a/client/components/MessageSearchForm.vue
+++ b/client/components/MessageSearchForm.vue
@@ -37,6 +37,7 @@ form.message-search input {
 	border: 0;
 	color: inherit;
 	background-color: #fafafa;
+	appearance: none;
 }
 
 form.message-search input::placeholder {


### PR DESCRIPTION
This is fixed in the same way as #4328.

--

Reported by @aab12345. Here's a screenshot of the search bar displaying the same rounding issue:

<img src="https://user-images.githubusercontent.com/367832/137423741-e30f156d-2099-4e7f-bab9-f34b9adf5f4b.PNG" width="200" alt="Image of search bar with its corners overly rounded" />

And after the fix is applied:

<img src="https://user-images.githubusercontent.com/367832/137423894-e73149c3-c2ca-441e-a349-e2cc10f999a3.jpeg" width="200" alt="Image of search bar with its corners a normal amount of rounded." />


