### PR TITLE
linkPreviews: Enforce TLS validity

### DIFF
--- a/server/plugins/irc-events/link.ts
+++ b/server/plugins/irc-events/link.ts
@@ -437,9 +437,6 @@ function fetch(uri: string, headers: Record<string, string>) {
 				retry: 0,
 				timeout: prefetchTimeout || 5000, // milliseconds
 				headers: getRequestHeaders(headers),
-				https: {
-					rejectUnauthorized: false,
-				},
 			});
 
 			gotStream


### PR DESCRIPTION
When a URL is prefixed with a TLS scheme, we should make sure
that the remote provides a valid cert, even just for prefetches.
Else MITM of such a site is trivial.

This probably breaks some people with self signed cert, but the
age where that was acceptable is past. We have free CAs now like
Let's Encrypt.