### PR TITLE
tests/server: Tear down test fixtures in the order they were setup

### DIFF
--- a/test/server.ts
+++ b/test/server.ts
@@ -39,10 +39,10 @@ describe("Server", function () {
 	});
 
 	after(function (done) {
-		server.close(done);
 		logInfoStub.restore();
 		logWarnStub.restore();
 		checkForUpdatesStub.restore();
+		server.close(done);
 	});
 
 	// eslint-disable-next-line @typescript-eslint/restrict-template-expressions

--- a/test/server.ts
+++ b/test/server.ts
@@ -39,6 +39,8 @@ describe("Server", function () {
 	});
 
 	after(function (done) {
+		// Tear down test fixtures in the order they were setup,
+		// in case setup crashed for any reason
 		logInfoStub.restore();
 		logWarnStub.restore();
 		checkForUpdatesStub.restore();


### PR DESCRIPTION
if for whatever reason before() fails to import the server, it causes after() to fail on the first line, so it doesn't restore stubs; causing other errors to be printed in other tests ("TypeError: Attempted to wrap warn which is already wrapped")