### PR TITLE
Improve responsiveness of channel name and topic.

### DIFF
--- a/client/components/Chat.vue
+++ b/client/components/Chat.vue
@@ -35,7 +35,11 @@
 							<span type="button" aria-label="Save topic"></span>
 						</span>
 					</div>
-					<span v-else :title="channel.topic" class="topic" @dblclick="editTopic"
+					<span
+						v-else
+						:title="channel.topic"
+						:class="{topic: true, empty: !channel.topic}"
+						@dblclick="editTopic"
 						><ParsedMessage
 							v-if="channel.topic"
 							:network="network"

--- a/client/css/style.css
+++ b/client/css/style.css
@@ -1051,7 +1051,10 @@ textarea.input {
 .header .title {
 	font-size: 15px;
 	padding-left: 6px;
-	flex-shrink: 0;
+	flex-shrink: 1;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 
 .topic-container {
@@ -1067,6 +1070,12 @@ textarea.input {
 	flex-grow: 1;
 	overflow: hidden;
 	font-size: 14px;
+	flex-shrink: 99999999;
+	min-width: 25px;
+}
+
+.header .topic.empty {
+	min-width: 0;
 }
 
 .header .topic-input {


### PR DESCRIPTION
This commit makes two changes:

1. Long channel names are truncated.
2. Topics cannot be shrinked into non-existence.

--

Fixes #4336

Screenshots of various screen sizes showing a very long channel name with a topic set:

<img width="315" alt="iPhone SE" src="https://user-images.githubusercontent.com/367832/138522295-84d9ad3a-bc0f-438c-a703-42c01cdf32ac.png">

<img width="311" alt="iPhone 8" src="https://user-images.githubusercontent.com/367832/138522299-185af2c8-0609-472a-8091-24a33c77cde5.png">

<img width="313" alt="iPhone 8 Plus" src="https://user-images.githubusercontent.com/367832/138522298-984542e1-0846-4577-93b5-231ede6bbe4d.png">

<img width="411" alt="iPad Mini" src="https://user-images.githubusercontent.com/367832/138522297-58636604-4392-44de-a6f4-3bbfd6581e42.png">

Screenshots showing a somewhat long channel name without a topic set:

<img width="308" alt="iPhone SE - No topic" src="https://user-images.githubusercontent.com/367832/138522655-39c82f13-7e08-46b7-9418-7d9b9a91ec99.png">

<img width="309" alt="iPhone 8 - No Topic" src="https://user-images.githubusercontent.com/367832/138522653-d7e37f7c-a691-48db-95e1-d91e04b1f58f.png">