### PR TITLE
Respect bind setting for all outgoing requests

### DIFF
--- a/server/plugins/changelog.ts
+++ b/server/plugins/changelog.ts
@@ -3,6 +3,7 @@ import colors from "chalk";
 import log from "../log";
 import pkg from "../../package.json";
 import ClientManager from "../clientManager";
+import Config from "../config";
 
 const TIME_TO_LIVE = 15 * 60 * 1000; // 15 minutes, in milliseconds
 
@@ -51,6 +52,7 @@ async function fetch() {
 				Accept: "application/vnd.github.v3.html", // Request rendered markdown
 				"User-Agent": pkg.name + "; +" + pkg.repository.url, // Identify the client
 			},
+			localAddress: Config.values.bind,
 		});
 
 		if (response.statusCode !== 200) {

--- a/server/plugins/irc-events/link.ts
+++ b/server/plugins/irc-events/link.ts
@@ -437,6 +437,7 @@ function fetch(uri: string, headers: Record<string, string>) {
 				retry: 0,
 				timeout: prefetchTimeout || 5000, // milliseconds
 				headers: getRequestHeaders(headers),
+				localAddress: Config.values.bind,
 			});
 
 			gotStream


### PR DESCRIPTION
So far the bind config only impacted the IRC connections.
However, nothing in our doc comment says that this is intentional.

> ### bind
> Set the local IP to bind to for outgoing connections.

This commit fixes the leak and uses it for all outgoing requests
as described by the docstring.