### PR TITLE
sqlite: synchronize enable() internally

### DIFF
--- a/test/plugins/sqlite.ts
+++ b/test/plugins/sqlite.ts
@@ -37,17 +37,19 @@ describe("SQLite Message Storage", function () {
 		fs.rmdir(path.join(Config.getHomePath(), "logs"), done);
 	});
 
-	it("should resolve an empty array when disabled", async function () {
-		const messages = await store.getMessages(null as any, null as any);
-		expect(messages).to.be.empty;
-	});
-
 	it("should create database file", async function () {
 		expect(store.isEnabled).to.be.false;
 		expect(fs.existsSync(expectedPath)).to.be.false;
 
 		await store.enable();
 		expect(store.isEnabled).to.be.true;
+	});
+
+	it("should resolve an empty array when disabled", async function () {
+		store.isEnabled = false;
+		const messages = await store.getMessages(null as any, null as any);
+		expect(messages).to.be.empty;
+		store.isEnabled = true;
 	});
 
 	it("should create tables", function (done) {


### PR DESCRIPTION
TL is stupid and doesn't wait for message{Provider,Storage} to settle before it starts using the store.

While this should be fixed globally, we can hack around the problem by pushing everything onto the call stack and hope that we'll eventually finish the setup before we blow the stack.

Now, how do we want to handle this?
Clearly the API design that was done initially doesn't cut it, but the changes will be rather high as we need to switch to an async model.

Do we merge this workaround for now, or do we roll back?
The problem with rolling back is that we can't do any migrations to our DB whatsoever