### PR TITLE
Allow escape key to close search bar and search page

### DIFF
--- a/client/components/MessageSearchForm.vue
+++ b/client/components/MessageSearchForm.vue
@@ -9,6 +9,7 @@
 				class="input"
 				placeholder="Search messages…"
 				@blur="closeSearch"
+				@keyup.esc="closeSearch"
 			/>
 		</div>
 		<button

--- a/client/components/MessageSearchForm.vue
+++ b/client/components/MessageSearchForm.vue
@@ -114,6 +114,7 @@ export default {
 	methods: {
 		closeSearch() {
 			if (!this.onSearchPage) {
+				this.searchInput = "";
 				this.searchOpened = false;
 			}
 		},

--- a/client/components/Windows/SearchResults.vue
+++ b/client/components/Windows/SearchResults.vue
@@ -93,6 +93,7 @@
 
 <script>
 import socket from "../../js/socket";
+import eventbus from "../../js/eventbus";
 
 import SidebarToggle from "../SidebarToggle.vue";
 import Message from "../Message.vue";
@@ -171,10 +172,15 @@ export default {
 	mounted() {
 		this.setActiveChannel();
 		this.doSearch();
+
+		eventbus.on("escapekey", this.closeSearch);
 		this.$root.$on("re-search", this.doSearch); // Enable MessageSearchForm to search for the same query again
 	},
 	beforeDestroy() {
 		this.$root.$off("re-search");
+	},
+	destroyed() {
+		eventbus.off("escapekey", this.closeSearch);
 	},
 	methods: {
 		setActiveChannel() {


### PR DESCRIPTION
Allows the user to close and clear the search bar and to navigate back from the search results if they're open by using the `esc` key.