### PR TITLE
implement auth plugins

### DIFF
--- a/defaults/config.js
+++ b/defaults/config.js
@@ -492,4 +492,5 @@ module.exports = {
 		// server window, displayed on the client.
 		raw: false,
 	},
+	authModule: "local",
 };

--- a/server/config.ts
+++ b/server/config.ts
@@ -104,6 +104,7 @@ export type ConfigType = {
 	ldap: Ldap;
 	debug: Debug;
 	themeColor: string;
+	authModule: string;
 };
 
 class Config {

--- a/server/plugins/packages/index.ts
+++ b/server/plugins/packages/index.ts
@@ -10,9 +10,17 @@ import inputs from "../inputs";
 import fs from "fs";
 import Utils from "../../command-line/utils";
 import Client from "../../client";
+import {AuthHandler} from "../auth";
 
 type Package = {
 	onServerStart: (packageApis: any) => void;
+	auth?: [
+		{
+			moduleName: string;
+			auth: AuthHandler;
+			isEnabled: () => boolean;
+		}
+	];
 };
 
 const packageMap = new Map<string, Package>();
@@ -44,6 +52,7 @@ export default {
 	getPackage,
 	loadPackages,
 	outdated,
+	packageMap,
 };
 
 // TODO: verify binds worked. Used to be 'this' instead of 'packageApis'


### PR DESCRIPTION
Implements auth plugins

example plugin:
```javascript
module.exports = {
	onServerStart: (api) => {
	},
	auth: [
		{
			moduleName: "testlocal",
			auth: localAuth,
			isEnabled: () => true,

		}
	],
	"1234": "123123",
};
```