### PR TITLE
Show a nicer error in Chan.loadMessages() when network is misconfigured

### DIFF
--- a/src/models/chan.js
+++ b/src/models/chan.js
@@ -241,6 +241,12 @@ Chan.prototype.loadMessages = function (client, network) {
 		return;
 	}
 
+	if (!network.irc) {
+		// Network created, but misconfigured
+		log.warn(`Failed to load messages, network ${network.name} is not initialized.`);
+		return;
+	}
+
 	client.messageProvider
 		.getMessages(network, this)
 		.then((messages) => {

--- a/src/models/chan.js
+++ b/src/models/chan.js
@@ -243,7 +243,9 @@ Chan.prototype.loadMessages = function (client, network) {
 
 	if (!network.irc) {
 		// Network created, but misconfigured
-		log.warn(`Failed to load messages, network ${network.name} is not initialized.`);
+		log.warn(
+			`Failed to load messages for ${client.name}, network ${network.name} is not initialized.`
+		);
 		return;
 	}
 
@@ -276,7 +278,7 @@ Chan.prototype.loadMessages = function (client, network) {
 				requestZncPlayback(this, network, from);
 			}
 		})
-		.catch((err) => log.error(`Failed to load messages: ${err}`));
+		.catch((err) => log.error(`Failed to load messages for ${client.name}: ${err}`));
 };
 
 Chan.prototype.isLoggable = function () {


### PR DESCRIPTION
ie. an actual error message instead of crashing on a `null` value, with the error reported in GH-4150.

The real (and helpful) error message will be displayed in the client's server buffer, thanks to GH-4475