### PR TITLE
Fix sidebar swipe flicker after letting go

### DIFF
--- a/client/components/Sidebar.vue
+++ b/client/components/Sidebar.vue
@@ -90,7 +90,7 @@
 </template>
 
 <script lang="ts">
-import {defineComponent, onMounted, onUnmounted, PropType, ref} from "vue";
+import {defineComponent, nextTick, onMounted, onUnmounted, PropType, ref} from "vue";
 import {useRoute} from "vue-router";
 import {useStore} from "../js/store";
 import NetworkList from "./NetworkList.vue";
@@ -199,18 +199,20 @@ export default defineComponent({
 
 			store.commit("sidebarDragging", false);
 
-			if (sidebar.value) {
-				sidebar.value.style.transform = "";
-			}
-
-			if (props.overlay) {
-				props.overlay.style.opacity = "";
-			}
-
 			touchStartPos.value = null;
 			touchCurPos.value = null;
 			touchStartTime.value = 0;
 			menuIsMoving.value = false;
+
+			void nextTick(() => {
+				if (sidebar.value) {
+					sidebar.value.style.transform = "";
+				}
+
+				if (props.overlay) {
+					props.overlay.style.opacity = "";
+				}
+			});
 		};
 
 		const onTouchStart = (e: TouchEvent) => {


### PR DESCRIPTION
I am not entirely sure why the timing changed (`store.commit` takes a tick to run now?), but this should fix it.

The bug is that `menu-open` applies after the transform/opacity styles are removed, which makes the browser (Chrome at least) animate from beginning, rather than the point where the finger was let go.