### PR TITLE
Fix ctcp request message

### DIFF
--- a/server/plugins/inputs/ctcp.ts
+++ b/server/plugins/inputs/ctcp.ts
@@ -16,17 +16,16 @@ const input: PluginInputHandler = function ({irc}, chan, cmd, args) {
 	}
 
 	const target = args.shift()!;
+	const type = args.shift()!;
 
 	chan.pushMessage(
 		this,
 		new Msg({
 			type: MessageType.CTCP_REQUEST,
-			ctcpMessage: `"${target}" to ${args[0]}`,
+			ctcpMessage: `"${type}" to ${target}`,
 			from: chan.getUser(irc.user.nick),
 		})
 	);
-
-	const type = args.shift()!;
 
 	irc.ctcpRequest(target, type, ...args);
 };


### PR DESCRIPTION
The message was ordered the wrong way in the TS rewrite.

Old:
    +bookworm sent a CTCP request: "chadler" to version
New:
    +bookworm sent a CTCP request: "version" to chadler