### PR TITLE
getGitCommit: allow git worktrees

### DIFF
--- a/src/helper.js
+++ b/src/helper.js
@@ -73,7 +73,7 @@ function getGitCommit() {
 		return _gitCommit;
 	}
 
-	if (!fs.existsSync(path.resolve(__dirname, "..", ".git", "HEAD"))) {
+	if (!fs.existsSync(path.resolve(__dirname, "..", ".git"))) {
 		_gitCommit = null;
 		return null;
 	}


### PR DESCRIPTION
Change the short circuit logic to only test for a .git path.
With worktrees that's just a file, not a directory and we really
shouldn't play git anyhow and not rely on implementation details.