### PR TITLE
User: fix file permissions on create

### DIFF
--- a/src/clientManager.js
+++ b/src/clientManager.js
@@ -169,7 +169,9 @@ ClientManager.prototype.addUser = function (name, password, enableLog) {
 	};
 
 	try {
-		fs.writeFileSync(userPath, JSON.stringify(user, null, "\t"));
+		fs.writeFileSync(userPath, JSON.stringify(user, null, "\t"), {
+			mode: 0o600,
+		});
 	} catch (e) {
 		log.error(`Failed to create user ${colors.green(name)} (${e})`);
 		throw e;
@@ -231,7 +233,9 @@ ClientManager.prototype.saveUser = function (client, callback) {
 	try {
 		// Write to a temp file first, in case the write fails
 		// we do not lose the original file (for example when disk is full)
-		fs.writeFileSync(pathTemp, newUser);
+		fs.writeFileSync(pathTemp, newUser, {
+			mode: 0o600,
+		});
 		fs.renameSync(pathTemp, pathReal);
 
 		return callback ? callback() : true;

--- a/src/command-line/start.js
+++ b/src/command-line/start.js
@@ -31,5 +31,5 @@ function initalizeConfig() {
 		log.info(`Configuration file created at ${colors.green(Helper.getConfigPath())}.`);
 	}
 
-	fs.mkdirSync(Helper.getUsersPath(), {recursive: true});
+	fs.mkdirSync(Helper.getUsersPath(), {recursive: true, mode: 0o700});
 }

--- a/src/command-line/users/reset.js
+++ b/src/command-line/users/reset.js
@@ -63,7 +63,9 @@ function change(name, password) {
 
 	// Write to a temp file first, in case the write fails
 	// we do not lose the original file (for example when disk is full)
-	fs.writeFileSync(pathTemp, newUser);
+	fs.writeFileSync(pathTemp, newUser, {
+		mode: 0o600,
+	});
 	fs.renameSync(pathTemp, pathReal);
 
 	log.info(`Successfully reset password for ${colors.bold(name)}.`);


### PR DESCRIPTION
User files contain secrets and should be protected.
Chances are that the user folder can be protected as well,
so let's do that if TL is creating the folder.