### PR TITLE
Replace deprecated Renovate config options.

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,16 +2,14 @@
   "extends": ["config:base"],
   "ignorePaths": ["test/"],
   "labels": ["Type: Dependencies"],
-  "rebaseStalePrs": true,
-  "statusCheckVerify": true,
   "stabilityDays": 1,
   "vulnerabilityAlerts": {
     "labels": ["Type: Security"]
   },
   "packageRules": [
     {
-      "depTypeList": ["dependencies", "devDependencies"],
-      "extends": ["schedule:monthly"]
+      "extends": ["schedule:monthly"],
+      "matchDepTypes": ["dependencies", "devDependencies"]
     }
   ]
 }


### PR DESCRIPTION
This was an automatically requested migration that the
`renovate-config-validator` asked for. It's hard to tell because the
config options it asked to be removed are no longer in their docs, but
I believe this will not change the behavior of the renovate bot at all.