### PR TITLE
Add `prefetchTimeout` config setting

### DIFF
--- a/defaults/config.js
+++ b/defaults/config.js
@@ -159,7 +159,7 @@ module.exports = {
 	//
 	// This value is set to `50` kilobytes by default.
 	prefetchMaxSearchSize: 50,
-	
+
 	// ### `prefetchTimeout`
 	//
 	// When `prefetch` is enabled, this value sets the number of milliseconds

--- a/defaults/config.js
+++ b/defaults/config.js
@@ -159,6 +159,18 @@ module.exports = {
 	//
 	// This value is set to `50` kilobytes by default.
 	prefetchMaxSearchSize: 50,
+	
+	// ### `prefetchTimeout`
+	//
+	// When `prefetch` is enabled, this value sets the number of milliseconds
+	// before The Lounge gives up attempting to fetch a link. This can be useful
+	// if you've increased the `prefetchMaxImageSize`.
+	//
+	// Take caution, however, that an inordinately large value may lead to
+	// performance issues or even a denial of service, since The Lounge will not
+	// be able to clean up outgoing connections as quickly. Usually the default
+	// value is appropriate, so only change it if necessary.
+	prefetchTimeout: 5000,
 
 	// ### `fileUpload`
 	//

--- a/defaults/config.js
+++ b/defaults/config.js
@@ -170,6 +170,8 @@ module.exports = {
 	// performance issues or even a denial of service, since The Lounge will not
 	// be able to clean up outgoing connections as quickly. Usually the default
 	// value is appropriate, so only change it if necessary.
+	//
+	// This value is set to `5000` milliseconds by default.
 	prefetchTimeout: 5000,
 
 	// ### `fileUpload`

--- a/src/plugins/irc-events/link.js
+++ b/src/plugins/irc-events/link.js
@@ -12,7 +12,6 @@ const imageTypeRegex = /^image\/.+/;
 const mediaTypeRegex = /^(audio|video)\/.+/;
 const log = require("../../log");
 
-
 module.exports = function (client, chan, msg, cleanText) {
 	if (!Helper.config.prefetch) {
 		return;
@@ -386,7 +385,9 @@ function fetch(uri, headers) {
 	const prefetchTimeout = Helper.config.prefetchTimeout;
 
 	if (!prefetchTimeout) {
-		log.warn("prefetchTimeout is missing from your The Lounge configuration, defaulting to 5000 ms");
+		log.warn(
+			"prefetchTimeout is missing from your The Lounge configuration, defaulting to 5000 ms"
+		);
 	}
 
 	promise = new Promise((resolve, reject) => {

--- a/src/plugins/irc-events/link.js
+++ b/src/plugins/irc-events/link.js
@@ -10,6 +10,8 @@ const storage = require("../storage");
 const currentFetchPromises = new Map();
 const imageTypeRegex = /^image\/.+/;
 const mediaTypeRegex = /^(audio|video)\/.+/;
+const log = require("../../log");
+
 
 module.exports = function (client, chan, msg, cleanText) {
 	if (!Helper.config.prefetch) {
@@ -381,6 +383,12 @@ function fetch(uri, headers) {
 		return promise;
 	}
 
+	const prefetchTimeout = Helper.config.prefetchTimeout;
+
+	if (!prefetchTimeout) {
+		log.warn("prefetchTimeout is missing from your The Lounge configuration, defaulting to 5000 ms");
+	}
+
 	promise = new Promise((resolve, reject) => {
 		let buffer = Buffer.from("");
 		let contentLength = 0;
@@ -390,7 +398,7 @@ function fetch(uri, headers) {
 		try {
 			const gotStream = got.stream(uri, {
 				retry: 0,
-				timeout: Helper.config.prefetchTimeout, // milliseconds
+				timeout: prefetchTimeout || 5000, // milliseconds
 				headers: getRequestHeaders(headers),
 				https: {
 					rejectUnauthorized: false,

--- a/src/plugins/irc-events/link.js
+++ b/src/plugins/irc-events/link.js
@@ -390,7 +390,7 @@ function fetch(uri, headers) {
 		try {
 			const gotStream = got.stream(uri, {
 				retry: 0,
-				timeout: 5000,
+				timeout: Helper.config.prefetchTimeout, // milliseconds
 				headers: getRequestHeaders(headers),
 				https: {
 					rejectUnauthorized: false,


### PR DESCRIPTION
The problem I'm solving is that of uploading an image that's about 8 MB and other users being unable to preview it.

<img width="475" alt="Capture 2022-04-08 at 15 52 41" src="https://user-images.githubusercontent.com/528994/162543970-97206db0-4490-4933-86d1-c35c0b2c0b99.png">

This pull request adds a new configuration setting called `prefetchTimeout`. To my mind, it makes sense to add this alongside the existing configurations for prefetch size and search size, since changing those would result in longer requests.

I set the default value to 5000 ms, which is what it is currently hard-coded to be.

Security note: In my description for the default value, I caution against changing it unwarily, since it can hypothetically make The Lounge more vulnerable to denial of service attacks (e.g., by posting a huge number of large links in a short time, causing The Lounge to run out of available sockets, or by tying up a large amount of bandwidth). However, it's unclear to me how much functionality would be impacted by prefetch failing, and in any case, such a hypothetical vulnerability already exists (it's just harder to exploit with the default settings).

So I might be worried about nothing.