### PR TITLE
Add Primary key to messages

### DIFF
--- a/server/plugins/messageStorage/sqlite.ts
+++ b/server/plugins/messageStorage/sqlite.ts
@@ -36,7 +36,20 @@ const schema = [
 ];
 
 // the migrations will be executed in an exclusive transaction as a whole
-export const migrations = [];
+// add new migrations to the end, with the version being the new 'currentSchemaVersion'
+export const migrations: Migration[] = [
+	{
+		version: 1672236339873,
+		stmts: [
+			"CREATE TABLE messages_new (id INTEGER PRIMARY KEY AUTOINCREMENT, network TEXT, channel TEXT, time INTEGER, type TEXT, msg TEXT);",
+			"INSERT INTO messages_new(network, channel, time, type, msg) select network, channel, time, type, msg from messages order by time asc;",
+			"DROP TABLE messages;",
+			"ALTER TABLE messages_new RENAME TO messages;",
+			"CREATE INDEX network_channel ON messages (network, channel);",
+			"CREATE INDEX time ON messages (time);",
+		],
+	},
+];
 
 class Deferred {
 	resolve!: () => void;
@@ -91,9 +104,23 @@ class SqliteMessageStorage implements SearchableMessageStorage {
 		}
 	}
 
-	async run_migrations() {
+	async setup_new_db() {
 		for (const stmt of schema) {
 			await this.serialize_run(stmt, []);
+		}
+
+		await this.serialize_run("INSERT INTO options (name, value) VALUES ('schema_version', ?)", [
+			currentSchemaVersion.toString(),
+		]);
+	}
+
+	async current_version(): Promise<number> {
+		const have_options = await this.serialize_get(
+			"select 1 from sqlite_master where type = 'table' and name = 'options'"
+		);
+
+		if (!have_options) {
+			return 0;
 		}
 
 		const version = await this.serialize_get(
@@ -101,31 +128,55 @@ class SqliteMessageStorage implements SearchableMessageStorage {
 		);
 
 		if (version === undefined) {
-			// new table
-			await this.serialize_run(
-				"INSERT INTO options (name, value) VALUES ('schema_version', ?)",
-				[currentSchemaVersion]
-			);
-			return;
+			// technically shouldn't happen, means something created a schema but didn't populate it
+			// we'll try our best to recover
+			return 0;
 		}
 
 		const storedSchemaVersion = parseInt(version.value, 10);
+		return storedSchemaVersion;
+	}
 
-		if (storedSchemaVersion === currentSchemaVersion) {
-			return;
-		}
-
-		if (storedSchemaVersion > currentSchemaVersion) {
-			throw `sqlite messages schema version is higher than expected (${storedSchemaVersion} > ${currentSchemaVersion}). Is The Lounge out of date?`;
-		}
-
+	async _run_migrations(dbVersion: number) {
 		log.info(
-			`sqlite messages schema version is out of date (${storedSchemaVersion} < ${currentSchemaVersion}). Running migrations if any.`
+			`sqlite messages schema version is out of date (${dbVersion} < ${currentSchemaVersion}). Running migrations.`
 		);
 
+		const to_execute = necessaryMigrations(dbVersion);
+
+		for (const stmt of to_execute.map((m) => m.stmts).flat()) {
+			await this.serialize_run(stmt, []);
+		}
+
 		await this.serialize_run("UPDATE options SET value = ? WHERE name = 'schema_version'", [
-			currentSchemaVersion,
+			currentSchemaVersion.toString(),
 		]);
+	}
+
+	async run_migrations() {
+		const version = await this.current_version();
+
+		if (version > currentSchemaVersion) {
+			throw `sqlite messages schema version is higher than expected (${version} > ${currentSchemaVersion}). Is The Lounge out of date?`;
+		} else if (version === currentSchemaVersion) {
+			return; // nothing to do
+		}
+
+		await this.serialize_run("BEGIN EXCLUSIVE TRANSACTION", []);
+
+		try {
+			if (version === 0) {
+				await this.setup_new_db();
+			} else {
+				await this._run_migrations(version);
+			}
+		} catch (err) {
+			await this.serialize_run("ROLLBACK", []);
+			throw err;
+		}
+
+		await this.serialize_run("COMMIT", []);
+		await this.serialize_run("VACUUM", []);
 	}
 
 	async close() {

--- a/server/plugins/messageStorage/sqlite.ts
+++ b/server/plugins/messageStorage/sqlite.ts
@@ -23,7 +23,7 @@ try {
 	);
 }
 
-const currentSchemaVersion = 1520239200;
+export const currentSchemaVersion = 1520239200;
 
 const schema = [
 	// Schema version #1

--- a/server/plugins/messageStorage/sqlite.ts
+++ b/server/plugins/messageStorage/sqlite.ts
@@ -25,12 +25,12 @@ try {
 
 type Migration = {version: number; stmts: string[]};
 
-export const currentSchemaVersion = 1520239200; // use `new Date().getTime()`
+export const currentSchemaVersion = 1672236339873; // use `new Date().getTime()`
 
 // Desired schema, adapt to the newest version and add migrations to the array below
 const schema = [
 	"CREATE TABLE IF NOT EXISTS options (name TEXT, value TEXT, CONSTRAINT name_unique UNIQUE (name))",
-	"CREATE TABLE IF NOT EXISTS messages (network TEXT, channel TEXT, time INTEGER, type TEXT, msg TEXT)",
+	"CREATE TABLE IF NOT EXISTS messages (id INTEGER PRIMARY KEY AUTOINCREMENT, network TEXT, channel TEXT, time INTEGER, type TEXT, msg TEXT)",
 	"CREATE INDEX IF NOT EXISTS network_channel ON messages (network, channel)",
 	"CREATE INDEX IF NOT EXISTS time ON messages (time)",
 ];

--- a/server/plugins/messageStorage/sqlite.ts
+++ b/server/plugins/messageStorage/sqlite.ts
@@ -23,15 +23,20 @@ try {
 	);
 }
 
-export const currentSchemaVersion = 1520239200;
+type Migration = {version: number; stmts: string[]};
 
+export const currentSchemaVersion = 1520239200; // use `new Date().getTime()`
+
+// Desired schema, adapt to the newest version and add migrations to the array below
 const schema = [
-	// Schema version #1
 	"CREATE TABLE IF NOT EXISTS options (name TEXT, value TEXT, CONSTRAINT name_unique UNIQUE (name))",
 	"CREATE TABLE IF NOT EXISTS messages (network TEXT, channel TEXT, time INTEGER, type TEXT, msg TEXT)",
 	"CREATE INDEX IF NOT EXISTS network_channel ON messages (network, channel)",
 	"CREATE INDEX IF NOT EXISTS time ON messages (time)",
 ];
+
+// the migrations will be executed in an exclusive transaction as a whole
+export const migrations = [];
 
 class Deferred {
 	resolve!: () => void;
@@ -324,6 +329,10 @@ function parseSearchRowsToMessages(id: number, rows: any[]) {
 	}
 
 	return messages;
+}
+
+export function necessaryMigrations(since: number): Migration[] {
+	return migrations.filter((m) => m.version > since);
 }
 
 export default SqliteMessageStorage;

--- a/test/plugins/sqlite.ts
+++ b/test/plugins/sqlite.ts
@@ -48,29 +48,6 @@ describe("SQLite Message Storage", function () {
 		store.isEnabled = true;
 	});
 
-	it("should create tables", function (done) {
-		store.database.all(
-			"SELECT name, tbl_name, sql FROM sqlite_master WHERE type = 'table'",
-			(err, row) => {
-				expect(err).to.be.null;
-				expect(row).to.deep.equal([
-					{
-						name: "options",
-						tbl_name: "options",
-						sql: "CREATE TABLE options (name TEXT, value TEXT, CONSTRAINT name_unique UNIQUE (name))",
-					},
-					{
-						name: "messages",
-						tbl_name: "messages",
-						sql: "CREATE TABLE messages (network TEXT, channel TEXT, time INTEGER, type TEXT, msg TEXT)",
-					},
-				]);
-
-				done();
-			}
-		);
-	});
-
 	it("should insert schema version to options table", function (done) {
 		store.database.get(
 			"SELECT value FROM options WHERE name = 'schema_version'",

--- a/test/plugins/sqlite.ts
+++ b/test/plugins/sqlite.ts
@@ -5,7 +5,102 @@ import {expect} from "chai";
 import util from "../util";
 import Msg, {MessageType} from "../../server/models/msg";
 import Config from "../../server/config";
-import MessageStorage, {currentSchemaVersion} from "../../server/plugins/messageStorage/sqlite";
+import MessageStorage, {
+	currentSchemaVersion,
+	migrations,
+	necessaryMigrations,
+} from "../../server/plugins/messageStorage/sqlite";
+import Client from "../../server/client";
+import sqlite3 from "sqlite3";
+
+const orig_schema = [
+	// Schema version #1
+	// DO NOT CHANGE THIS IN ANY WAY, it's needed to properly test migrations
+	"CREATE TABLE IF NOT EXISTS options (name TEXT, value TEXT, CONSTRAINT name_unique UNIQUE (name))",
+	"CREATE TABLE IF NOT EXISTS messages (network TEXT, channel TEXT, time INTEGER, type TEXT, msg TEXT)",
+	"CREATE INDEX IF NOT EXISTS network_channel ON messages (network, channel)",
+	"CREATE INDEX IF NOT EXISTS time ON messages (time)",
+];
+
+const v1_schema_version = 1520239200;
+
+const v1_dummy_messages = [
+	{
+		network: "8f650427-79a2-4950-b8af-94088b61b37c",
+		channel: "##linux",
+		time: 1594845354280,
+		type: "message",
+		msg: '{"from":{"mode":"","nick":"rascul"},"text":"db on a flash drive doesn\'t sound very nice though","self":false,"highlight":false,"users":[]}',
+	},
+	{
+		network: "8f650427-79a2-4950-b8af-94088b61b37c",
+		channel: "##linux",
+		time: 1594845357234,
+		type: "message",
+		msg: '{"from":{"mode":"","nick":"GrandPa-G"},"text":"that\'s the point of changing to make sure.","self":false,"highlight":false,"users":[]}',
+	},
+	{
+		network: "8f650427-79a2-4950-b8af-94088b61b37c",
+		channel: "#pleroma-dev",
+		time: 1594845358464,
+		type: "message",
+		msg: '{"from":{"mode":"@","nick":"rinpatch"},"text":"it\'s complicated","self":false,"highlight":false,"users":[]}',
+	},
+];
+
+describe("SQLite migrations", function () {
+	let db: sqlite3.Database;
+
+	function serialize_run(stmt: string, ...params: any[]): Promise<void> {
+		return new Promise((resolve, reject) => {
+			db.serialize(() => {
+				db.run(stmt, params, (err) => {
+					if (err) {
+						reject(err);
+						return;
+					}
+
+					resolve();
+				});
+			});
+		});
+	}
+
+	before(async function () {
+		db = new sqlite3.Database(":memory:");
+
+		for (const stmt of orig_schema) {
+			await serialize_run(stmt);
+		}
+
+		for (const msg of v1_dummy_messages) {
+			await serialize_run(
+				"INSERT INTO messages(network, channel, time, type, msg) VALUES(?, ?, ?, ?, ?)",
+				msg.network,
+				msg.channel,
+				msg.time,
+				msg.type,
+				msg.msg
+			);
+		}
+	});
+
+	after(function (done) {
+		db.close(done);
+	});
+
+	it("has working migrations", async function () {
+		const to_execute = necessaryMigrations(v1_schema_version);
+		expect(to_execute.length).to.eq(migrations.length);
+		await serialize_run("BEGIN EXCLUSIVE TRANSACTION");
+
+		for (const stmt of to_execute.map((m) => m.stmts).flat()) {
+			await serialize_run(stmt);
+		}
+
+		await serialize_run("COMMIT TRANSACTION");
+	});
+});
 
 describe("SQLite Message Storage", function () {
 	// Increase timeout due to unpredictable I/O on CI services

--- a/test/plugins/sqlite.ts
+++ b/test/plugins/sqlite.ts
@@ -5,7 +5,7 @@ import {expect} from "chai";
 import util from "../util";
 import Msg, {MessageType} from "../../server/models/msg";
 import Config from "../../server/config";
-import MessageStorage from "../../server/plugins/messageStorage/sqlite";
+import MessageStorage, {currentSchemaVersion} from "../../server/plugins/messageStorage/sqlite";
 
 describe("SQLite Message Storage", function () {
 	// Increase timeout due to unpredictable I/O on CI services
@@ -53,11 +53,8 @@ describe("SQLite Message Storage", function () {
 			"SELECT value FROM options WHERE name = 'schema_version'",
 			(err, row) => {
 				expect(err).to.be.null;
-
-				// Should be sqlite.currentSchemaVersion,
 				// compared as string because it's returned as such from the database
-				expect(row.value).to.equal("1520239200");
-
+				expect(row.value).to.equal(currentSchemaVersion.toString());
 				done();
 			}
 		);


### PR DESCRIPTION
Adds the necessary infra + runs the first bunch of migrations... namely the primary key for messages.
This will make our inserts slightly slower than now, however we can guarantee that we always have monotonically increasing IDs.

We can lower that requirement to get the speed back, with the problem that it can (and therefore will) eventually fail for someone with very fun side effects if we rely on those things in the code.