### PR TITLE
Allow wildcards in hostmask

### DIFF
--- a/test/tests/hostmask.js
+++ b/test/tests/hostmask.js
@@ -48,7 +48,14 @@ describe("Hostmask", function () {
 
 	it(".compareHostmask (wildcard)", function () {
 		const a = Helper.parseHostmask("nick!user@host");
-		const b = Helper.parseHostmask("nick!*@*");
+		const b = Helper.parseHostmask("n?ck!*@*");
+		expect(Helper.compareHostmask(b, a)).to.be.true;
+		expect(Helper.compareHostmask(a, b)).to.be.false;
+	});
+
+	it(".compareHostmask (wildcard - partial)", function () {
+		const a = Helper.parseHostmask("nicky!user@host");
+		const b = Helper.parseHostmask("nick*!*e?@?os*");
 		expect(Helper.compareHostmask(b, a)).to.be.true;
 		expect(Helper.compareHostmask(a, b)).to.be.false;
 	});
@@ -59,4 +66,48 @@ describe("Hostmask", function () {
 		expect(Helper.compareHostmask(b, a)).to.be.true;
 		expect(Helper.compareHostmask(a, b)).to.be.true;
 	});
+});
+
+describe("compareWithWildcard", function () {
+	const goodPairs = [
+		["asdf", "asdf"],
+		["AsDf", "asdf"],
+		["a?df*", "asdf"],
+		["*asdf*", "asdf"],
+		["*asdf", "asdf"],
+		["asd?", "asdf"],
+		["asd?*", "asdf"],
+		["a??f", "asdf"],
+		["a*", "asdf"],
+		["*f", "asdf"],
+		["*s*", "asdf"],
+		["*", ""],
+		["**", ""],
+	];
+
+	for (const t of goodPairs) {
+		it(`("${t[0]}", "${t[1]}")`, function () {
+			expect(Helper.compareWithWildcard(t[0], t[1])).to.be.true;
+		});
+	}
+
+	const badPairs = [
+		["asdf", "fdsa"],
+		["a?df*", "adfg"],
+		["?", ""],
+		["?asdf", "asdf"],
+		["?*", ""],
+		["*?*", ""],
+		["*?", ""],
+		["asd", "asdf"],
+		["sdf", "asdf"],
+		["sd", "asdf"],
+		["", "asdf"],
+	];
+
+	for (const t of badPairs) {
+		it(`("${t[0]}", "${t[1]}")`, function () {
+			expect(Helper.compareWithWildcard(t[0], t[1])).to.be.false;
+		});
+	}
 });


### PR DESCRIPTION
According to https://modern.ircdocs.horse/#wildcard-expressions
masks should support "*" and "?" wildcards.
Within TL this only impacts the /ignore functionality.

The reasoning for doing this is to ignore say GuestNNNN!*@* with
guest*!*@* and be done with it if someone spams a gateway.