### PR TITLE
Clarify description of prefetchMaxSearchSize.

### DIFF
--- a/defaults/config.js
+++ b/defaults/config.js
@@ -152,8 +152,9 @@ module.exports = {
 
 	// ### prefetchMaxSearchSize
 	//
-	// This value sets the maximum request size made to find the Open Graph tags
-	// for link previews. For some sites like YouTube this can easily exceed 300
+	// This value sets the maximum response size allowed when finding the Open
+	// Graph tags for link previews. The entire response is temporarily stored
+	// in memory and for some sites like YouTube this can easily exceed 300
 	// kilobytes.
 	//
 	// This value is set to `50` kilobytes by default.


### PR DESCRIPTION
This is a comments only change that fixes two problems:

1. The previous comment described it as limiting request size, but it
   instead limits the response size.
2. Previously it was unclear _why_ this size was significant. It wasn't
   obvious to me that the entire response would be stored in memory.