### PR TITLE
Re-add missing space between timestamp and nick

### DIFF
--- a/client/components/Message.vue
+++ b/client/components/Message.vue
@@ -17,8 +17,8 @@
 			aria-hidden="true"
 			:aria-label="messageTimeLocale"
 			class="time tooltipped tooltipped-e"
-			>{{ messageTime }}</span
-		>
+			>{{ messageTime }}
+		</span>
 		<template v-if="message.type === 'unhandled'">
 			<span class="from">[{{ message.command }}]</span>
 			<span class="content">


### PR DESCRIPTION
It was accidentally removed by 027c5b4ff7d3f391438d8477e83e912c6ed0c96e

Thanks to @MaxLeiter for finding the issue