### PR TITLE
Use correct option name (filter vs ldapFilter) in config.js comment

### DIFF
--- a/defaults/config.js
+++ b/defaults/config.js
@@ -457,7 +457,7 @@ module.exports = {
 			//   - `rootPassword`: Password of The Lounge LDAP system user.
 			rootPassword: "1234",
 
-			//   - `ldapFilter`: it is set to `"(objectClass=person)(memberOf=ou=accounts,dc=example,dc=com)"`
+			//   - `filter`: it is set to `"(objectClass=person)(memberOf=ou=accounts,dc=example,dc=com)"`
 			//     by default.
 			filter: "(objectClass=person)(memberOf=ou=accounts,dc=example,dc=com)",
 


### PR DESCRIPTION
The comment for the "filter" key under "searchDN" refers to it as "ldapFilter" instead of "filter".