### PR TITLE
Small cleanup of messageStorage/sqlite.

### DIFF
--- a/client/components/Windows/SearchResults.vue
+++ b/client/components/Windows/SearchResults.vue
@@ -124,7 +124,7 @@ export default {
 				return [];
 			}
 
-			return this.search.results.slice().reverse();
+			return this.search.results;
 		},
 		chan() {
 			const chanId = parseInt(this.$route.params.id, 10);

--- a/src/plugins/messageStorage/sqlite.js
+++ b/src/plugins/messageStorage/sqlite.js
@@ -236,7 +236,7 @@ class MessageStorage {
 						target: query.channelName,
 						networkUuid: query.networkUuid,
 						offset: query.offset,
-						results: parseSearchRowsToMessages(query.offset, rows),
+						results: parseSearchRowsToMessages(query.offset, rows).reverse(),
 					};
 					resolve(response);
 				}


### PR DESCRIPTION
* Extend test coverage to the `search` function.
* Test sort order of messages from `getMessages` and `search`
* Move reversal of `search` results from Vue to messageStorage.
* Remove unnecessary uses of `sqlite.serialize` in tests.
* Return promises from test functions where possible.

--

These changes were originally in #4334.