### PR TITLE
Cleanup configs (WIP)

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -2,12 +2,15 @@ module.exports = {
 	root: true,
 	overrides: [
 		{
-			files: ["**/*.ts"],
+			files: [
+				"**/*.ts",
+				// "**/*.vue"
+			],
 			parser: "@typescript-eslint/parser",
 			parserOptions: {
 				tsconfigRootDir: __dirname,
-				parser: "@typescript-eslint/parser",
 				project: ["./tsconfig.json", "./client/tsconfig.json", "./src/tsconfig.json"],
+				// extraFileExtensions: [".vue"],
 			},
 			plugins: ["@typescript-eslint"],
 			extends: [
@@ -16,29 +19,80 @@ module.exports = {
 				"plugin:@typescript-eslint/recommended-requiring-type-checking",
 				"prettier",
 			],
+			rules: {
+				// note you must disable the base rule as it can report incorrect errors
+				"no-shadow": "off",
+				"@typescript-eslint/no-shadow": ["error"],
+				// TODO: eventually remove these
+				"@typescript-eslint/ban-ts-comment": "off",
+				"@typescript-eslint/no-explicit-any": "off",
+				"@typescript-eslint/no-non-null-assertion": "off",
+				"@typescript-eslint/no-this-alias": "off",
+				"@typescript-eslint/no-unnecessary-type-assertion": "off",
+				"@typescript-eslint/no-unsafe-argument": "off",
+				"@typescript-eslint/no-unsafe-assignment": "off",
+				"@typescript-eslint/no-unsafe-call": "off",
+				"@typescript-eslint/no-unsafe-member-access": "off",
+				"@typescript-eslint/no-unused-vars": "off",
+			},
+		},
+		// TODO: verify
+		{
+			files: ["**/*.vue"],
+			parser: "vue-eslint-parser",
+			parserOptions: {
+				ecmaVersion: 2022,
+				ecmaFeatures: {
+					jsx: true,
+				},
+				parser: {
+					// Script parser for `<script>`
+					js: "espree",
+
+					// Script parser for `<script lang="ts">`
+					ts: "@typescript-eslint/parser",
+
+					// Script parser for vue directives (e.g. `v-if=` or `:attribute=`)
+					// and vue interpolations (e.g. `{{variable}}`).
+					// If not specified, the parser determined by `<script lang ="...">` is used.
+					"<template>": "espree",
+				},
+				tsconfigRootDir: __dirname,
+				project: ["./tsconfig.json", "./client/tsconfig.json", "./src/tsconfig.json"],
+			},
+			plugins: ["vue"],
+			extends: [
+				"plugin:vue/recommended",
+				"eslint:recommended",
+				"plugin:@typescript-eslint/recommended",
+				"plugin:@typescript-eslint/recommended-requiring-type-checking",
+				"prettier",
+			],
+			rules: {
+				"import/no-default-export": 0,
+				"import/unambiguous": 0, // vue SFC can miss script tags
+				"@typescript-eslint/prefer-readonly": 0, // can be used in template
+				"vue/component-tags-order": [
+					"error",
+					{
+						order: ["template", "style", "script"],
+					},
+				],
+				"vue/multi-word-component-names": "off",
+				"vue/no-mutating-props": "off",
+				"vue/no-v-html": "off",
+				"vue/require-default-prop": "off",
+				"vue/v-slot-style": ["error", "longform"],
+			},
 		},
 	],
-	parserOptions: {
-		ecmaVersion: 2022,
-		// sourceType: "module",
-		// project: ["./eslint.tsconfig.json"],
-		// extraFileExtensions: [".vue", ".cjs"],
-	},
-	// TODO: this should  just be for client?
-	parser: "vue-eslint-parser",
-	plugins: ["vue"],
 	env: {
 		es6: true,
 		browser: true,
 		mocha: true,
 		node: true,
 	},
-	extends: [
-		"plugin:vue/recommended",
-		"eslint:recommended",
-		"plugin:@typescript-eslint/recommended",
-		"prettier",
-	],
+	extends: ["eslint:recommended", "prettier"],
 	rules: {
 		"block-scoped-var": "error",
 		curly: ["error", "all"],
@@ -91,39 +145,5 @@ module.exports = {
 		"spaced-comment": ["error", "always"],
 		strict: "off",
 		yoda: "error",
-		"vue/component-tags-order": [
-			"error",
-			{
-				order: ["template", "style", "script"],
-			},
-		],
-		"vue/no-mutating-props": "off",
-		"vue/no-v-html": "off",
-		"vue/require-default-prop": "off",
-		"vue/v-slot-style": ["error", "longform"],
-		"vue/multi-word-component-names": "off",
-		"@typescript-eslint/no-explicit-any": "off",
-		"@typescript-eslint/no-non-null-assertion": "off",
-		"@typescript-eslint/no-unused-vars": "off",
-		"@typescript-eslint/no-this-alias": "off",
-		"no-shadow": "off",
-		"@typescript-eslint/no-shadow": "error",
 	},
-
-	// TODO: verify
-	overrides: [
-		{
-			files: ["*.vue"],
-			rules: {
-				"import/no-default-export": 0,
-			},
-		},
-		{
-			files: ["*.vue"],
-			rules: {
-				"@typescript-eslint/prefer-readonly": 0, // can be used in template
-				"import/unambiguous": 0, // vue SFC can miss script tags
-			},
-		},
-	],
 };

--- a/babel.config.cjs
+++ b/babel.config.cjs
@@ -1,7 +1,8 @@
 module.exports = {
 	presets: [
 		["@babel/preset-env", {bugfixes: true}],
-		"babel-preset-typescript-vue",
+		"babel-preset-typescript-vue", // TODO: last updated 2020-05-18, probably seek replacement after vue 3.x
+		// "@babel/typescript", // ? babel-preset-typescript-vue should be a drop-in replacement for @babel/typescript with vue support
 		// "@vue/babel-preset-jsx",
 	],
 	targets: "> 0.25%, not dead",

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -1,23 +1,17 @@
 {
   "extends": "../tsconfig.base.json",
   "include": ["./**/*"],
-  "files": [
-    "js/helpers/simplemap.json",
-    "js/helpers/fullnamemap.json",
-    "../package.json",
-    "./types.d.ts"
-  ],
+  "files": ["../package.json"],
   "compilerOptions": {
-    // "paths": {
-    //   "@js/*": ["js/*"]
-    // },
-    // https://v2.vuejs.org/v2/guide/typescript.html?redirect=true#Recommended-Configuration
-    "target": "ES5",
-    "strict": true,
-    "lib": ["ES2020", "dom"],
     "sourceMap": false,
-    "resolveJsonModule": true,
-    "baseUrl": "./",
-    "jsx": "preserve"
+    "jsx": "preserve",
+    // https://v2.vuejs.org/v2/guide/typescript.html?redirect=true#Recommended-Configuration
+    // this aligns with Vue's browser support
+    "target": "es5",
+    // this enables stricter inference for data properties on `this`
+    "strict": true,
+    // if using webpack 2+ or rollup, to leverage tree shaking:
+    "module": "es2015",
+    "moduleResolution": "node"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "4.3.1",
   "preferGlobal": true,
   "bin": {
-    "thelounge": "index.js"
+    "thelounge": "src/index.ts"
   },
   "repository": {
     "type": "git",
@@ -19,9 +19,10 @@
     "dev": "NODE_ENV=development ts-node --project src/tsconfig.json src/index.ts start --dev",
     "format:prettier": "prettier --write \"**/*.*\"",
     "lint:check-eslint": "eslint-config-prettier .eslintrc.cjs",
-    "lint:eslint": "eslint . --ext .js,.vue --report-unused-disable-directives --color",
+    "lint:eslint": "eslint . --report-unused-disable-directives --color",
     "lint:prettier": "prettier --list-different \"**/*.*\"",
     "lint:stylelint": "stylelint --color \"client/**/*.css\"",
+    "lint:tsc": "tsc --noEmit",
     "start": "node src/dist/src/index start",
     "test": "run-p --aggregate-output --continue-on-error lint:* test:*",
     "test:mocha": "webpack --mode=development && nyc --nycrc-path=test/.nycrc-mocha.json mocha --colors --config=test/.mocharc.yml",

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -1,28 +1,21 @@
 {
   "extends": "../tsconfig.base.json",
+  "include": ["**/*"],
   "files": [
-    "../package.json",
-    "../webpack.config.ts",
     "../babel.config.cjs",
-    "../defaults/config.js",
     "../client/js/constants.ts",
+    "../client/js/helpers/ircmessageparser/cleanIrcMessage.ts",
     "../client/js/helpers/ircmessageparser/findLinks.ts",
-    "../client/js/helpers/ircmessageparser/cleanIrcMessage.ts"
+    "../defaults/config.js",
+    "../package.json",
+    "../webpack.config.ts"
   ],
   "ts-node": {
     "files": true
   },
-  // TODO: these should be imported from the base config,
-  // but ts-node doesn't seem to care.
-  "include": ["**/*"],
-  // "typeRoots": ["./types/"],
-
   "compilerOptions": {
-    "types": ["node"],
-    "baseUrl": ".",
-    "noImplicitAny": false,
+    "noImplicitAny": false, // TODO: Remove eventually
     "outDir": "./dist",
     "noEmit": false
   }
-  // "references": [{"path": "../"}]
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,22 +1,20 @@
 {
   "compilerOptions": {
-    "declaration": true,
-    // "lib": ["es2019" ],
-    "module": "commonjs",
-    "target": "ESNext",
-    "rootDir": ".",
-    "baseUrl": ".",
-    "allowJs": true,
-    "checkJs": true,
-    "resolveJsonModule": true,
-    "composite": true,
+    "target": "esnext" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
+    "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
+    "allowJs": true /* Allow javascript files to be compiled. */,
+    "checkJs": true /* Report errors in .js files. */,
+    "declaration": true /* Generates corresponding '.d.ts' file. */,
+    "rootDir": "./" /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */,
+    "composite": true /* Enable project compilation */,
     "strict": true /* Enable all strict type-checking options. */,
-    // "typeRoots": ["./src/types/"],
-    "moduleResolution": "node",
-    "allowSyntheticDefaultImports": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
+    "moduleResolution": "node" /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */,
+    "baseUrl": "./" /* Base directory to resolve non-absolute module names. */,
+    "allowSyntheticDefaultImports": true /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */,
+    "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
+    "skipLibCheck": true /* Skip type checking of declaration files. */,
+    "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */,
+    "resolveJsonModule": true /* Enable importing .json files */
   },
   "files": ["./package.json"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,5 @@
 {
   "extends": "./tsconfig.base.json",
-  "compilerOptions": {
-    // TODO: enable
-    "noImplicitAny": false
-  },
   "files": ["./webpack.config.ts", "./babel.config.cjs", "./src/helper.ts"],
   "references": [
     {
@@ -12,5 +8,8 @@
     {
       "path": "./client"
     }
-  ]
+  ],
+  "compilerOptions": {
+    "noImplicitAny": false // TODO: Remove eventually
+  }
 }

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -6,6 +6,9 @@ import * as path from "path";
 import CopyPlugin from "copy-webpack-plugin";
 import MiniCssExtractPlugin from "mini-css-extract-plugin";
 // TODO; we should add a declaration file
+// ! vue-loader 15.x does not have typescript declarations
+// ! vue-loader 16.x does have typescript declarations, but is built for vue 3.x
+// ! this is currently working because of noImplicitAny being set in the root tsconfig.json and many eslint rules disabled in .eslintrc.cjs
 import VueLoaderPlugin from "vue-loader/lib/plugin";
 import babelConfig from "./babel.config.cjs";
 import Helper from "./src/helper";
@@ -43,7 +46,7 @@ const config: webpack.Configuration = {
 				},
 			},
 			{
-				test: /\.js$|\.ts$/,
+				test: /\.(ts|js)x?$/i,
 				include: [path.resolve(__dirname, "client")],
 				exclude: path.resolve(__dirname, "node_modules"),
 				use: {


### PR DESCRIPTION
I've labeled this as a WIP because it doesn't complete everything needed for the typescript branch to merge to master, but it's moving in the right direction. Some highlights:

* In eslint, define file extensions for ts and vue as overrides, and only apply the specific rules they need respectively. This works as intended for ts, but I have not yet fully figured out how to get it working for vue (because vue needs to be able to handle inline ts)
* Include a handful of ts specific eslint rules to be turned off globally until more issues can be resolved (tsc doesn't complain but eslint does with some things)
* Rearrange and clean up all tsconfig files (remove some duplication)
* Add some TODO comments (like eventually remove ...)

This should be able to merge into the typescript branch now and work can continue on the making typescript happy.