### PR TITLE
Fix misleading LDAP filiter in default config

### DIFF
--- a/defaults/config.js
+++ b/defaults/config.js
@@ -457,9 +457,9 @@ module.exports = {
 			//   - `rootPassword`: Password of The Lounge LDAP system user.
 			rootPassword: "1234",
 
-			//   - `filter`: it is set to `"(objectClass=person)(memberOf=ou=accounts,dc=example,dc=com)"`
+			//   - `filter`: it is set to `"(&(objectClass=person)(memberOf=ou=accounts,dc=example,dc=com))"`
 			//     by default.
-			filter: "(objectClass=person)(memberOf=ou=accounts,dc=example,dc=com)",
+			filter: "(&(objectClass=person)(memberOf=ou=accounts,dc=example,dc=com))",
 
 			//   - `base`: LDAP search base (search only within this node). It is set
 			//     to `"dc=example,dc=com"` by default.


### PR DESCRIPTION
The default filter provided in config files is invalid. This may mislead people. Confirm to issue #4620.