### PR TITLE
Plugin input

### DIFF
--- a/server/client.ts
+++ b/server/client.ts
@@ -465,38 +465,9 @@ class Client {
 		const cmd = args?.shift()?.toLowerCase() || "";
 
 		const irc = target.network.irc;
-		let connected = irc && irc.connection && irc.connection.connected;
+		const connected = irc?.connected;
 
-		if (inputs.userInputs.has(cmd)) {
-			const plugin = inputs.userInputs.get(cmd);
-
-			if (!plugin) {
-				// should be a no-op
-				throw new Error(`Plugin ${cmd} not found`);
-			}
-
-			if (typeof plugin.input === "function" && (connected || plugin.allowDisconnected)) {
-				connected = true;
-				plugin.input.apply(client, [target.network, target.chan, cmd, args]);
-			}
-		} else if (inputs.pluginCommands.has(cmd)) {
-			const plugin = inputs.pluginCommands.get(cmd);
-
-			if (typeof plugin.input === "function" && (connected || plugin.allowDisconnected)) {
-				connected = true;
-				plugin.input(
-					new PublicClient(client, plugin.packageInfo),
-					{network: target.network, chan: target.chan},
-					cmd,
-					args
-				);
-			}
-		} else if (connected) {
-			// TODO: fix
-			irc!.raw(text);
-		}
-
-		if (!connected) {
+		const emitFailureDisconnected = () => {
 			target.chan.pushMessage(
 				this,
 				new Msg({
@@ -504,7 +475,44 @@ class Client {
 					text: "You are not connected to the IRC network, unable to send your command.",
 				})
 			);
+		};
+
+		const plugin = inputs.userInputs.get(cmd);
+
+		if (plugin) {
+			if (!connected && !plugin.allowDisconnected) {
+				emitFailureDisconnected();
+				return;
+			}
+
+			plugin.input.apply(client, [target.network, target.chan, cmd, args]);
+			return;
 		}
+
+		const extPlugin = inputs.pluginCommands.get(cmd);
+
+		if (extPlugin) {
+			if (!connected && !extPlugin.allowDisconnected) {
+				emitFailureDisconnected();
+				return;
+			}
+
+			extPlugin.input(
+				new PublicClient(client, extPlugin.packageInfo),
+				{network: target.network, chan: target.chan},
+				cmd,
+				args
+			);
+			return;
+		}
+
+		if (!connected) {
+			emitFailureDisconnected();
+			return;
+		}
+
+		// TODO: fix
+		irc!.raw(text);
 	}
 
 	compileCustomHighlights() {


### PR DESCRIPTION
This types the public command API during the registration phase and reworks the input function to be a bit easier to understand, least for me.

Holler if you disagree, but I hate the pattern of

```js
if(stuff) {
 // ...
} else if (other) {
 // ...
} else if (yet another) {
 // ...
}
// return
```

That (implicit) return right there is not even on screen when you start to read the first few clauses, so you have no idea what the function does at the end only to then scroll down and find out that it indeed just returns.

We already know that we are done, tell the reader accordingly.