### PR TITLE
Have Renovate bot refresh our lockfile for us.

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "extends": ["config:base"],
   "ignorePaths": ["test/"],
   "labels": ["Type: Dependencies"],
+  "lockFileMaintenance": {"enabled": true},
   "stabilityDays": 1,
   "vulnerabilityAlerts": {
     "labels": ["Type: Security"]

--- a/renovate.json
+++ b/renovate.json
@@ -2,16 +2,14 @@
   "extends": ["config:base"],
   "ignorePaths": ["test/"],
   "labels": ["Type: Dependencies"],
-  "rebaseStalePrs": true,
-  "statusCheckVerify": true,
   "stabilityDays": 1,
   "vulnerabilityAlerts": {
     "labels": ["Type: Security"]
   },
   "packageRules": [
     {
-      "depTypeList": ["dependencies", "devDependencies"],
-      "extends": ["schedule:monthly"]
+      "extends": ["schedule:monthly"],
+      "matchDepTypes": ["dependencies", "devDependencies"]
     }
   ]
 }


### PR DESCRIPTION
I noticed that caniuse-lite wants to be updated regularly via
`npx browserslist@latest --update-db`. Renovate bot can do this if we
enable its `lockFileMaintenance` option
([source](https://github.com/renovatebot/renovate/issues/8615)).

I'm not sure exactly how annoying Renovate bot will be if we enable
this option but I figure we can just try it and disable it if it's
annoying.