### PR TITLE
Upgrade irc-framework 4.12.1 -> 4.7 to mitigate possible RCE.

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "file-type": "16.5.3",
     "filenamify": "4.3.0",
     "got": "11.8.3",
-    "irc-framework": "4.12.1",
+    "irc-framework": "4.7",
     "is-utf8": "0.2.1",
     "ldapjs": "2.3.1",
     "linkify-it": "3.0.3",


### PR DESCRIPTION
**Issue**: Possible RCE in `irc-framework` affecting version's 2.5.0 to 4.7.0

**Resolution:** Upgrade `irc-framework` to 4.7.0.

**Additional resources:**

Vulnerability Report: https://snyk.io/test/github/thelounge/lounge/9e249a1d2fb28adc1873e183bee8d734b2928d7f

Related issue: https://github.com/kiwiirc/irc-framework/issues/244
Related PR: https://github.com/kiwiirc/irc-framework/commit/24be97dbe2160a679e905d95b45c5461ab173b61