### PR TITLE
Offer to upload text to server if user tries to send a long message

### DIFF
--- a/client/components/ChatInput.vue
+++ b/client/components/ChatInput.vue
@@ -260,10 +260,30 @@ export default {
 				autocompletionRef.hide();
 			}
 
-			this.channel.inputHistoryPosition = 0;
-			this.channel.pendingMessage = "";
-			this.$refs.input.value = "";
-			this.setInputSize();
+			const resetInput = () => {
+				this.channel.inputHistoryPosition = 0;
+				this.channel.pendingMessage = "";
+				this.$refs.input.value = "";
+				this.setInputSize();
+			};
+
+			if (this.$store.state.serverConfiguration.fileUpload) {
+				const lines = 1 + (text.match(/\n/g) || "").length;
+
+				// TODO: Offer a confirmation to user whether they want to upload
+				if (lines > 3 || text.length > 700) {
+					resetInput();
+
+					const file = new File([text], "paste.txt", {
+						type: "text/plain",
+					});
+					upload.triggerUpload([file]);
+
+					return false;
+				}
+			}
+
+			resetInput();
 
 			// Store new message in history if last message isn't already equal
 			if (this.channel.inputHistory[1] !== text) {

--- a/client/components/ChatInput.vue
+++ b/client/components/ChatInput.vue
@@ -275,7 +275,7 @@ export default {
 					this.channel.inputHistory.splice(1, 0, text);
 				}
 
-				// Limit input history to a 100 entries
+				// Limit input history to 100 entries
 				if (this.channel.inputHistory.length > 100) {
 					this.channel.inputHistory.pop();
 				}
@@ -304,7 +304,8 @@ export default {
 						{
 							title: "Upload as file?",
 							text: `You're trying to send a lot of text. Would you like to upload it?`,
-							button: "Upload",
+							confirmButton: "Upload",
+							cancelButton: "Send anyway",
 						},
 						(result) => {
 							if (!result) {

--- a/client/components/ConfirmDialog.vue
+++ b/client/components/ConfirmDialog.vue
@@ -6,8 +6,12 @@
 				<p>{{ data.text }}</p>
 			</div>
 			<div class="confirm-buttons">
-				<button class="btn btn-cancel" @click="close(false)">Cancel</button>
-				<button class="btn btn-danger" @click="close(true)">{{ data.button }}</button>
+				<button class="btn btn-cancel" @click="close(false)">
+					{{ data.cancelButton || "Cancel" }}
+				</button>
+				<button class="btn btn-danger" @click="close(true)">
+					{{ data.confirmButton }}
+				</button>
 			</div>
 		</div>
 	</div>

--- a/client/js/helpers/contextMenu.js
+++ b/client/js/helpers/contextMenu.js
@@ -154,7 +154,7 @@ export function generateChannelContextMenu($root, channel, network) {
 					{
 						title: "Clear history",
 						text: `Are you sure you want to clear history for ${channel.name}? This cannot be undone.`,
-						button: "Clear history",
+						confirmButton: "Clear history",
 					},
 					(result) => {
 						if (!result) {

--- a/client/js/vue.js
+++ b/client/js/vue.js
@@ -36,7 +36,7 @@ new Vue({
 					{
 						title: "Remove network",
 						text: `Are you sure you want to quit and remove ${channel.name}? This cannot be undone.`,
-						button: "Remove network",
+						confirmButton: "Remove network",
 					},
 					(result) => {
 						if (!result) {


### PR DESCRIPTION
Seems to work okay, except that cancel/escape either needs to A) send the message anyways (current behavior) or B) close the modal and not send. The problem with B is that then there's no way to send the message without uploading it. 

I need to either revamp the ConfirmDialog to support multiple actions, allow the caller to distinguish how it was cancelled, or figure something else out. 