### PR TITLE
Rearrange webpack dev/prod plugins

### DIFF
--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -96,12 +96,6 @@ const config: webpack.Configuration = {
 		new MiniCssExtractPlugin({
 			filename: "css/style.css",
 		}),
-
-		// Client tests that require Vue may end up requireing socket.io
-		new webpack.NormalModuleReplacementPlugin(
-			/js(\/|\\)socket\.js/,
-			path.resolve(__dirname, "scripts/noop.js")
-		),
 	],
 };
 
@@ -187,6 +181,14 @@ export default (env: any, argv: any) => {
 			})
 		);
 	}
+
+	config.plugins!.push(
+		// Client tests that require Vue may end up requireing socket.io
+		new webpack.NormalModuleReplacementPlugin(
+			/js(\/|\\)socket\.js/,
+			path.resolve(__dirname, "scripts/noop.js")
+		)
+	);
 
 	return config;
 };


### PR DESCRIPTION
Dev and Prod both use the same common set of plugins. This moves the common set to the main config and then adds the production plugins when running in production mode.

Plugin order matters, so I've added the `NormalModuleReplacementPlugin` last at the very bottom.

This does move the `MiniCssExtractPlugin` above the `DefinePlugin`, but I am not sure if that is important.

Edit: This may not be worth chasing. I slapped it together kind of quick, and there's not a huge benefit to it. I just noticed that `VueLoaderPlugin`, `MiniCssExtractPlugin`, and `NormalModuleReplacementPlugin` are used in prod and dev, and all the rest are only used in prod. Feel free to close this, or I can put more effort into making it work correctly if needed.