### PR TITLE
SearchResults: remove dead code

### DIFF
--- a/client/components/Windows/SearchResults.vue
+++ b/client/components/Windows/SearchResults.vue
@@ -236,20 +236,6 @@ export default defineComponent({
 			// TODO: Implement jumping to messages!
 			// This is difficult because it means client will need to handle a potentially nonlinear message set
 			// (loading IntersectionObserver both before AND after the messages)
-			router
-				.push({
-					name: "MessageList",
-					params: {
-						id: channel.value?.id,
-					},
-					query: {
-						focused: id,
-					},
-				})
-				.catch((e) => {
-					// eslint-disable-next-line no-console
-					console.error(`Failed to navigate to message ${id}`, e);
-				});
 		};
 
 		watch(


### PR DESCRIPTION
Nachtalb put some infra in place that was never actually working. It errors out when a user clicks on a message.

Remove the offending code, but keep it all in place so that we can improve on it.