### PR TITLE
Csp

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -50,6 +50,7 @@ module.exports = function (options = {}) {
 	app.set("env", "production")
 		.disable("x-powered-by")
 		.use(allRequests)
+		.use(addSecurityHeaders)
 		.get("/", indexRequest)
 		.get("/service-worker.js", forceNoCacheRequest)
 		.get("/js/bundle.js.map", forceNoCacheRequest)
@@ -286,14 +287,7 @@ function allRequests(req, res, next) {
 	return next();
 }
 
-function forceNoCacheRequest(req, res, next) {
-	// Intermittent proxies must not cache the following requests,
-	// browsers must fetch the latest version of these files (service worker, source maps)
-	res.setHeader("Cache-Control", "no-cache, no-transform");
-	return next();
-}
-
-function indexRequest(req, res) {
+function addSecurityHeaders(req, res, next) {
 	const policies = [
 		"default-src 'none'", // default to nothing
 		"base-uri 'none'", // disallow <base>, has no fallback to default-src
@@ -317,9 +311,21 @@ function indexRequest(req, res) {
 		policies.push("img-src http: https: data:");
 	}
 
-	res.setHeader("Content-Type", "text/html");
 	res.setHeader("Content-Security-Policy", policies.join("; "));
 	res.setHeader("Referrer-Policy", "no-referrer");
+
+	return next();
+}
+
+function forceNoCacheRequest(req, res, next) {
+	// Intermittent proxies must not cache the following requests,
+	// browsers must fetch the latest version of these files (service worker, source maps)
+	res.setHeader("Cache-Control", "no-cache, no-transform");
+	return next();
+}
+
+function indexRequest(req, res) {
+	res.setHeader("Content-Type", "text/html");
 
 	return fs.readFile(
 		path.join(__dirname, "..", "client", "index.html.tpl"),


### PR DESCRIPTION
In custom themes we want to be able to load remote fonts and pictures, the TL CSP header would in principle allow it, but we didn't actually apply them to the plugins / themes.

Rather than playing whack a mole let's just globally apply the CSP.