### PR TITLE
Improve readability of maximum upload size error

### DIFF
--- a/client/js/upload.ts
+++ b/client/js/upload.ts
@@ -125,7 +125,7 @@ class Uploader {
 			if (maxFileSize > 0 && file.size > maxFileSize) {
 				const maxFileSizeInMB = (maxFileSize / 1024 / 1024).toFixed(0);
 				this.handleResponse({
-					error: `File "${file.name}" is larger than the maximum allowed size of ${maxFileSizeInMB} MB.`,
+					error: `File "${file.name}" is larger than the maximum allowed size of ${maxFileSizeInMB} MB`,
 				});
 
 				continue;

--- a/client/js/upload.ts
+++ b/client/js/upload.ts
@@ -2,6 +2,7 @@ import {update as updateCursor} from "undate";
 
 import socket from "./socket";
 import {store} from "./store";
+import friendlysize from "../js/helpers/friendlysize";
 
 class Uploader {
 	xhr: XMLHttpRequest | null = null;
@@ -123,9 +124,9 @@ class Uploader {
 			}
 
 			if (maxFileSize > 0 && file.size > maxFileSize) {
-				const maxFileSizeInMB = (maxFileSize / 1024 / 1024).toFixed(0);
+				const maxFileSizeHR = friendlysize(maxFileSize);
 				this.handleResponse({
-					error: `File "${file.name}" is larger than the maximum allowed size of ${maxFileSizeInMB} MB`,
+					error: `File "${file.name}" is larger than the maximum allowed size of ${maxFileSizeHR}`,
 				});
 
 				continue;

--- a/client/js/upload.ts
+++ b/client/js/upload.ts
@@ -116,7 +116,6 @@ class Uploader {
 
 		const wasQueueEmpty = this.fileQueue.length === 0;
 		const maxFileSize = store.state.serverConfiguration?.fileUploadMaxFileSize || 0;
-		const maxFileSizeInMB = (maxFileSize / 1024 / 1024).toFixed(0);
 
 		for (const file of files) {
 			if (!file) {
@@ -124,6 +123,7 @@ class Uploader {
 			}
 
 			if (maxFileSize > 0 && file.size > maxFileSize) {
+				const maxFileSizeInMB = (maxFileSize / 1024 / 1024).toFixed(0);
 				this.handleResponse({
 					error: `File "${file.name}" is larger than the maximum allowed size of ${maxFileSizeInMB} MB.`,
 				});

--- a/client/js/upload.ts
+++ b/client/js/upload.ts
@@ -116,6 +116,7 @@ class Uploader {
 
 		const wasQueueEmpty = this.fileQueue.length === 0;
 		const maxFileSize = store.state.serverConfiguration?.fileUploadMaxFileSize || 0;
+		const maxFileSizeInMB = (maxFileSize / 1024 / 1024).toFixed(0);
 
 		for (const file of files) {
 			if (!file) {
@@ -124,7 +125,7 @@ class Uploader {
 
 			if (maxFileSize > 0 && file.size > maxFileSize) {
 				this.handleResponse({
-					error: `File ${file.name} is over the maximum allowed size`,
+					error: `File "${file.name}" is larger than the maximum allowed size of ${maxFileSizeInMB} MB.`,
 				});
 
 				continue;


### PR DESCRIPTION
The original version was a little clunky and hard to decipher. It would also be useful for rejected uploads to specify the maximum file size.