### PR TITLE
cli: don't error if the user folder doesn't exist

### DIFF
--- a/src/clientManager.js
+++ b/src/clientManager.js
@@ -145,6 +145,10 @@ ClientManager.prototype.loadUser = function (name) {
 };
 
 ClientManager.prototype.getUsers = function () {
+	if (!fs.existsSync(Helper.getUsersPath())) {
+		return [];
+	}
+
 	return fs
 		.readdirSync(Helper.getUsersPath())
 		.filter((file) => file.endsWith(".json"))

--- a/src/command-line/users/list.js
+++ b/src/command-line/users/list.js
@@ -3,8 +3,6 @@
 const log = require("../../log");
 const colors = require("chalk");
 const program = require("commander");
-const fs = require("fs");
-const Helper = require("../../helper");
 const Utils = require("../utils");
 
 program
@@ -12,11 +10,6 @@ program
 	.description("List all users")
 	.on("--help", Utils.extraHelp)
 	.action(function () {
-		if (!fs.existsSync(Helper.getUsersPath())) {
-			log.error(`${Helper.getUsersPath()} does not exist.`);
-			return;
-		}
-
 		const ClientManager = require("../../clientManager");
 		const users = new ClientManager().getUsers();
 
@@ -25,16 +18,17 @@ program
 			return;
 		}
 
-		if (users.length > 0) {
-			log.info("Users:");
-			users.forEach((user, i) => {
-				log.info(`${i + 1}. ${colors.bold(user)}`);
-			});
-		} else {
+		if (users.length === 0) {
 			log.info(
 				`There are currently no users. Create one with ${colors.bold(
 					"thelounge add <name>"
 				)}.`
 			);
+			return;
 		}
+
+		log.info("Users:");
+		users.forEach((user, i) => {
+			log.info(`${i + 1}. ${colors.bold(user)}`);
+		});
 	});


### PR DESCRIPTION
The user folder gets created on demand, thelounge list should not
fail if the folder doesn't exist.
This just means that no users are present, so report that instead.