### PR TITLE
Fix uploader mount/unmount lifecycle

### DIFF
--- a/client/components/ChatInput.vue
+++ b/client/components/ChatInput.vue
@@ -337,6 +337,7 @@ export default defineComponent({
 				autocompletionRef.value = undefined;
 			}
 
+			upload.unmounted();
 			upload.abort();
 		});
 

--- a/client/js/upload.ts
+++ b/client/js/upload.ts
@@ -18,18 +18,26 @@ class Uploader {
 	onPaste = (e: ClipboardEvent) => this.paste(e);
 
 	init() {
-		document.addEventListener("dragenter", this.onDragEnter);
-		document.addEventListener("dragover", this.onDragOver);
-		document.addEventListener("dragleave", this.onDragLeave);
-		document.addEventListener("drop", this.onDrop);
-		document.addEventListener("paste", this.onPaste);
-
 		socket.on("upload:auth", (token) => this.uploadNextFileInQueue(token));
 	}
 
 	mounted() {
 		this.overlay = document.getElementById("upload-overlay") as HTMLDivElement;
 		this.uploadProgressbar = document.getElementById("upload-progressbar") as HTMLSpanElement;
+
+		document.addEventListener("dragenter", this.onDragEnter);
+		document.addEventListener("dragover", this.onDragOver);
+		document.addEventListener("dragleave", this.onDragLeave);
+		document.addEventListener("drop", this.onDrop);
+		document.addEventListener("paste", this.onPaste);
+	}
+
+	unmounted() {
+		document.removeEventListener("dragenter", this.onDragEnter);
+		document.removeEventListener("dragover", this.onDragOver);
+		document.removeEventListener("dragleave", this.onDragLeave);
+		document.removeEventListener("drop", this.onDrop);
+		document.removeEventListener("paste", this.onPaste);
 	}
 
 	dragOver(event: DragEvent) {
@@ -308,12 +316,6 @@ class Uploader {
 			this.xhr.abort();
 			this.xhr = null;
 		}
-
-		document.removeEventListener("dragenter", this.onDragEnter);
-		document.removeEventListener("dragover", this.onDragOver);
-		document.removeEventListener("dragleave", this.onDragLeave);
-		document.removeEventListener("drop", this.onDrop);
-		document.removeEventListener("paste", this.onPaste);
 	}
 }
 
@@ -323,5 +325,6 @@ export default {
 	abort: () => instance.abort(),
 	initialize: () => instance.init(),
 	mounted: () => instance.mounted(),
+	unmounted: () => instance.unmounted(),
 	triggerUpload: (files) => instance.triggerUpload(files),
 };


### PR DESCRIPTION
Currently, in `ChatInput.vue` we call `upload.abort()` which removes the event listeners, which are never added back. This effectively permanently disable uploads if the user navigates away to Settings or any other non-chat pages, and back.

Moves the binding to `mounted()` so that they're properly rebound when a chat window is in view, and also adds an `unmounted()` for clarity.

This should also fix an edge case if the page opens up on a non-chat page and there was never a ChatInput to unbind it, such as login page or add network pages.