### PR TITLE
Framework internals

### DIFF
--- a/server/models/network.ts
+++ b/server/models/network.ts
@@ -416,10 +416,8 @@ class Network {
 		}
 
 		if (this.irc) {
-			const connected = this.irc.connection && this.irc.connection.connected;
-
 			if (this.nick !== oldNick) {
-				if (connected) {
+				if (this.irc.connected) {
 					// Send new nick straight away
 					this.irc.changeNick(this.nick);
 				} else {
@@ -434,7 +432,7 @@ class Network {
 			}
 
 			if (
-				connected &&
+				this.irc.connected &&
 				this.realname !== oldRealname &&
 				this.irc.network.cap.isEnabled("setname")
 			) {

--- a/server/plugins/inputs/connect.ts
+++ b/server/plugins/inputs/connect.ts
@@ -15,7 +15,7 @@ const input: PluginInputHandler = function (network, chan, cmd, args) {
 			return;
 		}
 
-		if (irc.connection && irc.connection.connected) {
+		if (irc.connected) {
 			chan.pushMessage(
 				this,
 				new Msg({

--- a/server/plugins/inputs/nick.ts
+++ b/server/plugins/inputs/nick.ts
@@ -47,7 +47,7 @@ const input: PluginInputHandler = function (network, chan, cmd, args) {
 	// If connected to IRC, send to server and wait for ACK
 	// otherwise update the nick and UI straight away
 	if (network.irc) {
-		if (network.irc.connection && network.irc.connection.connected) {
+		if (network.irc.connected) {
 			network.irc.changeNick(newNick);
 
 			return;

--- a/server/plugins/inputs/part.ts
+++ b/server/plugins/inputs/part.ts
@@ -36,9 +36,7 @@ const input: PluginInputHandler = function (network, chan, cmd, args) {
 	if (
 		target.type !== ChanType.CHANNEL ||
 		target.state === ChanState.PARTED ||
-		!network.irc ||
-		!network.irc.connection ||
-		!network.irc.connection.connected
+		!network.irc.connected
 	) {
 		this.part(network, target);
 	} else {

--- a/server/plugins/inputs/raw.ts
+++ b/server/plugins/inputs/raw.ts
@@ -4,7 +4,7 @@ const commands = ["raw", "send", "quote"];
 
 const input: PluginInputHandler = function ({irc}, chan, cmd, args) {
 	if (args.length !== 0) {
-		irc.connection.write(args.join(" "));
+		irc.raw(...args);
 	}
 
 	return true;


### PR DESCRIPTION
We are constantly messing with internal state of the irc-framework.
This isn't documented in the public api and presumably disallowed.

There's some tricky places which we probably need to write PRs for (accessing the tls status and such).

However, we can at least start with the easy pickings.