### PR TITLE
uploader.js: upload m4a as audio/mp4 | link.js: embed audio/mp4, x-flac, and x-m4a

### DIFF
--- a/src/plugins/irc-events/link.js
+++ b/src/plugins/irc-events/link.js
@@ -251,7 +251,7 @@ function parse(msg, chan, preview, res, client) {
 		case "audio/x-mpeg":
 		case "audio/x-mpeg-3":
 		case "audio/flac":
-		case "audio/x-m4a":
+		case "audio/mp4":
 			if (!preview.link.startsWith("https://")) {
 				break;
 			}

--- a/src/plugins/irc-events/link.js
+++ b/src/plugins/irc-events/link.js
@@ -251,7 +251,9 @@ function parse(msg, chan, preview, res, client) {
 		case "audio/x-mpeg":
 		case "audio/x-mpeg-3":
 		case "audio/flac":
+		case "audio/x-flac":
 		case "audio/mp4":
+		case "audio/x-m4a":
 			if (!preview.link.startsWith("https://")) {
 				break;
 			}

--- a/src/plugins/uploader.js
+++ b/src/plugins/uploader.js
@@ -117,6 +117,8 @@ class Uploader {
 			detectedMimeType = "audio/wav";
 		} else if (detectedMimeType === "audio/x-flac") {
 			detectedMimeType = "audio/flac";
+		} else if (detectedMimeType === "audio/x-m4a") {
+			detectedMimeType = "audio/mp4";
 		}
 
 		res.setHeader("Content-Disposition", disposition);


### PR DESCRIPTION
Trying to follow the MDN, it says that `.m4a` should be set to `audio/mp4`.

This PR makes it so that an `.m4a` file uploaded through The Lounge has the mime type `audio/mp4` set. This also ensures that files being served with `audio/mp4` are embedded by The Lounge.

The only sample `.m4a` files I could find to test with that wasn't something I already have or uploaded were:

* https://dl.espressif.com/dl/audio/ff-16b-2c-44100hz.m4a
* https://dl.espressif.com/dl/audio/ff-16b-1c-44100hz.m4a

but these set `audio/mpeg`, which TL already handles. 😅 It would seem that `.m4a`s are quite rare to just be openly hosted around.

Edit: I found https://filesamples.com/samples/audio/m4a/Symphony%20No.6%20(1st%20movement).m4a which seems to serve as `audio/x-m4a`.

---

Source: https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Containers#browser_compatibility

Relevant previous PR: #4210.