### PR TITLE
embed `video/quicktime` depends on #4501

### DIFF
--- a/src/plugins/irc-events/link.js
+++ b/src/plugins/irc-events/link.js
@@ -271,6 +271,7 @@ function parse(msg, chan, preview, res, client) {
 		case "video/webm":
 		case "video/ogg":
 		case "video/mp4":
+		case "video/quicktime":
 			if (!preview.link.startsWith("https://")) {
 				break;
 			}


### PR DESCRIPTION
alternatively: can depend on https://bugs.chromium.org/p/chromium/issues/detail?id=1120292#c6
