### PR TITLE
Correct ClientManager module export

### DIFF
--- a/server/clientManager.ts
+++ b/server/clientManager.ts
@@ -294,3 +294,7 @@ class ClientManager {
 }
 
 export default ClientManager;
+
+// Required to instantiate constructors after ES6.
+// https://stackoverflow.com/questions/40294870/module-exports-vs-export-default-in-node-js-and-es6
+module.exports = ClientManager;


### PR DESCRIPTION
This fixes an error:

```node ➜ /workspaces/thelounge (master ✗) $ node index add test
/workspaces/thelounge/dist/server/command-line/users/add.js:27
    const manager = new ClientManager();
                    ^

TypeError: ClientManager is not a constructor
    at Command.<anonymous> (/workspaces/thelounge/dist/server/command-line/users/add.js:27:21)
    at Command.listener [as _actionHandler] (/workspaces/thelounge/node_modules/commander/lib/command.js:480:17)
    at /workspaces/thelounge/node_modules/commander/lib/command.js:1234:65
    at Command._chainOrCall (/workspaces/thelounge/node_modules/commander/lib/command.js:1151:12)
    at Command._parseCommand (/workspaces/thelounge/node_modules/commander/lib/command.js:1234:27)
    at Command._dispatchSubcommand (/workspaces/thelounge/node_modules/commander/lib/command.js:1057:25)
    at Command._parseCommand (/workspaces/thelounge/node_modules/commander/lib/command.js:1200:19)
    at Command.parse (/workspaces/thelounge/node_modules/commander/lib/command.js:889:10)
    at Object.<anonymous> (/workspaces/thelounge/dist/server/command-line/index.js:53:9)
    at Module._compile (node:internal/modules/cjs/loader:1105:14)

Node.js v18.0.0