### PR TITLE
Add favoriting/pinning channels

### DIFF
--- a/client/components/Channel.vue
+++ b/client/components/Channel.vue
@@ -1,6 +1,6 @@
 <template>
 	<ChannelWrapper ref="wrapper" v-bind="$props">
-		<span class="name">{{ channel.name }}</span>
+		<span class="name">{{ name() }}</span>
 		<span
 			v-if="channel.unread"
 			:class="{highlight: channel.highlight && !channel.muted}"
@@ -50,6 +50,9 @@ export default {
 	methods: {
 		close() {
 			this.$root.closeChannel(this.channel);
+		},
+		name() {
+			return this.channel.displayName ? this.channel.displayName : this.channel.name;
 		},
 	},
 };

--- a/client/components/Channel.vue
+++ b/client/components/Channel.vue
@@ -15,13 +15,27 @@
 			>
 				<span class="parted-channel-icon" />
 			</span>
-			<span class="close-tooltip tooltipped tooltipped-w" aria-label="Leave">
-				<button class="close" aria-label="Leave" @click.stop="close" />
+			<span
+				class="close-tooltip tooltipped tooltipped-w"
+				:aria-label="channel.favorite ? 'Unfavorite' : 'Leave'"
+			>
+				<button
+					class="close"
+					:aria-label="channel.favorite ? 'Unfavorite' : 'Leave'"
+					@click.stop="close"
+				/>
 			</span>
 		</template>
 		<template v-else>
-			<span class="close-tooltip tooltipped tooltipped-w" aria-label="Close">
-				<button class="close" aria-label="Close" @click.stop="close" />
+			<span
+				class="close-tooltip tooltipped tooltipped-w"
+				:aria-label="channel.favorite ? 'Unfavorite' : 'Close'"
+			>
+				<button
+					class="close"
+					:aria-label="channel.favorite ? 'Unfavorite' : 'Close'"
+					@click.stop="close"
+				/>
 			</span>
 		</template>
 	</ChannelWrapper>

--- a/client/components/ChannelWrapper.vue
+++ b/client/components/ChannelWrapper.vue
@@ -57,6 +57,10 @@ export default {
 			const extra = [];
 			const type = this.channel.type;
 
+			if (this.channel.favorite) {
+				`favorited on ${this.network.name}`;
+			}
+
 			if (this.channel.unread > 0) {
 				if (this.channel.unread > 1) {
 					extra.push(`${this.channel.unread} unread messages`);

--- a/client/components/Chat.vue
+++ b/client/components/Chat.vue
@@ -13,13 +13,13 @@
 				:id="'chan-' + channel.id"
 				class="chat-view"
 				:data-type="channel.type"
-				:aria-label="channel.name"
+				:aria-label="channel.displayName ? channel.displayName : channel.name"
 				role="tabpanel"
 			>
 				<div class="header">
 					<SidebarToggle />
 					<span class="title" :aria-label="'Currently open ' + channel.type">{{
-						channel.name
+						channel.displayName ? channel.displayName : channel.name
 					}}</span>
 					<div v-if="channel.editTopic === true" class="topic-container">
 						<input

--- a/client/components/CollapseButton.css
+++ b/client/components/CollapseButton.css
@@ -1,0 +1,27 @@
+.collapse-network {
+	width: 40px;
+	opacity: 0.4;
+	padding-left: 11px;
+	transition: opacity 0.2s;
+	flex-shrink: 0;
+}
+
+.collapse-network-icon {
+	display: block;
+	width: 20px;
+	height: 20px;
+	transition: transform 0.2s;
+}
+
+.network.collapsed .collapse-network-icon {
+	transform: rotate(-90deg);
+}
+
+.collapse-network-icon::before {
+	content: "\f0d7"; /* http://fontawesome.io/icon/caret-down/ */
+	color: #fff;
+}
+
+.collapse-network:hover {
+	opacity: 1;
+}

--- a/client/components/CollapseFavoritesButton.vue
+++ b/client/components/CollapseFavoritesButton.vue
@@ -1,0 +1,36 @@
+<template>
+	<button
+		v-if="favorites.length > 0"
+		:aria-label="getExpandLabel()"
+		:aria-expanded="isCollapsed"
+		class="collapse-network"
+		@click.stop="onCollapseClick"
+	>
+		<span class="collapse-network-icon" />
+	</button>
+	<span v-else class="collapse-network" />
+</template>
+
+<style scoped>
+@import "./CollapseButton.css";
+</style>
+
+<script>
+export default {
+	name: "CollapseFavoritesButton",
+	props: {
+		onCollapseClick: Function,
+	},
+	data() {
+		return {
+			favorites: this.$store.state.favoriteChannels,
+			isCollapsed: !this.$store.state.favoritesOpen,
+		};
+	},
+	methods: {
+		getExpandLabel() {
+			return this.isCollapsed ? "Expand" : "Collapse";
+		},
+	},
+};
+</script>

--- a/client/components/CollapseNetworkButton.vue
+++ b/client/components/CollapseNetworkButton.vue
@@ -1,0 +1,32 @@
+<template>
+	<button
+		v-if="network.channels.length > 1"
+		:aria-controls="'network-' + network.uuid"
+		:aria-label="getExpandLabel(network)"
+		:aria-expanded="!network.isCollapsed"
+		class="collapse-network"
+		@click.stop="onCollapseClick"
+	>
+		<span class="collapse-network-icon" />
+	</button>
+	<span v-else class="collapse-network" />
+</template>
+
+<style scoped>
+@import "./CollapseButton.css";
+</style>
+
+<script>
+export default {
+	name: "CollapseNetworkButton",
+	props: {
+		network: Object,
+		onCollapseClick: Function,
+	},
+	methods: {
+		getExpandLabel(network) {
+			return network.isCollapsed ? "Expand" : "Collapse";
+		},
+	},
+};
+</script>

--- a/client/components/ContextMenu.vue
+++ b/client/components/ContextMenu.vue
@@ -43,6 +43,7 @@ import {
 	generateUserContextMenu,
 	generateChannelContextMenu,
 	generateInlineChannelContextMenu,
+	generateFavoritesContextMenu,
 } from "../js/helpers/contextMenu.js";
 import eventbus from "../js/eventbus";
 
@@ -70,6 +71,7 @@ export default {
 		eventbus.on("contextmenu:user", this.openUserContextMenu);
 		eventbus.on("contextmenu:channel", this.openChannelContextMenu);
 		eventbus.on("contextmenu:inline-channel", this.openInlineChannelContextMenu);
+		eventbus.on("contextmenu:favorites", this.openFavoritesContextMenu);
 	},
 	destroyed() {
 		eventbus.off("escapekey", this.close);
@@ -77,6 +79,7 @@ export default {
 		eventbus.off("contextmenu:user", this.openUserContextMenu);
 		eventbus.off("contextmenu:channel", this.openChannelContextMenu);
 		eventbus.off("contextmenu:inline-channel", this.openInlineChannelContextMenu);
+		eventbus.off("contextmenu:favorites", this.openFavoritesContextMenu);
 
 		this.close();
 	},
@@ -117,6 +120,10 @@ export default {
 					modes: [],
 				}
 			);
+			this.open(data.event, items);
+		},
+		openFavoritesContextMenu(data) {
+			const items = generateFavoritesContextMenu();
 			this.open(data.event, items);
 		},
 		open(event, items) {

--- a/client/components/Favorites.vue
+++ b/client/components/Favorites.vue
@@ -1,0 +1,75 @@
+<template>
+	<div class="favorites">
+		<div class="channel-list-item" data-type="lobby" @contextmenu.prevent="openContextMenu">
+			<div class="lobby-wrap">
+				<CollapseFavoritesButton :on-collapse-click="onCollapseClick" />
+				<span title="Favorites" class="name">Favorites</span>
+				<span v-if="unreadCount > 0" class="badge">{{ unreadCount }}</span>
+			</div>
+		</div>
+		<div v-for="channel in $store.state.favoriteChannels" :key="channel.id">
+			<Channel
+				:channel="channel"
+				:network="network"
+				:is-filtering="false"
+				:active="
+					$store.state.activeChannel && channel === $store.state.activeChannel.channel
+				"
+			/>
+		</div>
+	</div>
+</template>
+
+<style scoped>
+.lobby-wrap {
+	display: flex;
+	/* margin-left: 40px; */
+}
+</style>
+<script>
+import eventbus from "../js/eventbus";
+import roundBadgeNumber from "../js/helpers/roundBadgeNumber";
+import Channel from "./Channel.vue";
+import CollapseFavoritesButton from "./CollapseFavoritesButton.vue";
+
+export default {
+	name: "Favorites",
+	components: {
+		Channel,
+		CollapseFavoritesButton,
+	},
+	props: {
+		channels: Array,
+	},
+	computed: {
+		network() {
+			return {
+				isCollapsed: !this.$store.state.favoritesOpen,
+				status: {
+					connected: true,
+					secure: true,
+				},
+			};
+		},
+	},
+
+	methods: {
+		onCollapseClick() {
+			this.$store.commit("toggleFavorites");
+		},
+		openContextMenu(event) {
+			eventbus.emit("contextmenu:favorites", {
+				event: event,
+				channel: this.channel,
+			});
+		},
+		unreadCount() {
+			const unread = this.channels.reduce((acc, channel) => {
+				return acc + channel.unread || 0;
+			}, 0);
+
+			return roundBadgeNumber(unread);
+		},
+	},
+};
+</script>

--- a/client/components/Favorites.vue
+++ b/client/components/Favorites.vue
@@ -4,31 +4,39 @@
 			<div class="lobby-wrap">
 				<CollapseFavoritesButton :on-collapse-click="onCollapseClick" />
 				<span title="Favorites" class="name">Favorites</span>
-				<span v-if="unreadCount > 0" class="badge">{{ unreadCount }}</span>
 			</div>
 		</div>
-		<div v-for="channel in $store.state.favoriteChannels" :key="channel.id">
-			<Channel
-				:channel="channel"
-				:network="network"
-				:is-filtering="false"
-				:active="
-					$store.state.activeChannel && channel === $store.state.activeChannel.channel
-				"
-			/>
-		</div>
+		<Draggable
+			draggable=".channel-list-item"
+			ghost-class="ui-sortable-ghost"
+			drag-class="ui-sortable-dragging"
+			:group="network.uuid"
+			:list="channels"
+			:delay="longTouchDuration"
+			:delay-on-touch-only="true"
+			:touch-start-threshold="10"
+			class="channels"
+			@choose="onDraggableChoose"
+			@unchoose="onDraggableUnchoose"
+		>
+			<template v-for="channel in channels">
+				<Channel
+					:key="channel.id"
+					:channel="channel"
+					:network="network"
+					:is-filtering="false"
+					:active="
+						$store.state.activeChannel && channel === $store.state.activeChannel.channel
+					"
+				/>
+			</template>
+		</Draggable>
 	</div>
 </template>
 
-<style scoped>
-.lobby-wrap {
-	display: flex;
-	/* margin-left: 40px; */
-}
-</style>
 <script>
+import Draggable from "vuedraggable";
 import eventbus from "../js/eventbus";
-import roundBadgeNumber from "../js/helpers/roundBadgeNumber";
 import Channel from "./Channel.vue";
 import CollapseFavoritesButton from "./CollapseFavoritesButton.vue";
 
@@ -37,9 +45,13 @@ export default {
 	components: {
 		Channel,
 		CollapseFavoritesButton,
+		Draggable,
 	},
 	props: {
 		channels: Array,
+		onDraggableUnchoose: Function,
+		onDraggableChoose: Function,
+		longTouchDuration: Number,
 	},
 	computed: {
 		network() {
@@ -52,7 +64,6 @@ export default {
 			};
 		},
 	},
-
 	methods: {
 		onCollapseClick() {
 			this.$store.commit("toggleFavorites");
@@ -62,13 +73,6 @@ export default {
 				event: event,
 				channel: this.channel,
 			});
-		},
-		unreadCount() {
-			const unread = this.channels.reduce((acc, channel) => {
-				return acc + channel.unread || 0;
-			}, 0);
-
-			return roundBadgeNumber(unread);
 		},
 	},
 };

--- a/client/components/NetworkList.vue
+++ b/client/components/NetworkList.vue
@@ -80,7 +80,12 @@
 				role="region"
 				aria-live="polite"
 			>
-				<Favorites :channels="$store.state.favoriteChannels" />
+				<Favorites
+					:channels="$store.state.favoriteChannels"
+					:long-touch-duration="LONG_TOUCH_DURATION"
+					:on-draggable-unchoose="onDraggableUnchoose"
+					:on-draggable-choose="onDraggableChoose"
+				/>
 			</div>
 			<div
 				v-for="network in $store.state.networks"
@@ -277,8 +282,6 @@ export default {
 		Mousetrap.bind("alt+shift+right", this.expandNetwork);
 		Mousetrap.bind("alt+shift+left", this.collapseNetwork);
 		Mousetrap.bind("alt+j", this.toggleSearch);
-
-		console.log(this.$store.state.favoriteChannels[0]);
 	},
 	beforeDestroy() {
 		Mousetrap.unbind("alt+shift+right", this.expandNetwork);

--- a/client/components/NetworkList.vue
+++ b/client/components/NetworkList.vue
@@ -70,6 +70,19 @@
 			@unchoose="onDraggableUnchoose"
 		>
 			<div
+				v-if="$store.state.favoriteChannels.length"
+				id="favorites"
+				aria-label="Favorite channels"
+				class="network"
+				:class="{
+					collapsed: !$store.state.favoritesOpen,
+				}"
+				role="region"
+				aria-live="polite"
+			>
+				<Favorites :channels="$store.state.favoriteChannels" />
+			</div>
+			<div
 				v-for="network in $store.state.networks"
 				:id="'network-' + network.uuid"
 				:key="network.uuid"
@@ -101,7 +114,6 @@
 					:channel="network.channels[0]"
 					@toggle-join-channel="network.isJoinChannelShown = !network.isJoinChannelShown"
 				/>
-
 				<Draggable
 					draggable=".channel-list-item"
 					ghost-class="ui-sortable-ghost"
@@ -118,7 +130,7 @@
 				>
 					<template v-for="(channel, index) in network.channels">
 						<Channel
-							v-if="index > 0"
+							v-if="index > 0 && !channel.favorite"
 							:key="channel.id"
 							:channel="channel"
 							:network="network"
@@ -200,6 +212,7 @@ import Mousetrap from "mousetrap";
 import Draggable from "vuedraggable";
 import {filter as fuzzyFilter} from "fuzzy";
 import NetworkLobby from "./NetworkLobby.vue";
+import Favorites from "./Favorites.vue";
 import Channel from "./Channel.vue";
 import JoinChannel from "./JoinChannel.vue";
 
@@ -216,6 +229,7 @@ export default {
 		NetworkLobby,
 		Channel,
 		Draggable,
+		Favorites,
 	},
 	data() {
 		return {
@@ -263,6 +277,8 @@ export default {
 		Mousetrap.bind("alt+shift+right", this.expandNetwork);
 		Mousetrap.bind("alt+shift+left", this.collapseNetwork);
 		Mousetrap.bind("alt+j", this.toggleSearch);
+
+		console.log(this.$store.state.favoriteChannels[0]);
 	},
 	beforeDestroy() {
 		Mousetrap.unbind("alt+shift+right", this.expandNetwork);

--- a/client/components/NetworkLobby.vue
+++ b/client/components/NetworkLobby.vue
@@ -1,16 +1,6 @@
 <template>
 	<ChannelWrapper v-bind="$props" :channel="channel">
-		<button
-			v-if="network.channels.length > 1"
-			:aria-controls="'network-' + network.uuid"
-			:aria-label="getExpandLabel(network)"
-			:aria-expanded="!network.isCollapsed"
-			class="collapse-network"
-			@click.stop="onCollapseClick"
-		>
-			<span class="collapse-network-icon" />
-		</button>
-		<span v-else class="collapse-network" />
+		<CollapseNetworkButton :network="network" :on-collapse-click="onCollapseClick" />
 		<div class="lobby-wrap">
 			<span :title="channel.name" class="name">{{ channel.name }}</span>
 			<span
@@ -49,11 +39,13 @@
 import collapseNetwork from "../js/helpers/collapseNetwork";
 import roundBadgeNumber from "../js/helpers/roundBadgeNumber";
 import ChannelWrapper from "./ChannelWrapper.vue";
+import CollapseNetworkButton from "./CollapseNetworkButton.vue";
 
 export default {
 	name: "Channel",
 	components: {
 		ChannelWrapper,
+		CollapseNetworkButton,
 	},
 	props: {
 		network: Object,
@@ -75,9 +67,6 @@ export default {
 	methods: {
 		onCollapseClick() {
 			collapseNetwork(this.network, !this.network.isCollapsed);
-		},
-		getExpandLabel(network) {
-			return network.isCollapsed ? "Expand" : "Collapse";
 		},
 	},
 };

--- a/client/css/style.css
+++ b/client/css/style.css
@@ -372,6 +372,8 @@ p {
 .context-menu-clear-favorites::before,
 .context-menu-clear-history::before { content: "\f1f8"; /* https://fontawesome.com/icons/trash?style=solid */ }
 .context-menu-mute::before { content: "\f6a9"; /* https://fontawesome.com/v5.15/icons/volume-mute?style=solid */ }
+.context-menu-favorite::before { content: "\f005"; /* http://fontawesome.io/icon/star/ */ }
+
 
 .channel-list-item .not-secure-icon::before {
 	content: "\f071"; /* https://fontawesome.com/icons/exclamation-triangle?style=solid */
@@ -509,6 +511,7 @@ p {
 	content: "\f359"; /* https://fontawesome.com/icons/arrow-alt-circle-left?style=solid */
 	color: #2ecc40;
 }
+
 
 #chat .msg[data-type="action"] .from::before {
 	content: "\f005"; /* http://fontawesome.io/icon/star/ */

--- a/client/css/style.css
+++ b/client/css/style.css
@@ -369,11 +369,11 @@ p {
 .context-menu-action-revoke-mode::before { content: "\f068"; /* http://fontawesome.io/icon/minus/ */ }
 .context-menu-network::before { content: "\f233"; /* https://fontawesome.com/icons/server?style=solid */ }
 .context-menu-edit::before { content: "\f303"; /* https://fontawesome.com/icons/pencil-alt?style=solid */ }
+
 .context-menu-clear-favorites::before,
 .context-menu-clear-history::before { content: "\f1f8"; /* https://fontawesome.com/icons/trash?style=solid */ }
 .context-menu-mute::before { content: "\f6a9"; /* https://fontawesome.com/v5.15/icons/volume-mute?style=solid */ }
 .context-menu-favorite::before { content: "\f005"; /* http://fontawesome.io/icon/star/ */ }
-
 
 .channel-list-item .not-secure-icon::before {
 	content: "\f071"; /* https://fontawesome.com/icons/exclamation-triangle?style=solid */
@@ -511,7 +511,6 @@ p {
 	content: "\f359"; /* https://fontawesome.com/icons/arrow-alt-circle-left?style=solid */
 	color: #2ecc40;
 }
-
 
 #chat .msg[data-type="action"] .from::before {
 	content: "\f005"; /* http://fontawesome.io/icon/star/ */

--- a/client/css/style.css
+++ b/client/css/style.css
@@ -369,6 +369,7 @@ p {
 .context-menu-action-revoke-mode::before { content: "\f068"; /* http://fontawesome.io/icon/minus/ */ }
 .context-menu-network::before { content: "\f233"; /* https://fontawesome.com/icons/server?style=solid */ }
 .context-menu-edit::before { content: "\f303"; /* https://fontawesome.com/icons/pencil-alt?style=solid */ }
+.context-menu-clear-favorites::before,
 .context-menu-clear-history::before { content: "\f1f8"; /* https://fontawesome.com/icons/trash?style=solid */ }
 .context-menu-mute::before { content: "\f6a9"; /* https://fontawesome.com/v5.15/icons/volume-mute?style=solid */ }
 
@@ -917,34 +918,6 @@ background on hover (unless active) */
 .channel-list-item[data-type="lobby"] .add-channel.opened {
 	/* translateZ(0) enables hardware acceleration, this is to avoid jittering when animating */
 	transform: rotate(45deg) translateZ(0);
-}
-
-#sidebar .network .collapse-network {
-	width: 40px;
-	opacity: 0.4;
-	padding-left: 11px;
-	transition: opacity 0.2s;
-	flex-shrink: 0;
-}
-
-#sidebar .network .collapse-network-icon {
-	display: block;
-	width: 20px;
-	height: 20px;
-	transition: transform 0.2s;
-}
-
-#sidebar .network.collapsed .collapse-network-icon {
-	transform: rotate(-90deg);
-}
-
-#sidebar .network .collapse-network-icon::before {
-	content: "\f0d7"; /* http://fontawesome.io/icon/caret-down/ */
-	color: #fff;
-}
-
-#sidebar .collapse-network:hover {
-	opacity: 1;
 }
 
 #footer {

--- a/client/js/commands/favorite.js
+++ b/client/js/commands/favorite.js
@@ -1,0 +1,33 @@
+"use strict";
+import socket from "../socket";
+import store from "../store";
+
+function input(args) {
+	if (args.length === 0) {
+		const {channel} = store.state.activeChannel;
+
+		socket.emit("input", {
+			target: channel.id,
+			text: `/favorite ${channel.name}`,
+		});
+	} else {
+		for (const arg of args) {
+			for (const network of store.state.networks) {
+				const channel = network.channels.find((c) => c.name === arg);
+
+				if (!channel) {
+					continue;
+				}
+
+				socket.emit("input", {
+					target: channel.id,
+					text: `/favorite ${channel.name}`,
+				});
+			}
+		}
+	}
+
+	return true;
+}
+
+export default {input};

--- a/client/js/helpers/contextMenu.js
+++ b/client/js/helpers/contextMenu.js
@@ -88,6 +88,21 @@ export function generateChannelContextMenu($root, channel, network) {
 							}),
 				  },
 		];
+		// Add menu items for all except lobbies
+	} else {
+		// Add favorites item
+		items.push({
+			label: channel.favorite ? "Remove from favorites" : "Add to favorites",
+			type: "item",
+			class: "favorite",
+			action() {
+				if (channel.favorite) {
+					socket.emit("favorites:remove", channel.id);
+				} else {
+					socket.emit("favorites:add", channel.id);
+				}
+			},
+		});
 	}
 
 	// Add menu items for channels
@@ -202,6 +217,21 @@ export function generateChannelContextMenu($root, channel, network) {
 		class: "close",
 		action() {
 			$root.closeChannel(channel);
+		},
+	});
+
+	return items;
+}
+
+export function generateFavoritesContextMenu() {
+	const items = [];
+
+	items.push({
+		label: "Clear favorites",
+		type: "item",
+		class: "clear-favorites",
+		action() {
+			socket.emit("favorites:clear");
 		},
 	});
 

--- a/client/js/helpers/contextMenu.js
+++ b/client/js/helpers/contextMenu.js
@@ -97,9 +97,9 @@ export function generateChannelContextMenu($root, channel, network) {
 			class: "favorite",
 			action() {
 				if (channel.favorite) {
-					socket.emit("favorites:remove", channel.id);
+					socket.emit("favorites:remove", Number(channel.id));
 				} else {
-					socket.emit("favorites:add", channel.id);
+					socket.emit("favorites:add", Number(channel.id));
 				}
 			},
 		});
@@ -210,7 +210,6 @@ export function generateChannelContextMenu($root, channel, network) {
 		});
 	}
 
-	// Add close menu item
 	items.push({
 		label: closeMap[channel.type],
 		type: "item",

--- a/client/js/helpers/isChannelCollapsed.js
+++ b/client/js/helpers/isChannelCollapsed.js
@@ -3,7 +3,12 @@
 import store from "../store";
 
 export default (network, channel) => {
-	if (!network.isCollapsed || channel.highlight || channel.type === "lobby") {
+	if (
+		!network.isCollapsed ||
+		channel.highlight ||
+		channel.type === "lobby" ||
+		(channel.favorite === true && store.state.favoritesOpen)
+	) {
 		return false;
 	}
 

--- a/client/js/socket-events/favorites.js
+++ b/client/js/socket-events/favorites.js
@@ -4,7 +4,5 @@ import socket from "../socket";
 import store from "../store";
 
 socket.on("favorites", function (data) {
-	console.log("favorites", data);
-
 	store.commit("favoriteChannels", data.favoriteChannels);
 });

--- a/client/js/socket-events/favorites.js
+++ b/client/js/socket-events/favorites.js
@@ -1,0 +1,10 @@
+"use strict";
+
+import socket from "../socket";
+import store from "../store";
+
+socket.on("favorites", function (data) {
+	console.log("favorites", data);
+
+	store.commit("favoriteChannels", data.favoriteChannels);
+});

--- a/client/js/socket-events/index.js
+++ b/client/js/socket-events/index.js
@@ -27,3 +27,4 @@ import "./history_clear";
 import "./mentions";
 import "./search";
 import "./mute_changed";
+import "./favorites";

--- a/client/js/socket-events/init.js
+++ b/client/js/socket-events/init.js
@@ -11,6 +11,7 @@ socket.on("init", function (data) {
 	store.commit("networks", mergeNetworkData(data.networks));
 	store.commit("isConnected", true);
 	store.commit("currentUserVisibleError", null);
+	store.commit("favoriteChannels", data.favoriteChannels);
 
 	if (data.token) {
 		storage.set("token", data.token);

--- a/client/js/store.js
+++ b/client/js/store.js
@@ -132,7 +132,6 @@ const store = new Vuex.Store({
 			state.messageSearchResults = value;
 		},
 		favoriteChannels(state, payload) {
-			console.log("payload", payload);
 			state.favoriteChannels.forEach((channel) => {
 				channel.favorite = false;
 				channel.displayName = "";
@@ -159,7 +158,7 @@ const store = new Vuex.Store({
 						);
 
 						netChan.channel.displayName =
-							netChan.channel.name + `(${netChan.network.name})`;
+							netChan.channel.name + ` (${netChan.network.name})`;
 
 						otherNetChan.channel.displayName =
 							otherNetChan.channel.name + ` (${otherNetChan.network.name})`;

--- a/client/js/store.js
+++ b/client/js/store.js
@@ -28,6 +28,7 @@ const store = new Vuex.Store({
 		isAutoCompleting: false,
 		isConnected: false,
 		networks: [],
+		favoriteChannels: [],
 		mentions: [],
 		hasServiceWorker: false,
 		pushNotificationState: "unsupported",
@@ -43,6 +44,7 @@ const store = new Vuex.Store({
 		messageSearchResults: null,
 		messageSearchInProgress: false,
 		searchEnabled: false,
+		favoritesOpen: storage.get("thelounge.state.favorites") !== "false",
 	},
 	mutations: {
 		appLoaded(state) {
@@ -129,10 +131,59 @@ const store = new Vuex.Store({
 
 			state.messageSearchResults = value;
 		},
+		favoriteChannels(state, payload) {
+			console.log("payload", payload);
+			state.favoriteChannels.forEach((channel) => {
+				channel.favorite = false;
+				channel.displayName = "";
+			});
+
+			store.favoriteChannels = [];
+
+			// Channels can have the same name across networks, so we need to track and distinguish duplicates.
+			// We use a map so we can go back and update the channel that the name is a duplicate of.
+			// If they have a the same names on two different networks that have the same name,
+			// that's on them. I'm not paid to do this.
+			const names = new Map(); // Map of name --> { channelId, networkuuId }
+			state.favoriteChannels = payload.map(({channelId, networkUuid}) => {
+				const netChan = this.getters.findChannelOnNetworkById(networkUuid, channelId);
+				netChan.channel.favorite = true;
+
+				if (names.has(netChan.channel.name)) {
+					const dupe = names.get(netChan.channel.name);
+
+					if (dupe) {
+						const otherNetChan = this.getters.findChannelOnNetworkById(
+							dupe.networkId,
+							dupe.channelId
+						);
+
+						netChan.channel.displayName =
+							netChan.channel.name + `(${netChan.network.name})`;
+
+						otherNetChan.channel.displayName =
+							otherNetChan.channel.name + ` (${otherNetChan.network.name})`;
+					}
+				} else {
+					names.set(netChan.channel.name, {
+						channelId: netChan.channel.id,
+						networkId: netChan.network.uuid,
+					});
+				}
+
+				return netChan.channel;
+			});
+		},
+		toggleFavorites(state) {
+			state.favoritesOpen = !state.favoritesOpen;
+		},
 	},
 	actions: {
 		partChannel({commit, state}, netChan) {
 			const mentions = state.mentions.filter((msg) => !(msg.chanId === netChan.channel.id));
+			const favorites = state.favoriteChannels.filter((fav) => fav.id !== netChan.channel.id);
+
+			commit("favoriteChannels", favorites);
 			commit("mentions", mentions);
 		},
 	},
@@ -149,6 +200,21 @@ const store = new Vuex.Store({
 
 				for (const channel of network.channels) {
 					if (channel.name === channelName) {
+						return {network, channel};
+					}
+				}
+			}
+
+			return null;
+		},
+		findChannelOnNetworkById: (state) => (networkUuid, channelId) => {
+			for (const network of state.networks) {
+				if (network.uuid !== networkUuid) {
+					continue;
+				}
+
+				for (const channel of network.channels) {
+					if (channel.id === channelId) {
 						return {network, channel};
 					}
 				}

--- a/client/js/vue.js
+++ b/client/js/vue.js
@@ -50,16 +50,16 @@ new Vue({
 						});
 					}
 				);
+			} else if (channel.favorite) {
+				socket.emit("favorites:remove", Number(channel.id));
+			} else {
+				channel.closed = true;
 
-				return;
+				socket.emit("input", {
+					target: Number(channel.id),
+					text: "/close",
+				});
 			}
-
-			channel.closed = true;
-
-			socket.emit("input", {
-				target: Number(channel.id),
-				text: "/close",
-			});
 		},
 	},
 	render(createElement) {

--- a/client/js/vue.js
+++ b/client/js/vue.js
@@ -90,6 +90,13 @@ store.watch(
 );
 
 store.watch(
+	(state) => state.favoritesOpen,
+	(favoritesOpen) => {
+		storage.set("thelounge.state.favorites", favoritesOpen);
+	}
+);
+
+store.watch(
 	(_, getters) => getters.title,
 	(title) => {
 		document.title = title;

--- a/src/models/chan.js
+++ b/src/models/chan.js
@@ -42,6 +42,7 @@ function Chan(attr) {
 		highlight: 0,
 		users: new Map(),
 		muted: false,
+		favorite: false,
 	});
 }
 
@@ -297,6 +298,18 @@ Chan.prototype.isLoggable = function () {
 
 Chan.prototype.setMuteStatus = function (muted) {
 	this.muted = !!muted;
+};
+
+Chan.prototype.export = function () {
+	const keys = ["name", "muted", "favorite"];
+
+	if (this.type === Chan.Type.CHANNEL) {
+		keys.push("key");
+	} else if (this.type === Chan.Type.QUERY) {
+		keys.push("type");
+	}
+
+	return _.pick(this, keys);
 };
 
 function requestZncPlayback(channel, network, from) {

--- a/src/models/network.js
+++ b/src/models/network.js
@@ -533,15 +533,7 @@ Network.prototype.export = function () {
 			return channel.type === Chan.Type.CHANNEL || channel.type === Chan.Type.QUERY;
 		})
 		.map(function (chan) {
-			const keys = ["name", "muted"];
-
-			if (chan.type === Chan.Type.CHANNEL) {
-				keys.push("key");
-			} else if (chan.type === Chan.Type.QUERY) {
-				keys.push("type");
-			}
-
-			return _.pick(chan, keys);
+			return chan.export();
 		});
 
 	return network;

--- a/src/plugins/inputs/favorite.js
+++ b/src/plugins/inputs/favorite.js
@@ -1,0 +1,52 @@
+"use strict";
+
+const Msg = require("../../models/msg");
+const User = require("../../models/user");
+
+exports.commands = ["favorite"];
+exports.allowDisconnected = true;
+
+exports.input = function (network, chan, cmd, args) {
+	const client = this;
+
+	if (args.length === 0) {
+		chan.pushMessage(
+			client,
+			new Msg({
+				type: Msg.Type.ERROR,
+				text: `Usage: /favorite [channel-or-conversation-name]`,
+			})
+		);
+
+		return;
+	} else if (args.length === 1) {
+		const channel = network.channels.find((c) => c.name === args[0]);
+
+		if (!channel) {
+			chan.pushMessage(
+				client,
+				new Msg({
+					type: Msg.Type.ERROR,
+					text: `Channel or conversation ${args[0]} not found.`,
+				})
+			);
+			return;
+		}
+
+		this.addToFavorites(network.uuid, channel.id);
+
+		chan.pushMessage(
+			client,
+			new Msg({
+				// type: Msg.Type.ACTION,
+				text: `Favorited ${channel.name}`,
+				from: new User({
+					nick: network.irc.user.nick,
+				}),
+				self: true,
+			})
+		);
+	}
+
+	this.save();
+};

--- a/src/plugins/inputs/index.js
+++ b/src/plugins/inputs/index.js
@@ -36,6 +36,7 @@ const userInputs = [
 	"topic",
 	"whois",
 	"mute",
+	"favorite",
 ].reduce(function (plugins, name) {
 	const plugin = require(`./${name}`);
 	plugin.commands.forEach((command) => plugins.set(command, plugin));

--- a/src/server.js
+++ b/src/server.js
@@ -684,12 +684,10 @@ function initializeClient(socket, client, token, lastMessage, openChannel) {
 				}
 			}
 
-			for (const attachedClient of Object.keys(client.attachedClients)) {
-				manager.sockets.in(attachedClient).emit("mute:changed", {
-					target,
-					status: setMutedTo,
-				});
-			}
+			client.emitToAttachedClients("mute:changed", {
+				target,
+				status: setMutedTo,
+			});
 
 			client.save();
 		});
@@ -726,6 +724,38 @@ function initializeClient(socket, client, token, lastMessage, openChannel) {
 		}
 	});
 
+	socket.on("favorites:add", (channelId) => {
+		if (!channelId) {
+			return;
+		}
+
+		const {network, chan} = client.find(channelId);
+
+		if (!network || !chan) {
+			return;
+		}
+
+		client.addToFavorites(network.uuid, chan.id);
+	});
+
+	socket.on("favorites:remove", (channelId) => {
+		if (!channelId) {
+			return;
+		}
+
+		const {network, chan} = client.find(channelId);
+
+		if (!network || !chan) {
+			return;
+		}
+
+		client.removeFromFavorites(chan.id);
+	});
+
+	socket.on("favorites:clear", () => {
+		client.clearFavorites();
+	});
+
 	socket.join(client.id);
 
 	const sendInitEvent = (tokenToSend) => {
@@ -735,6 +765,7 @@ function initializeClient(socket, client, token, lastMessage, openChannel) {
 				network.getFilteredClone(openChannel, lastMessage)
 			),
 			token: tokenToSend,
+			favoriteChannels: client.favoriteChannels,
 		});
 		socket.emit("commands", inputs.getCommands());
 	};

--- a/test/models/chan.js
+++ b/test/models/chan.js
@@ -220,7 +220,8 @@ describe("Chan", function () {
 					"topic",
 					"type",
 					"unread",
-					"users"
+					"users",
+					"favorite"
 				);
 		});
 

--- a/test/models/network.js
+++ b/test/models/network.js
@@ -79,12 +79,17 @@ describe("Network", function () {
 				saslAccount: "testaccount",
 				saslPassword: "testpassword",
 				channels: [
-					new Chan({name: "#thelounge", key: "", muted: false}),
-					new Chan({name: "&foobar", key: "", muted: false}),
-					new Chan({name: "#secret", key: "foo", muted: false}),
-					new Chan({name: "&secure", key: "bar", muted: true}),
-					new Chan({name: "Channel List", type: Chan.Type.SPECIAL}),
-					new Chan({name: "PrivateChat", type: Chan.Type.QUERY, muted: true}),
+					new Chan({name: "#thelounge", key: "", muted: false, favorite: true}),
+					new Chan({name: "&foobar", key: "", muted: false, favorite: false}),
+					new Chan({name: "#secret", key: "foo", muted: false, favorite: true}),
+					new Chan({name: "&secure", key: "bar", muted: true, favorite: false}),
+					new Chan({name: "Channel List", type: Chan.Type.SPECIAL, favorite: false}),
+					new Chan({
+						name: "PrivateChat",
+						type: Chan.Type.QUERY,
+						muted: true,
+						favorite: false,
+					}),
 				],
 			});
 			network.setNick("chillin`");
@@ -113,11 +118,11 @@ describe("Network", function () {
 				proxyPassword: "",
 				proxyUsername: "",
 				channels: [
-					{name: "#thelounge", key: "", muted: false},
-					{name: "&foobar", key: "", muted: false},
-					{name: "#secret", key: "foo", muted: false},
-					{name: "&secure", key: "bar", muted: true},
-					{name: "PrivateChat", type: "query", muted: true},
+					{name: "#thelounge", key: "", muted: false, favorite: true},
+					{name: "&foobar", key: "", muted: false, favorite: false},
+					{name: "#secret", key: "foo", muted: false, favorite: true},
+					{name: "&secure", key: "bar", muted: true, favorite: false},
+					{name: "PrivateChat", type: "query", muted: true, favorite: false},
 				],
 				ignoreList: [],
 			});


### PR DESCRIPTION
Closes #180, #4078(?) 

It effectively adds a new network, 'favorites' that can contain channels from any network.

If there's a name conflict, the server name is appended to the channel name while it's favorited.

The functionality all works except the command, as I'm not sure of how that should work.

I was thinking:

`/favorites add [target] [...targets]`
`/favorites remove [target] [...targets]`
`/favorites clear`

If no target is provided, it's assumed to be the current channel.

Here you can see two `#testing123` channels with the server name attached. It's also added to the topic line, so (for example) on mobile you can be confident which you pressed
<img width="508" alt="A screenshot showing the Favorites 'network'" src="https://user-images.githubusercontent.com/8675906/166136891-e1efc1b0-ee26-468b-8a78-bb9994078b99.png">

The Favorites 'network' can't be opened (clicking it does nothing), but does have a context menu:
<img width="345" alt="The context menu has one option: 'clear favorites'" src="https://user-images.githubusercontent.com/8675906/166136909-174344e7-a9da-4dd4-8be8-3d1aefbd9853.png">

You can add channels/queries to your favorites with the context menu (or aforementioned command):
<img width="277" alt="Context menues have an 'add to favorites' option now" src="https://user-images.githubusercontent.com/8675906/166136924-71eab497-1020-495b-bfb6-59a2b085e22c.png">

