### PR TITLE
bump vulnerable ua-parser-js version

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "semver": "7.3.5",
     "socket.io": "3.1.2",
     "tlds": "1.216.0",
-    "ua-parser-js": "0.7.28",
+    "ua-parser-js": "0.7.30",
     "uuid": "8.3.2",
     "web-push": "3.4.5",
     "yarn": "1.22.10"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8177,10 +8177,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-ua-parser-js@0.7.28:
-  version "0.7.28"
-  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.28.tgz#8ba04e653f35ce210239c64661685bf9121dec31"
-  integrity sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g==
+ua-parser-js@0.7.30:
+  version "0.7.30"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.30.tgz#4cf5170e8b55ac553fe8b38df3a82f0669671f0b"
+  integrity sha512-uXEtSresNUlXQ1QL4/3dQORcGv7+J2ookOG2ybA/ga9+HYEXueT2o+8dUJQkpedsyTyCJ6jCCirRcKtdtx1kbg==
 
 uc.micro@^1.0.1:
   version "1.0.6"


### PR DESCRIPTION
There's a malicious `ua-parser-js` NPM takeover, this PR bumps `ua-parser-js` version to the safe 0.7.30.

Security advisory: https://github.com/advisories/GHSA-pjwm-rvh2-c87w
GH thread: faisalman/ua-parser-js#536
