### PR TITLE
remove VueApp from router

### DIFF
--- a/client/js/types.d.ts
+++ b/client/js/types.d.ts
@@ -67,14 +67,6 @@ type ClientLinkPreview = LinkPreview & {
 	sourceLoaded?: boolean;
 };
 
-declare module "vue-router" {
-	import Vue from "./vue";
-
-	interface Router {
-		app: Vue.VueApp;
-	}
-}
-
 interface BeforeInstallPromptEvent extends Event {
 	/**
 	 * Returns an array of DOMString items containing the platforms on which the event was dispatched.

--- a/client/js/vue.ts
+++ b/client/js/vue.ts
@@ -5,7 +5,7 @@ import {createApp} from "vue";
 import {store, CallableGetters, key} from "./store";
 import App from "../components/App.vue";
 import storage from "./localStorage";
-import {router, navigate} from "./router";
+import {router} from "./router";
 import socket from "./socket";
 import eventbus from "./eventbus";
 
@@ -20,7 +20,6 @@ const faviconAlerted = favicon?.dataset.other || "";
 
 export const VueApp = createApp(App);
 
-router.app = VueApp;
 VueApp.use(router);
 VueApp.use(store, key);
 


### PR DESCRIPTION
Nothing actually depends on the vue app being monkey patched onto the router, so let's get rid of it.