### PR TITLE
Remove node 12, add node 18

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,10 +9,6 @@ jobs:
     strategy:
       matrix:
         include:
-          # EOL: April 2022
-          - os: ubuntu-latest
-            node_version: 12.x
-
           # EOL: April 2023
           - os: ubuntu-latest
             node_version: 14.x
@@ -24,6 +20,10 @@ jobs:
             node_version: 16.x
           - os: windows-latest
             node_version: 16.x
+
+          # EOL: April 2025
+          - os: ubuntu-latest
+            node_version: 18.x
 
     runs-on: ${{ matrix.os }}
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   ],
   "license": "MIT",
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "dependencies": {
     "@fastify/busboy": "1.0.0",


### PR DESCRIPTION
Move windows/macos to it later when it actually goes LTS.