### PR TITLE
renovate: Disable digest updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["config:base"],
+  "extends": ["config:base", ":disableDigestUpdates"],
   "ignorePaths": ["test/"],
   "labels": ["Type: Dependencies"],
   "lockFileMaintenance": {"enabled": true},


### PR DESCRIPTION
There's a reason one pins a commit and it is because we
want that specific commit.
Renovate gets *really* noisy if commits are made frequently
to a repo, so let's disable it.