### PR TITLE
Fix yarn dev

### DIFF
--- a/src/plugins/dev-server.js
+++ b/src/plugins/dev-server.js
@@ -6,7 +6,7 @@ module.exports = (app) => {
 	log.debug("Starting server in development mode");
 
 	const webpack = require("webpack");
-	const webpackConfig = require("../../webpack.config.js")(undefined, {mode: "development"});
+	const webpackConfig = require("../../webpack.config.js")(undefined, {mode: "production"});
 
 	webpackConfig.plugins.push(new webpack.HotModuleReplacementPlugin());
 	webpackConfig.entry["js/bundle.js"].push(

--- a/src/plugins/dev-server.js
+++ b/src/plugins/dev-server.js
@@ -6,7 +6,7 @@ module.exports = (app) => {
 	log.debug("Starting server in development mode");
 
 	const webpack = require("webpack");
-	const webpackConfig = require("../../webpack.config.js");
+	const webpackConfig = require("../../webpack.config.js")(undefined, {mode: "development"});
 
 	webpackConfig.plugins.push(new webpack.HotModuleReplacementPlugin());
 	webpackConfig.entry["js/bundle.js"].push(

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -154,9 +154,7 @@ module.exports = (env, argv) => {
 		config.devtool = "eval";
 		config.stats = "errors-only";
 		config.output.path = path.resolve(__dirname, "test/public");
-		config.entry = {
-			"testclient.js": [path.resolve(__dirname, "test/client/index.js")],
-		};
+		config.entry["testclient.js"] = [path.resolve(__dirname, "test/client/index.js")];
 
 		// Add the istanbul plugin to babel-loader options
 		for (const rule of config.module.rules) {
@@ -171,7 +169,7 @@ module.exports = (env, argv) => {
 		config.optimization.splitChunks = false;
 
 		// Disable plugins like copy files, it is not required
-		config.plugins = [
+		config.plugins.push(
 			new VueLoaderPlugin(),
 
 			// Client tests that require Vue may end up requireing socket.io
@@ -181,8 +179,8 @@ module.exports = (env, argv) => {
 			),
 
 			// "Fixes" Critical dependency: the request of a dependency is an expression
-			new webpack.ContextReplacementPlugin(/vue-server-renderer$/),
-		];
+			new webpack.ContextReplacementPlugin(/vue-server-renderer$/)
+		);
 	}
 
 	if (argv.mode === "production") {


### PR DESCRIPTION
~~This may significantly change how the webpack development config behaves. Instead of replacing `entry` and `plugins` this will append to the existing values. This makes the dev-server use the webpack development config (previously it used production).~~

Completely rewrote the changes here. Main thing is the mini css extract was needed in the dev webpack config mode.

Also added using `output.clean` https://webpack.js.org/configuration/output/#outputclean instead of removing files from the output directory manually.