### PR TITLE
Prevent autocomplete for highlight settings

### DIFF
--- a/client/components/Windows/Settings.vue
+++ b/client/components/Windows/Settings.vue
@@ -386,6 +386,7 @@ expressions, it will trigger a highlight."
 						type="text"
 						name="highlights"
 						class="input"
+						autocomplete="off"
 						placeholder="Comma-separated, e.g.: word, some more words, anotherword"
 					/>
 				</label>
@@ -410,6 +411,7 @@ your nickname or expressions defined in custom highlights."
 						type="text"
 						name="highlightExceptions"
 						class="input"
+						autocomplete="off"
 						placeholder="Comma-separated, e.g.: word, some more words, anotherword"
 					/>
 				</label>


### PR DESCRIPTION
Chrome seems to somewhat often auto fill the text input of the
highlight exception list with my username as the next field that
follows is of type password.
Try to work around that by telling chrome not to autofill either of
those.

Do note that this is only a hint... The broser vendors apply some
$magic heuristics and if they trigger they ignore the hint.