### PR TITLE
Improved PWA style mainly for new iOS devices

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -89,6 +89,8 @@ html,
 body {
 	height: 100%;
 	overscroll-behavior: none; /* prevent overscroll navigation actions */
+	margin-top: env(safe-area-inset-top);
+	padding-bottom: env(safe-area-inset-bottom);
 }
 
 body {
@@ -668,6 +670,7 @@ p {
 	max-height: 100%;
 	will-change: transform;
 	color: #b7c5d1; /* same as .channel-list-item color */
+	margin-left: env(safe-area-inset-left);
 }
 
 #viewport.menu-open #sidebar {
@@ -954,6 +957,7 @@ background on hover (unless active) */
 	flex-shrink: 0;
 	display: flex;
 	justify-content: center;
+	margin-bottom: env(safe-area-inset-bottom);
 }
 
 #footer button {
@@ -1067,6 +1071,8 @@ textarea.input {
 	display: flex;
 	flex-shrink: 0;
 	overflow: hidden;
+	padding-right: env(safe-area-inset-right);
+	padding-left: env(safe-area-inset-left);
 }
 
 #chat .header {
@@ -1199,6 +1205,7 @@ textarea.input {
 	flex-grow: 1;
 	overflow: hidden;
 	position: relative;
+	padding-left: env(safe-area-inset-left);
 }
 
 #chat .chat {
@@ -2207,6 +2214,7 @@ part/quit messages where we don't load previews (adds a blank line otherwise) */
 	display: flex;
 	align-items: flex-end;
 	position: relative;
+	padding-left: env(safe-area-inset-left);
 }
 
 #user-visible-error {
@@ -2707,6 +2715,10 @@ part/quit messages where we don't load previews (adds a blank line otherwise) */
 		max-height: 58px;
 		max-width: 104px;
 	}
+
+	.mentions-popup {
+		top: calc(45px + env(safe-area-inset-top));
+	}
 }
 
 @media (max-width: 479px) {
@@ -2932,4 +2944,8 @@ part/quit messages where we don't load previews (adds a blank line otherwise) */
 	height: 100%;
 	justify-content: center;
 	align-items: center;
+}
+
+#submit-tooltip {
+	padding-right: env(safe-area-inset-right);
 }

--- a/client/index.html.tpl
+++ b/client/index.html.tpl
@@ -3,7 +3,7 @@
 	<head>
 
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, user-scalable=no">
+	<meta name="viewport" content="width=device-width, user-scalable=no, viewport-fit=cover">
 
 	<link rel="preload" as="script" href="js/loading-error-handlers.js?v=<%- cacheBust %>">
 	<link rel="preload" as="script" href="js/bundle.vendor.js?v=<%- cacheBust %>">


### PR DESCRIPTION
On new devices with rounded corners, thelounge PWA version is unusable, this PR tries to fix it.

**Before changes:**
<img width="469" alt="before1" src="https://user-images.githubusercontent.com/6783135/159185492-5419e4fb-552f-4436-8797-fa66f08e12d7.png">
<img width="513" alt="before2" src="https://user-images.githubusercontent.com/6783135/159185494-6e01f51c-735f-4bb3-bf5e-813d922b8214.png">
<img width="469" alt="before3" src="https://user-images.githubusercontent.com/6783135/159185498-c79e81df-35db-40d2-8aca-215a7d4da097.png">
In the screenshots above, you can see that the clickable elements are too close to the edge of the screen.

**After changes:**
<img width="513" alt="after1" src="https://user-images.githubusercontent.com/6783135/159185509-25ad1935-06fc-4240-a860-9f656a78a55f.png">
<img width="469" alt="after2" src="https://user-images.githubusercontent.com/6783135/159185512-18b030dc-237e-4d82-a604-f38034e5b7c8.png">
<img width="469" alt="after3" src="https://user-images.githubusercontent.com/6783135/159185514-f92ea99e-f4e6-4700-84f0-f97c7261ebed.png">
<img width="861" alt="after4" src="https://user-images.githubusercontent.com/6783135/159185517-188dab81-b533-4537-b1ab-b4f57f20949d.png">
<img width="861" alt="after5" src="https://user-images.githubusercontent.com/6783135/159185521-1657be2d-9aeb-4f14-90f2-bbdaac4ef06e.png">
<img width="861" alt="after6" src="https://user-images.githubusercontent.com/6783135/159185522-3fc00bfe-40af-4daa-ac99-def33643b0dc.png">
<img width="861" alt="after7" src="https://user-images.githubusercontent.com/6783135/159185528-05f05eb7-da11-4120-b6be-31a689085a6b.png">


If anyone has any device with rounded corners (iOS, Android or other), I would ask to test this PR.

PR does not change the appearance of the app in the browser. It only modifies the appearance of the PWA application.