### PR TITLE
Bump required node version to 12.x and add 16.x builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,10 +9,6 @@ jobs:
     strategy:
       matrix:
         include:
-          # EOL: April 2021
-          - os: ubuntu-latest
-            node_version: 10.x
-
           # EOL: April 2022
           - os: ubuntu-latest
             node_version: 12.x

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,14 +16,18 @@ jobs:
           # EOL: April 2023
           - os: ubuntu-latest
             node_version: 14.x
-          - os: macOS-latest
-            node_version: 14.x
-          - os: windows-latest
-            node_version: 14.x
 
           # EOL: June 2021
           - os: ubuntu-latest
             node_version: 15.x
+
+          # EOL: April 2024
+          - os: ubuntu-latest
+            node_version: 16.x
+          - os: macOS-latest
+            node_version: 16.x
+          - os: windows-latest
+            node_version: 16.x
 
     runs-on: ${{ matrix.os }}
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   ],
   "license": "MIT",
   "engines": {
-    "node": ">=10.15.0"
+    "node": ">=12.0.0"
   },
   "dependencies": {
     "bcryptjs": "2.4.3",


### PR DESCRIPTION
Node 10 was deprecated in April 2021.