### PR TITLE
Add /kickban

### DIFF
--- a/client/components/Windows/Help.vue
+++ b/client/components/Windows/Help.vue
@@ -583,10 +583,22 @@
 
 			<div class="help-item">
 				<div class="subject">
-					<code>/kick nick</code>
+					<code>/kick nick [reason]</code>
 				</div>
 				<div class="description">
 					<p>Kick a user from the current channel.</p>
+				</div>
+			</div>
+
+			<div class="help-item">
+				<div class="subject">
+					<code>/kickban nick [reason]</code>
+				</div>
+				<div class="description">
+					<p>
+						Kick and ban (<code>+b</code>) a user from the current channel. Unlike
+						<code>/ban</code>, only nicknames (and not host masks) can be used.
+					</p>
 				</div>
 			</div>
 

--- a/src/plugins/inputs/ban.js
+++ b/src/plugins/inputs/ban.js
@@ -3,7 +3,7 @@
 const Chan = require("../../models/chan");
 const Msg = require("../../models/msg");
 
-exports.commands = ["ban", "unban", "banlist"];
+exports.commands = ["ban", "unban", "banlist", "kickban"];
 
 exports.input = function ({irc}, chan, cmd, args) {
 	if (chan.type !== Chan.Type.CHANNEL) {
@@ -33,6 +33,9 @@ exports.input = function ({irc}, chan, cmd, args) {
 	}
 
 	switch (cmd) {
+		case "kickban":
+			irc.raw("KICK", chan.name, args[0], args.slice(1).join(" "));
+		// fall through
 		case "ban":
 			irc.ban(chan.name, args[0]);
 			break;


### PR DESCRIPTION
This patch adds a new command, /kickban, that is a combination of /kick and /ban: it kicks the specific user from the channel and then sets the +b mode to ban the user from the channel.
