### PR TITLE
Initial work on adding an events API to plugins

### DIFF
--- a/server/events.ts
+++ b/server/events.ts
@@ -1,0 +1,26 @@
+import EventEmitter from "events";
+import Client from "./client";
+import {NetworkWithIrcFramework} from "./models/network";
+import {MessageData, NotificationData} from "./plugins/irc-events/message";
+export interface ClientEvents {
+	message: (
+		irc: NetworkWithIrcFramework["irc"],
+		network: NetworkWithIrcFramework,
+		client: Client,
+		data: MessageData
+	) => void;
+	notification: (
+		irc: NetworkWithIrcFramework["irc"],
+		network: NetworkWithIrcFramework,
+		client: Client,
+		data: MessageData,
+		notification: NotificationData
+	) => void;
+}
+
+export interface ClientEmitter {
+	on<U extends keyof ClientEvents>(event: U, listener: ClientEvents[U]): this;
+	emit<U extends keyof ClientEvents>(event: U, ...args: Parameters<ClientEvents[U]>): boolean;
+}
+
+export class ClientEmitter extends EventEmitter {}


### PR DESCRIPTION
Out of a conversation on IRC, we talked about the potential benefits of an event API to be used for plugins (and potentially other places within thelounge).

This PR includes some initial work in adding an EventEmitter to be used by plugins. This is done at a high level this way:
1. Create an `EventEmitter` on the `Client` objects that is used for broadcasting messages about a specific client
    - The `EventEmitter` is typed, the definitions in `./servers/events` includes the interface that are used to define
       what events are emitted and their arguments.
2. Create an `EventEmitter` on the `packageApi` that is stored by the packages handler
3. For APIs that should be emitted to the package, define a method that is used to iterate through package emitters and 
    broadcast the message
    - An event listener needs to be added to the client definition to emit the messages using the defined method.

This is just an initial crude implementation out of our conversation (@brunnre8 on IRC). I tested it with a simple plugin that does this:

```javascript
module.exports = {
    onServerStart: api => {
        api.Events.on('message', console.log);
        api.Events.on('notification', console.log);
    },
};
```