### PR TITLE
Validate user input in /whois

### DIFF
--- a/src/plugins/inputs/whois.js
+++ b/src/plugins/inputs/whois.js
@@ -33,6 +33,13 @@ exports.input = function ({irc}, chan, cmd, args) {
 		}
 	};
 
+	if (!target) {
+		sendToClient({
+			error: `/${cmd} needs a target nick`,
+		});
+		return;
+	}
+
 	switch (cmd) {
 		case "whois":
 			irc.whois(target, targetNick, sendToClient);


### PR DESCRIPTION
We should probably check for the arguments, rather than sending invalid stuff