### PR TITLE
Remove uses of window.event.

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -23,6 +23,10 @@ rules:
   no-duplicate-imports: error
   no-else-return: error
   no-implicit-globals: error
+  no-restricted-globals:
+    - error
+    - event
+    - fdescribe
   no-shadow: error
   no-template-curly-in-string: error
   no-unsafe-negation: error

--- a/client/components/Chat.vue
+++ b/client/components/Chat.vue
@@ -227,7 +227,7 @@ export default {
 				network: this.network,
 			});
 		},
-		openMentions() {
+		openMentions(event) {
 			eventbus.emit("mentions:toggle", {
 				event: event,
 			});

--- a/client/components/InlineChannel.vue
+++ b/client/components/InlineChannel.vue
@@ -19,7 +19,7 @@ export default {
 		channel: String,
 	},
 	methods: {
-		openContextMenu() {
+		openContextMenu(event) {
 			eventbus.emit("contextmenu:inline-channel", {
 				event: event,
 				channel: this.channel,

--- a/client/components/NetworkList.vue
+++ b/client/components/NetworkList.vue
@@ -348,7 +348,7 @@ export default {
 			event.item.classList.remove("ui-sortable-dragging-touch-cue");
 			this.startDrag = null;
 		},
-		onDraggableTouchStart() {
+		onDraggableTouchStart(event) {
 			if (event.touches.length === 1) {
 				// This prevents an iOS long touch default behavior: selecting
 				// the nearest selectable text.

--- a/client/js/helpers/listenForTwoFingerSwipes.js
+++ b/client/js/helpers/listenForTwoFingerSwipes.js
@@ -39,7 +39,7 @@ function listenForTwoFingerSwipes(onTwoFingerSwipe) {
 
 	document.body.addEventListener(
 		"touchend",
-		function () {
+		function (event) {
 			if (event.touches.length >= 2) {
 				return;
 			}


### PR DESCRIPTION
window.event is a deprecated global that's set to the currently
dispatched event.

Tested by:

- Opened and closed mentions box by clicking its icon in the top bar
- Left and right clicked on an inline channel name and saw context menu
  open both times
- Two-finger swiped on iOS and saw channel change
- Long-touched and dragged channel in network list on iOS and reordered
  the list successfully