### PR TITLE
Revert "Preserve location on first and last line when scrolling through inputs"

### DIFF
--- a/client/components/ChatInput.vue
+++ b/client/components/ChatInput.vue
@@ -140,10 +140,11 @@ export default {
 				return;
 			}
 
-			const oldValue = this.$refs.input.value;
-			const oldPosition = this.$refs.input.selectionStart;
-			const onRow = (oldValue.slice(null, oldPosition).match(/\n/g) || []).length;
-			const totalRows = (oldValue.match(/\n/g) || []).length;
+			const onRow = (
+				this.$refs.input.value.slice(null, this.$refs.input.selectionStart).match(/\n/g) ||
+				[]
+			).length;
+			const totalRows = (this.$refs.input.value.match(/\n/g) || []).length;
 
 			const {channel} = this;
 
@@ -164,29 +165,7 @@ export default {
 			}
 
 			channel.pendingMessage = channel.inputHistory[channel.inputHistoryPosition];
-			const newValue = channel.pendingMessage;
-			this.$refs.input.value = newValue;
-
-			let newPosition;
-
-			if (key === "up") {
-				const lastIndexOfNewLine = newValue.lastIndexOf("\n");
-				const lastLine = newValue.slice(null, lastIndexOfNewLine);
-				newPosition =
-					oldPosition > lastLine.length
-						? newValue.length
-						: lastIndexOfNewLine + oldPosition + 1;
-			} else {
-				const lastPositionOnFirstLine =
-					newValue.indexOf("\n") === -1 ? newValue.length + 1 : newValue.indexOf("\n");
-				const relativeRowPos = oldPosition - oldValue.lastIndexOf("\n") - 1;
-				newPosition =
-					relativeRowPos > lastPositionOnFirstLine
-						? lastPositionOnFirstLine
-						: relativeRowPos;
-			}
-
-			this.$refs.input.setSelectionRange(newPosition, newPosition);
+			this.$refs.input.value = channel.pendingMessage;
 			this.setInputSize();
 
 			return false;


### PR DESCRIPTION
This reverts commit [c5f6b46](https://github.com/thelounge/thelounge/pull/4205/commits), half of PR #4205. The cursor location is now the end of the input when you go up or down. 

Closes #4362.

Note the other commit in the original PR, `Only scroll history when cursor is on first or last row`, is untouched by this.  