### PR TITLE
Include leading '<' + remove leading ' ' when copying messages

### DIFF
--- a/client/components/Message.vue
+++ b/client/components/Message.vue
@@ -27,11 +27,11 @@
 			</span>
 		</template>
 		<template v-else-if="isAction()">
-			<span class="from"><span class="only-copy">*** </span></span>
+			<span class="from"><span class="only-copy">***&nbsp;</span></span>
 			<component :is="messageComponent" :network="network" :message="message" />
 		</template>
 		<template v-else-if="message.type === 'action'">
-			<span class="from"><span class="only-copy">* </span></span>
+			<span class="from"><span class="only-copy">*&nbsp;</span></span>
 			<span class="content" dir="auto">
 				<Username
 					:user="message.from"
@@ -53,21 +53,21 @@
 				<template v-if="message.from && message.from.nick">
 					<span class="only-copy" aria-hidden="true">&lt;</span>
 					<Username :user="message.from" :network="network" :channel="channel" />
-					<span class="only-copy" aria-hidden="true">&gt; </span>
+					<span class="only-copy" aria-hidden="true">&gt;&nbsp;</span>
 				</template>
 			</span>
 			<span v-else-if="message.type === 'plugin'" class="from">
 				<template v-if="message.from && message.from.nick">
 					<span class="only-copy" aria-hidden="true">[</span>
 					{{ message.from.nick }}
-					<span class="only-copy" aria-hidden="true">] </span>
+					<span class="only-copy" aria-hidden="true">]&nbsp;</span>
 				</template>
 			</span>
 			<span v-else class="from">
 				<template v-if="message.from && message.from.nick">
 					<span class="only-copy" aria-hidden="true">-</span>
 					<Username :user="message.from" :network="network" :channel="channel" />
-					<span class="only-copy" aria-hidden="true">- </span>
+					<span class="only-copy" aria-hidden="true">-&nbsp;</span>
 				</template>
 			</span>
 			<span class="content" dir="auto">

--- a/client/components/Message.vue
+++ b/client/components/Message.vue
@@ -17,9 +17,8 @@
 			aria-hidden="true"
 			:aria-label="messageTimeLocale"
 			class="time tooltipped tooltipped-e"
+			>{{ messageTime }}</span
 		>
-			{{ messageTime }}
-		</span>
 		<template v-if="message.type === 'unhandled'">
 			<span class="from">[{{ message.command }}]</span>
 			<span class="content">

--- a/client/css/style.css
+++ b/client/css/style.css
@@ -280,7 +280,8 @@ p {
 .only-copy {
 	font-size: 0;
 	opacity: 0;
-	width: 0;
+	width: 0.01px;  /* Must be non-zero to be the first selected character on Firefox */
+	display: inline-block;
 }
 
 /* Icons */


### PR DESCRIPTION
Closes GH-4369.

1. Fix missing leading '<'

Firefox does not seem to select leading (or trailing) characters that are
too small; so this commit sets a very small width, that is still large
enough to be selected.

This commit also adds `display: inline-block`, so the width is not
ignored; but this causes Chrome to ignore the space after `>`, so I made
it a non-breakable space.

An alternative is to make only the leading `only-copy` an
`inline-block`, but I think the non-breakable space is a good idea
regardless.

2. Remove leading ' ' when copying multiple messages