### PR TITLE
Storage cleanup

### DIFF
--- a/server/client.ts
+++ b/server/client.ts
@@ -138,7 +138,7 @@ class Client {
 
 		if (!Config.values.public && client.config.log) {
 			if (Config.values.messageStorage.includes("sqlite")) {
-				client.messageProvider = new SqliteMessageStorage(client);
+				client.messageProvider = new SqliteMessageStorage(client.name);
 				client.messageStorage.push(client.messageProvider);
 			}
 

--- a/server/client.ts
+++ b/server/client.ts
@@ -143,7 +143,7 @@ class Client {
 			}
 
 			if (Config.values.messageStorage.includes("text")) {
-				client.messageStorage.push(new TextFileMessageStorage(client));
+				client.messageStorage.push(new TextFileMessageStorage(client.name));
 			}
 
 			for (const messageStorage of client.messageStorage) {

--- a/server/models/chan.ts
+++ b/server/models/chan.ts
@@ -287,7 +287,7 @@ class Chan {
 		}
 
 		client.messageProvider
-			.getMessages(network, this)
+			.getMessages(network, this, () => client.idMsg++)
 			.then((messages) => {
 				if (messages.length === 0) {
 					if (network.irc!.network.cap.isEnabled("znc.in/playback")) {

--- a/server/plugins/messageStorage/sqlite.ts
+++ b/server/plugins/messageStorage/sqlite.ts
@@ -8,11 +8,7 @@ import Msg, {Message} from "../../models/msg";
 import Client from "../../client";
 import Chan, {Channel} from "../../models/chan";
 import Helper from "../../helper";
-import type {
-	SearchResponse,
-	SearchQuery,
-	SqliteMessageStorage as ISqliteMessageStorage,
-} from "./types";
+import type {SearchResponse, SearchQuery, SearchableMessageStorage} from "./types";
 import Network from "../../models/network";
 
 // TODO; type
@@ -49,11 +45,11 @@ class Deferred {
 	}
 }
 
-class SqliteMessageStorage implements ISqliteMessageStorage {
-	client: Client;
+class SqliteMessageStorage implements SearchableMessageStorage {
 	isEnabled: boolean;
 	database!: Database;
 	initDone: Deferred;
+	client: Client;
 
 	constructor(client: Client) {
 		this.client = client;

--- a/server/plugins/messageStorage/text.ts
+++ b/server/plugins/messageStorage/text.ts
@@ -5,17 +5,16 @@ import filenamify from "filenamify";
 
 import Config from "../../config";
 import {MessageStorage} from "./types";
-import Client from "../../client";
 import Channel from "../../models/chan";
 import {Message, MessageType} from "../../models/msg";
 import Network from "../../models/network";
 
 class TextFileMessageStorage implements MessageStorage {
-	client: Client;
 	isEnabled: boolean;
+	username: string;
 
-	constructor(client: Client) {
-		this.client = client;
+	constructor(username: string) {
+		this.username = username;
 		this.isEnabled = false;
 	}
 
@@ -36,7 +35,7 @@ class TextFileMessageStorage implements MessageStorage {
 
 		const logPath = path.join(
 			Config.getUserLogsPath(),
-			this.client.name,
+			this.username,
 			TextFileMessageStorage.getNetworkFolderName(network)
 		);
 

--- a/server/plugins/messageStorage/types.d.ts
+++ b/server/plugins/messageStorage/types.d.ts
@@ -6,7 +6,6 @@ import {Network} from "../../models/network";
 import Client from "../../client";
 
 interface MessageStorage {
-	client: Client;
 	isEnabled: boolean;
 
 	enable(): Promise<void>;
@@ -38,7 +37,6 @@ export type SearchResponse =
 
 type SearchFunction = (query: SearchQuery) => Promise<SearchResponse>;
 
-export interface SqliteMessageStorage extends MessageStorage {
-	database: Database;
-	search: SearchFunction | [];
+export interface SearchableMessageStorage extends MessageStorage {
+	search: SearchFunction;
 }

--- a/server/plugins/messageStorage/types.d.ts
+++ b/server/plugins/messageStorage/types.d.ts
@@ -16,7 +16,7 @@ interface MessageStorage {
 
 	deleteChannel(network: Network, channel: Channel): Promise<void>;
 
-	getMessages(network: Network, channel: Channel): Promise<Message[]>;
+	getMessages(network: Network, channel: Channel, nextID: () => number): Promise<Message[]>;
 
 	canProvideMessages(): boolean;
 }


### PR DESCRIPTION
Fixes several issues with the message storage API's

Reason I'm doing the cleanup (besides the fact that it's needed) is that I want to write a manual migration cli command.

For that I need to initialize the sqlite storage for a user, without actually having a client at all.
When we accept accept a client, that's not possible.