### PR TITLE
Remove downloads badge and add thelounge/thelounge-docker link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@
 		<a href="https://thelounge.chat/docs">Docs</a>
 		•
 		<a href="https://demo.thelounge.chat/">Demo</a>
+    •
+		<a href="https://github.com/thelounge/thelounge-docker">Docker</a>
 	</strong>
 </p>
 <p align="center">
@@ -28,9 +30,6 @@
 	<a href="https://github.com/thelounge/thelounge/actions"><img
 		alt="Build Status"
 		src="https://github.com/thelounge/thelounge/workflows/Build/badge.svg"></a>
-	<a href="https://npm-stat.com/charts.html?package=thelounge&from=2016-02-12"><img
-		alt="Total downloads on npm"
-		src="https://img.shields.io/npm/dy/thelounge.svg?colorA=333a41&colorB=007dc7&maxAge=3600&label=Downloads"></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
The download stat is fairly meaningless and afaict inaccurate. 