### PR TITLE
Don't use strict in typescript

### DIFF
--- a/client/components/MessageTypes/index.ts
+++ b/client/components/MessageTypes/index.ts
@@ -1,5 +1,3 @@
-"use strict";
-
 // This creates a version of `require()` in the context of the current
 // directory, so we iterate over its content, which is a map statically built by
 // Webpack.

--- a/client/js/helpers/parse.ts
+++ b/client/js/helpers/parse.ts
@@ -1,8 +1,6 @@
 // TODO: type
 // @ts-nocheck
 
-"use strict";
-
 import {h as createElement, VNode} from "vue";
 import parseStyle from "./ircmessageparser/parseStyle";
 import findChannels, {ChannelPart} from "./ircmessageparser/findChannels";

--- a/test/commands/mode.ts
+++ b/test/commands/mode.ts
@@ -1,6 +1,4 @@
 // @ts-nocheck TODO re-enable
-"use strict";
-
 import {expect} from "chai";
 import Client from "../../src/client";
 

--- a/test/fixtures/env.ts
+++ b/test/fixtures/env.ts
@@ -1,5 +1,3 @@
-"use strict";
-
 import fs from "fs";
 
 import * as path from "path";

--- a/test/models/chan.ts
+++ b/test/models/chan.ts
@@ -1,4 +1,3 @@
-"use strict";
 import {expect} from "chai";
 
 import Chan from "../../src/models/chan";

--- a/test/models/msg.ts
+++ b/test/models/msg.ts
@@ -1,5 +1,3 @@
-"use strict";
-
 import {expect} from "chai";
 
 import Msg from "../../src/models/msg";

--- a/test/models/network.ts
+++ b/test/models/network.ts
@@ -1,6 +1,4 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
-"use strict";
-
 import {expect} from "chai";
 import Chan, {ChanType} from "../../src/models/chan";
 import Msg from "../../src/models/msg";

--- a/test/plugins/auth/ldap.ts
+++ b/test/plugins/auth/ldap.ts
@@ -1,5 +1,3 @@
-"use strict";
-
 import log from "../../../src/log";
 import ldapAuth from "../../../src/plugins/auth/ldap";
 import Config from "../../../src/config";

--- a/test/plugins/clientCertificate.ts
+++ b/test/plugins/clientCertificate.ts
@@ -1,5 +1,3 @@
-"use strict";
-
 import fs from "fs";
 import path from "path";
 import {expect} from "chai";

--- a/test/plugins/inputs/indexTest.ts
+++ b/test/plugins/inputs/indexTest.ts
@@ -1,5 +1,3 @@
-"use strict";
-
 import {expect} from "chai";
 import inputs from "../../../src/plugins/inputs";
 

--- a/test/plugins/link.ts
+++ b/test/plugins/link.ts
@@ -1,7 +1,5 @@
 /* eslint-disable @typescript-eslint/restrict-template-expressions */
 /* eslint-disable @typescript-eslint/restrict-plus-operands */
-"use strict";
-
 import path from "path";
 import {expect} from "chai";
 import util from "../util";

--- a/test/plugins/packages/indexTest.ts
+++ b/test/plugins/packages/indexTest.ts
@@ -1,5 +1,3 @@
-"use strict";
-
 import log from "../../../src/log";
 import {expect} from "chai";
 import TestUtil from "../../util";

--- a/test/plugins/sqlite.ts
+++ b/test/plugins/sqlite.ts
@@ -1,6 +1,4 @@
 /* eslint-disable @typescript-eslint/no-unsafe-return */
-"use strict";
-
 import fs from "fs";
 import path from "path";
 import {expect} from "chai";

--- a/test/plugins/storage.ts
+++ b/test/plugins/storage.ts
@@ -1,6 +1,4 @@
 /* eslint-disable @typescript-eslint/restrict-plus-operands */
-"use strict";
-
 import fs from "fs";
 import path from "path";
 import crypto from "crypto";

--- a/test/server.ts
+++ b/test/server.ts
@@ -1,5 +1,3 @@
-"use strict";
-
 import log from "../src/log";
 import Config from "../src/config";
 import {expect} from "chai";

--- a/test/src/command-line/utilsTest.ts
+++ b/test/src/command-line/utilsTest.ts
@@ -1,5 +1,3 @@
-"use strict";
-
 import log from "../../../src/log";
 import {expect} from "chai";
 import TestUtil from "../../util";

--- a/test/src/helperTest.ts
+++ b/test/src/helperTest.ts
@@ -1,5 +1,3 @@
-"use strict";
-
 import {expect} from "chai";
 import os from "os";
 import Helper from "../../src/helper";

--- a/test/tests/build.ts
+++ b/test/tests/build.ts
@@ -1,5 +1,3 @@
-"use strict";
-
 import {expect} from "chai";
 import fs from "fs";
 import path from "path";

--- a/test/tests/customhighlights.ts
+++ b/test/tests/customhighlights.ts
@@ -1,5 +1,3 @@
-"use strict";
-
 import {expect} from "chai";
 import log from "../../src/log";
 import Client from "../../src/client";

--- a/test/tests/hexip.ts
+++ b/test/tests/hexip.ts
@@ -1,5 +1,3 @@
-"use strict";
-
 import {expect} from "chai";
 import Helper from "../../src/helper";
 

--- a/test/tests/hostmask.ts
+++ b/test/tests/hostmask.ts
@@ -1,5 +1,3 @@
-"use strict";
-
 import {expect} from "chai";
 import Helper from "../../src/helper";
 

--- a/test/tests/mergeConfig.ts
+++ b/test/tests/mergeConfig.ts
@@ -1,5 +1,3 @@
-"use strict";
-
 import {expect} from "chai";
 import sinon from "ts-sinon";
 

--- a/test/tests/nickhighlights.ts
+++ b/test/tests/nickhighlights.ts
@@ -1,5 +1,3 @@
-"use strict";
-
 import {expect} from "chai";
 
 import Network from "../../src/models/network";

--- a/test/tests/passwords.ts
+++ b/test/tests/passwords.ts
@@ -1,5 +1,3 @@
-"use strict";
-
 import {expect} from "chai";
 import Helper from "../../src/helper";
 

--- a/test/tests/textLogFolder.ts
+++ b/test/tests/textLogFolder.ts
@@ -1,5 +1,3 @@
-"use strict";
-
 import {expect} from "chai";
 import Network from "../../src/models/network";
 import TextFileMessageStorage from "../../src/plugins/messageStorage/text";

--- a/test/util.ts
+++ b/test/util.ts
@@ -1,5 +1,3 @@
-"use strict";
-
 import _ from "lodash";
 import express from "express";
 import Network from "../src/models/network";

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -1,5 +1,3 @@
-"use strict";
-
 import * as webpack from "webpack";
 import * as path from "path";
 import CopyPlugin from "copy-webpack-plugin";


### PR DESCRIPTION
all TS files, when transpiled by babel into JS, will have `use strict` in them anyway. There is no need to include it in TS files.