### PR TITLE
Plugins: include pre-releases in compatibility lookup

### DIFF
--- a/src/plugins/packages/index.js
+++ b/src/plugins/packages/index.js
@@ -109,7 +109,9 @@ function loadPackage(packageName) {
 
 		if (
 			packageInfo.thelounge.supports &&
-			!semver.satisfies(Helper.getVersionNumber(), packageInfo.thelounge.supports)
+			!semver.satisfies(Helper.getVersionNumber(), packageInfo.thelounge.supports, {
+				includePrerelease: true, // our pre-releases should respect the semver guarantees
+			})
 		) {
 			throw `v${packageInfo.version} does not support this version of The Lounge. Supports: ${packageInfo.thelounge.supports}`;
 		}


### PR DESCRIPTION
Semver doesn't treat pre-release versions as upgrades, meaning >4.3.0 isn't satisfied
by 4.3.1-rc.1.
For the purpose of TL plugins however, we are only interested in the semantic version and
expect that rc's adhere to the compatibility promise.