### PR TITLE
Automatically update ignored list when ignoring / unignoring

### DIFF
--- a/client/components/Special/ListIgnored.vue
+++ b/client/components/Special/ListIgnored.vue
@@ -29,8 +29,8 @@ export default {
 		channel: Object,
 	},
 	methods: {
-		getLocaletime(date) {
-			return localetime(date);
+		getLocaletime(datetime) {
+			return localetime(datetime);
 		},
 	},
 };

--- a/client/components/Special/ListIgnored.vue
+++ b/client/components/Special/ListIgnored.vue
@@ -9,7 +9,7 @@
 		<tbody>
 			<tr v-for="user in channel.data" :key="user.hostmask">
 				<td class="hostmask"><ParsedMessage :network="network" :text="user.hostmask" /></td>
-				<td class="when">{{ localetime(user.when) }}</td>
+				<td class="when">{{ getLocaletime(user.when) }}</td>
 			</tr>
 		</tbody>
 	</table>
@@ -29,7 +29,7 @@ export default {
 		channel: Object,
 	},
 	methods: {
-		localetime(date) {
+		getLocaletime(date) {
 			return localetime(date);
 		},
 	},

--- a/client/components/Special/ListIgnored.vue
+++ b/client/components/Special/ListIgnored.vue
@@ -1,5 +1,5 @@
 <template>
-	<div v-if="channel.data.length === 0" class="empty-list">Your ignorelist is empty.</div>
+	<div v-if="channel.data.length === 0" class="empty-ignore-list">Your ignorelist is empty.</div>
 	<table v-else class="ignore-list">
 		<thead>
 			<tr>
@@ -17,7 +17,7 @@
 </template>
 
 <style scoped>
-.empty-list {
+.empty-ignore-list {
 	padding: 0 0.5rem;
 }
 </style>

--- a/client/components/Special/ListIgnored.vue
+++ b/client/components/Special/ListIgnored.vue
@@ -1,5 +1,6 @@
 <template>
-	<table class="ignore-list">
+	<div v-if="channel.data.length === 0" class="empty-list">Your ignorelist is empty.</div>
+	<table v-else class="ignore-list">
 		<thead>
 			<tr>
 				<th class="hostmask">Hostmask</th>
@@ -14,6 +15,12 @@
 		</tbody>
 	</table>
 </template>
+
+<style scoped>
+.empty-list {
+	padding: 0 0.5rem;
+}
+</style>
 
 <script>
 import ParsedMessage from "../ParsedMessage.vue";

--- a/client/js/socket-events/msg_special.js
+++ b/client/js/socket-events/msg_special.js
@@ -7,5 +7,8 @@ import {switchToChannel} from "../router";
 socket.on("msg:special", function (data) {
 	const channel = store.getters.findChannel(data.chan);
 	channel.channel.data = data.data;
-	switchToChannel(channel.channel);
+
+	if (data.focus) {
+		switchToChannel(channel.channel);
+	}
 });

--- a/src/plugins/inputs/ignore.js
+++ b/src/plugins/inputs/ignore.js
@@ -6,11 +6,12 @@ const Helper = require("../../helper");
 
 exports.commands = ["ignore", "unignore", "ignorelist"];
 
+const IGNORELIST_CHAN_NAME = "Ignored users";
+
 exports.input = function (network, chan, cmd, args) {
 	const client = this;
 	let target;
 	let hostmask;
-	let create_new_ignored_window = false;
 
 	function emitError(msg) {
 		chan.pushMessage(
@@ -38,23 +39,23 @@ exports.input = function (network, chan, cmd, args) {
 			// IRC nicks are case insensitive
 			if (hostmask.nick.toLowerCase() === network.nick.toLowerCase()) {
 				emitError("You can't ignore yourself");
-			} else if (
-				!network.ignoreList.some(function (entry) {
-					return Helper.compareHostmask(entry, hostmask);
-				})
-			) {
-				hostmask.when = Date.now();
-				network.ignoreList.push(hostmask);
-
-				client.save();
-				emitError(
-					`\u0002${hostmask.nick}!${hostmask.ident}@${hostmask.hostname}\u000f added to ignorelist`
-				);
-			} else {
-				emitError("The specified user/hostmask is already ignored");
+				return;
 			}
 
-			break;
+			if (hostmaskInList(network.ignoreList, hostmask)) {
+				emitError("The specified user/hostmask is already ignored");
+				return;
+			}
+
+			hostmask.when = Date.now();
+			network.ignoreList.push(hostmask);
+			client.save();
+			// TODO: This should not be an error, that's the happy path for gods sake...
+			emitError(
+				`\u0002${hostmask.nick}!${hostmask.ident}@${hostmask.hostname}\u000f added to ignorelist`
+			);
+			updateIgnoreList(client, network);
+			return;
 		}
 
 		case "unignore": {
@@ -62,67 +63,78 @@ exports.input = function (network, chan, cmd, args) {
 				return Helper.compareHostmask(entry, hostmask);
 			});
 
-			// Check if the entry exists before removing it, otherwise
-			// let the user know.
-			if (idx !== -1) {
-				network.ignoreList.splice(idx, 1);
-				client.save();
-				// TODO: This should not be an error, that's the happy path for gods sake...
-				emitError(
-					`Successfully removed \u0002${hostmask.nick}!${hostmask.ident}@${hostmask.hostname}\u000f from ignorelist`
-				);
-			} else {
+			if (idx === -1) {
 				emitError("The specified user/hostmask is not ignored");
+				return;
 			}
 
-			break;
+			network.ignoreList.splice(idx, 1);
+			client.save();
+			// TODO: This should not be an error, that's the happy path for gods sake...
+			emitError(
+				`Successfully removed \u0002${hostmask.nick}!${hostmask.ident}@${hostmask.hostname}\u000f from ignorelist`
+			);
+			updateIgnoreList(client, network);
+			return;
 		}
 
 		case "ignorelist":
 			if (network.ignoreList.length === 0) {
-				chan.pushMessage(
-					client,
-					new Msg({
-						type: Msg.Type.ERROR,
-						text: "Ignorelist is empty",
-					})
-				);
-			} else {
-				create_new_ignored_window = true;
+				emitError("Ignorelist is empty");
+				return;
 			}
 
+			createOrUpdateIgnoreList(client, network, false);
 			break;
 	}
+};
 
-	const chanName = "Ignored users";
-	const channel = network.getChannel(chanName);
+function updateIgnoreList(client, network, focus) {
+	const channel = network.getChannel(IGNORELIST_CHAN_NAME);
 
-	if (typeof channel === "undefined" && !create_new_ignored_window) {
+	if (typeof channel === "undefined") {
+		// nothing to do, there is no open ignorelist
 		return;
 	}
 
-	const ignored = network.ignoreList.map((data) => ({
+	const shouldFocus = focus === undefined ? false : focus; // default to no focus
+	client.emit("msg:special", {
+		chan: channel.id,
+		data: chanDataFromList(network.ignoreList),
+		focus: shouldFocus,
+	});
+}
+
+function createOrUpdateIgnoreList(client, network) {
+	const channel = network.getChannel(IGNORELIST_CHAN_NAME);
+
+	if (typeof channel !== "undefined") {
+		// already have an existing window, so update and focus
+		return updateIgnoreList(client, network, true);
+	}
+
+	const newChan = client.createChannel({
+		type: Chan.Type.SPECIAL,
+		special: Chan.SpecialType.IGNORELIST,
+		name: IGNORELIST_CHAN_NAME,
+		data: chanDataFromList(network.ignoreList),
+	});
+	client.emit("join", {
+		network: network.uuid,
+		chan: newChan.getFilteredClone(true),
+		index: network.addChannel(newChan),
+	});
+}
+
+function hostmaskInList(list, hostmask) {
+	return list.some(function (entry) {
+		return Helper.compareHostmask(entry, hostmask);
+	});
+}
+
+function chanDataFromList(list) {
+	return list.map((data) => ({
 		hostmask: `${data.nick}!${data.ident}@${data.hostname}`,
 		when: data.when,
 	}));
-
-	if (typeof channel === "undefined" && create_new_ignored_window) {
-		const newChan = client.createChannel({
-			type: Chan.Type.SPECIAL,
-			special: Chan.SpecialType.IGNORELIST,
-			name: chanName,
-			data: ignored,
-		});
-		client.emit("join", {
-			network: network.uuid,
-			chan: newChan.getFilteredClone(true),
-			index: network.addChannel(newChan),
-		});
-	} else {
-		client.emit("msg:special", {
-			chan: channel.id,
-			data: ignored,
-			focus: false,
-		});
-	}
-};
+}

--- a/src/plugins/irc-events/list.js
+++ b/src/plugins/irc-events/list.js
@@ -52,6 +52,7 @@ module.exports = function (irc, network) {
 			client.emit("msg:special", {
 				chan: chan.id,
 				data: msg,
+				focus: false,
 			});
 		}
 	}

--- a/src/plugins/irc-events/modelist.js
+++ b/src/plugins/irc-events/modelist.js
@@ -67,6 +67,7 @@ module.exports = function (irc, network) {
 			client.emit("msg:special", {
 				chan: chan.id,
 				data: data,
+				focus: false,
 			});
 		}
 	}


### PR DESCRIPTION
Title says it all ;)

When the ignore window is opened on the client it'll automatically update the ignored-user list. 

Added an additional message when the ignorelist is empty.

Fixed bug where an open ignorelist would not update when all ignore entries were removed.