### PR TITLE
Use nick as a realname fallback

### DIFF
--- a/defaults/config.js
+++ b/defaults/config.js
@@ -241,7 +241,7 @@ module.exports = {
 	// - `nick`: Nick name. Percent signs (`%`) will be replaced by random
 	//   numbers from 0 to 9. For example, `Guest%%%` may become `Guest123`.
 	// - `username`: User name.
-	// - `realname`: Real name.
+	// - `realname`: Real name displayed by some clients. Defaults to the nick if set to ""
 	// - `leaveMessage`: Network specific leave message (overrides global leaveMessage)
 	// - `join`: Comma-separated list of channels to auto-join once connected.
 	//
@@ -271,7 +271,7 @@ module.exports = {
 		rejectUnauthorized: true,
 		nick: "thelounge%%",
 		username: "thelounge",
-		realname: "The Lounge User",
+		realname: "",
 		join: "#thelounge",
 		leaveMessage: "",
 	},

--- a/server/models/network.ts
+++ b/server/models/network.ts
@@ -190,7 +190,7 @@ class Network {
 		}
 
 		this.username = cleanString(this.username) || "thelounge";
-		this.realname = cleanString(this.realname) || "The Lounge User";
+		this.realname = cleanString(this.realname) || this.nick;
 		this.leaveMessage = cleanString(this.leaveMessage);
 		this.password = cleanString(this.password);
 		this.host = cleanString(this.host).toLowerCase();

--- a/test/models/network.ts
+++ b/test/models/network.ts
@@ -145,7 +145,7 @@ describe("Network", function () {
 			expect(network.validate({} as any)).to.be.true;
 			expect(network.nick).to.equal("thelounge");
 			expect(network.username).to.equal("thelounge");
-			expect(network.realname).to.equal("The Lounge User");
+			expect(network.realname).to.equal("thelounge");
 			expect(network.port).to.equal(6667);
 
 			const network2 = new Network({
@@ -184,6 +184,27 @@ describe("Network", function () {
 			expect(network2.host).to.equal("irc.example.com");
 
 			Config.values.lockNetwork = false;
+		});
+
+		it("realname should be set to nick only if realname is empty", function () {
+			const network = new Network({
+				host: "localhost",
+				nick: "dummy",
+			});
+
+			expect(network.validate({} as any)).to.be.true;
+			expect(network.nick).to.equal("dummy");
+			expect(network.realname).to.equal("dummy");
+
+			const network2 = new Network({
+				host: "localhost",
+				nick: "dummy",
+				realname: "notdummy",
+			});
+
+			expect(network2.validate({} as any)).to.be.true;
+			expect(network2.nick).to.equal("dummy");
+			expect(network2.realname).to.equal("notdummy");
 		});
 
 		it("should apply STS policies iff they match", function () {


### PR DESCRIPTION
Currently the realname is set to an advertisement if it isn't explicitly
set by the user.
Some clients started to show the realname as a display name in their
UI, which makes this tedious as you'll end up with gazillion "The Lounge
User" entries.

To avoid this, set the realname to the nick on first connect, so that
it is useful.
Note that this isn't done on nick changes, but only on the initial
connect step.

Fixes: https://github.com/thelounge/thelounge/issues/4527