### PR TITLE
Prevent round and white search styling in iOS 15.

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -1713,6 +1713,7 @@ part/quit messages where we don't load previews (adds a blank line otherwise) */
 
 #chat .userlist .search {
 	color: var(--body-color);
+	appearance: none;
 	border: 0;
 	background: none;
 	font: inherit;


### PR DESCRIPTION
This is fixed the same way as in #4333.

--

Before fix is applied:

<img src="https://user-images.githubusercontent.com/367832/140031891-67639855-8806-4ebe-969e-bbf40120f04c.PNG" width=200 alt="before">


After fix is applied:

<img src="https://user-images.githubusercontent.com/367832/140031920-d547096e-d00c-455c-ae75-d30376a873a2.PNG" width=200 alt="after">