### PR TITLE
Use "M" shorthand for messages >= one million

### DIFF
--- a/client/js/helpers/roundBadgeNumber.ts
+++ b/client/js/helpers/roundBadgeNumber.ts
@@ -8,5 +8,5 @@ export default (count: number) => {
 	const {divisor, suffix} =
 		suffixes[Math.min(suffixes.length - 1, Math.floor(Math.log10(count) / 3))];
 
-	return (count / divisor).toFixed(2).slice(0, -1) + suffix;
+	return String(Math.ceil((count / divisor) * 10) / 10).concat(suffix);
 };

--- a/client/js/helpers/roundBadgeNumber.ts
+++ b/client/js/helpers/roundBadgeNumber.ts
@@ -1,12 +1,11 @@
 export default (count: number) => {
-	const suffixes = [
-		{divisor: 1, suffix: ""},
-		{divisor: 1000, suffix: "k"},
-		{divisor: 1000000, suffix: "m"},
-	];
+	if (count < 1000) {
+		return count.toString();
+	}
 
-	const {divisor, suffix} =
-		suffixes[Math.min(suffixes.length - 1, Math.floor(Math.log10(count) / 3))];
-
-	return String(Math.ceil((count / divisor) * 10) / 10).concat(suffix);
+	const suffixes = ["", "k", "M"];
+	const magnitudeIndex = Math.min(Math.floor(Math.log10(count) / 3), suffixes.length - 1);
+	const magnitude = 1000 ** magnitudeIndex;
+	const roundedCount = (count / magnitude).toFixed(1);
+	return roundedCount + suffixes[magnitudeIndex];
 };

--- a/client/js/helpers/roundBadgeNumber.ts
+++ b/client/js/helpers/roundBadgeNumber.ts
@@ -3,5 +3,11 @@ export default (count: number) => {
 		return count.toString();
 	}
 
-	return (count / 1000).toFixed(2).slice(0, -1) + "k";
+	if (count >= 1000 && count < 1000000) {
+		return (count / 1000).toFixed(2).slice(0, -1) + "k";
+	}
+
+	if (count >= 1000000) {
+		return (count / 1000000).toFixed(2).slice(0, -1) + "m";
+	}
 };

--- a/client/js/helpers/roundBadgeNumber.ts
+++ b/client/js/helpers/roundBadgeNumber.ts
@@ -1,13 +1,12 @@
 export default (count: number) => {
-	if (count < 1000) {
-		return count.toString();
-	}
+	const suffixes = [
+		{divisor: 1, suffix: ""},
+		{divisor: 1000, suffix: "k"},
+		{divisor: 1000000, suffix: "m"},
+	];
 
-	if (count >= 1000 && count < 1000000) {
-		return (count / 1000).toFixed(2).slice(0, -1) + "k";
-	}
+	const {divisor, suffix} =
+		suffixes[Math.min(suffixes.length - 1, Math.floor(Math.log10(count) / 3))];
 
-	if (count >= 1000000) {
-		return (count / 1000000).toFixed(2).slice(0, -1) + "m";
-	}
+	return (count / divisor).toFixed(2).slice(0, -1) + suffix;
 };

--- a/test/client/js/helpers/roundBadgeNumberTest.ts
+++ b/test/client/js/helpers/roundBadgeNumberTest.ts
@@ -6,8 +6,13 @@ describe("roundBadgeNumber helper", function () {
 		expect(roundBadgeNumber(123)).to.equal("123");
 	});
 
-	it("should return numbers above 999 in thousands", function () {
+	it("should return numbers between 1000 and 999999 with a 'k' suffix", function () {
 		expect(roundBadgeNumber(1000)).to.be.equal("1.0k");
+	});
+
+	it("should return numbers above 999999 with a 'm' suffix", function () {
+		expect(roundBadgeNumber(1000000)).to.be.equal("1.0m");
+		expect(roundBadgeNumber(1234567)).to.be.equal("1.2m");
 	});
 
 	it("should round and not floor", function () {

--- a/test/client/js/helpers/roundBadgeNumberTest.ts
+++ b/test/client/js/helpers/roundBadgeNumberTest.ts
@@ -10,9 +10,9 @@ describe("roundBadgeNumber helper", function () {
 		expect(roundBadgeNumber(1000)).to.be.equal("1.0k");
 	});
 
-	it("should return numbers above 999999 with a 'm' suffix", function () {
-		expect(roundBadgeNumber(1000000)).to.be.equal("1.0m");
-		expect(roundBadgeNumber(1234567)).to.be.equal("1.2m");
+	it("should return numbers above 999999 with a 'M' suffix", function () {
+		expect(roundBadgeNumber(1000000)).to.be.equal("1.0M");
+		expect(roundBadgeNumber(1234567)).to.be.equal("1.2M");
 	});
 
 	it("should round and not floor", function () {


### PR DESCRIPTION
Implements [Unread messages count] Abandon "k" (= thousand) when it reaches million+ #4615