### PR TITLE
Use the DNS result order returned by the OS

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,4 +25,11 @@ if (!require("semver").satisfies(process.version, pkg.engines.node)) {
 	process.exit(1);
 }
 
+const dns = require("dns");
+
+// Set DNS result order early before anything that may depend on it happens.
+if (dns.setDefaultResultOrder) {
+	dns.setDefaultResultOrder("verbatim");
+}
+
 require("./src/command-line");


### PR DESCRIPTION
Calling [`setDefaultResultOrder('verbatim')`](https://nodejs.org/api/dns.html#dnssetdefaultresultorderorder) will make Node prefer IPv6 for socket connections (if possible) just like most other applications.
IMO this should be the default for any application in 2022 anyway but this is particularly relevant for IRC connections as highlighted by #3420.
The function was added in some version of Node 16/14 so there's an `if` for now.

closes #3420