### PR TITLE
Restore constructor props commits

### DIFF
--- a/server/models/chan.ts
+++ b/server/models/chan.ts
@@ -41,19 +41,18 @@ export type ChanConfig = {
 };
 
 class Chan {
-	// TODO: don't force existence, figure out how to make TS infer it.
-	id!: number;
-	messages!: Msg[];
-	name!: string;
-	key!: string;
-	topic!: string;
-	firstUnread!: number;
-	unread!: number;
-	highlight!: number;
-	users!: Map<string, User>;
-	muted!: boolean;
-	type!: ChanType;
-	state!: ChanState;
+	id: number;
+	messages: Msg[];
+	name: string;
+	key: string;
+	topic: string;
+	firstUnread: number;
+	unread: number;
+	highlight: number;
+	users: Map<string, User>;
+	muted: boolean;
+	type: ChanType;
+	state: ChanState;
 
 	userAway?: boolean;
 	special?: SpecialChanType;
@@ -63,20 +62,22 @@ class Chan {
 	static optionalProperties = ["userAway", "special", "data", "closed", "num_users"];
 
 	constructor(attr?: Partial<Chan>) {
-		_.defaults(this, attr, {
-			id: 0,
-			messages: [],
-			name: "",
-			key: "",
-			topic: "",
-			type: ChanType.CHANNEL,
-			state: ChanState.PARTED,
-			firstUnread: 0,
-			unread: 0,
-			highlight: 0,
-			users: new Map(),
-			muted: false,
-		});
+		this.id = 0;
+		this.messages = [];
+		this.name = "";
+		this.key = "";
+		this.topic = "";
+		this.type = ChanType.CHANNEL;
+		this.state = ChanState.PARTED;
+		this.firstUnread = 0;
+		this.unread = 0;
+		this.highlight = 0;
+		this.users = new Map();
+		this.muted = false;
+
+		if (attr) {
+			Object.assign(this, attr);
+		}
 	}
 
 	destroy() {

--- a/server/models/network.ts
+++ b/server/models/network.ts
@@ -96,93 +96,96 @@ export type NetworkConfig = {
 };
 
 class Network {
-	nick!: string;
-	name!: string;
-	host!: string;
-	port!: number;
-	tls!: boolean;
-	userDisconnected!: boolean;
-	rejectUnauthorized!: boolean;
-	password!: string;
-	awayMessage!: string;
-	commands!: any[];
-	username!: string;
-	realname!: string;
-	leaveMessage!: string;
-	sasl!: string;
-	saslAccount!: string;
-	saslPassword!: string;
-	channels!: Chan[];
-	uuid!: string;
-	proxyHost!: string;
-	proxyPort!: number;
-	proxyUsername!: string;
-	proxyPassword!: string;
-	proxyEnabled!: boolean;
+	nick: string;
+	name: string;
+	host: string;
+	port: number;
+	tls: boolean;
+	userDisconnected: boolean;
+	rejectUnauthorized: boolean;
+	password: string;
+	awayMessage: string;
+	commands: any[];
+	username: string;
+	realname: string;
+	leaveMessage: string;
+	sasl: string;
+	saslAccount: string;
+	saslPassword: string;
+	channels: Chan[];
+	uuid: string;
+	proxyHost: string;
+	proxyPort: number;
+	proxyUsername: string;
+	proxyPassword: string;
+	proxyEnabled: boolean;
 	highlightRegex?: RegExp;
 
 	irc?: IrcFramework.Client & {
 		options?: NetworkIrcOptions;
 	};
 
-	chanCache!: Chan[];
-	ignoreList!: IgnoreList;
-	keepNick!: string | null;
+	chanCache: Chan[];
+	ignoreList: IgnoreList;
+	keepNick: string | null;
 
-	status!: NetworkStatus;
-
-	serverOptions!: {
+	serverOptions: {
 		CHANTYPES: string[];
 		PREFIX: Prefix;
 		NETWORK: string;
 	};
 
 	// TODO: this is only available on export
-	hasSTSPolicy!: boolean;
+	hasSTSPolicy: boolean;
+	status: NetworkStatus;
 
 	constructor(attr?: Partial<Network>) {
-		_.defaults(this, attr, {
-			name: "",
-			nick: "",
-			host: "",
-			port: 6667,
-			tls: false,
-			userDisconnected: false,
-			rejectUnauthorized: false,
-			password: "",
-			awayMessage: "",
-			commands: [],
-			username: "",
-			realname: "",
-			leaveMessage: "",
-			sasl: "",
-			saslAccount: "",
-			saslPassword: "",
-			channels: [],
-			irc: null,
-			serverOptions: {
-				CHANTYPES: ["#", "&"],
-				PREFIX: new Prefix([
-					{symbol: "!", mode: "Y"},
-					{symbol: "@", mode: "o"},
-					{symbol: "%", mode: "h"},
-					{symbol: "+", mode: "v"},
-				]),
-				NETWORK: "",
-			},
+		this.name = "";
+		this.nick = "";
+		this.host = "";
+		this.port = 6667;
+		this.tls = false;
+		this.userDisconnected = false;
+		this.rejectUnauthorized = false;
+		this.password = "";
+		this.awayMessage = "";
+		this.commands = [];
+		this.username = "";
+		this.realname = "";
+		this.leaveMessage = "";
+		this.sasl = "";
+		this.saslAccount = "";
+		this.saslPassword = "";
+		this.channels = [];
+		this.serverOptions = {
+			CHANTYPES: ["#", "&"],
+			PREFIX: new Prefix([
+				{symbol: "!", mode: "Y"},
+				{symbol: "@", mode: "o"},
+				{symbol: "%", mode: "h"},
+				{symbol: "+", mode: "v"},
+			]),
+			NETWORK: "",
+		};
+		this.proxyHost = "";
+		this.proxyPort = 1080;
+		this.proxyUsername = "";
+		this.proxyPassword = "";
+		this.proxyEnabled = false;
 
-			proxyHost: "",
-			proxyPort: 1080,
-			proxyUsername: "",
-			proxyPassword: "",
-			proxyEnabled: false,
+		this.chanCache = [];
+		this.ignoreList = [];
+		this.keepNick = null;
+		this.hasSTSPolicy = false;
+		this.uuid = "invalid"; // sentinel value that makes us generate a new one
 
-			chanCache: [],
-			ignoreList: [],
-			keepNick: null,
-		});
+		this.status = {connected: false, secure: false};
 
-		if (!this.uuid) {
+		if (attr) {
+			Object.assign(this, attr);
+		}
+
+		if (this.uuid === "invalid" || !this.uuid) {
 			this.uuid = uuidv4();
 		}
 

--- a/server/models/user.ts
+++ b/server/models/user.ts
@@ -1,30 +1,27 @@
-import _ from "lodash";
 import Prefix from "./prefix";
 
 class User {
-	modes!: string[];
+	modes: string[];
 	// Users in the channel have only one mode assigned
-	mode!: string;
-	away!: string;
-	nick!: string;
-	lastMessage!: number;
+	away: string;
+	nick: string;
+	lastMessage: number;
 
 	constructor(attr: Partial<User>, prefix?: Prefix) {
-		_.defaults(this, attr, {
-			modes: [],
-			away: "",
-			nick: "",
-			lastMessage: 0,
-		});
+		this.modes = [];
+		this.away = "";
+		this.nick = "";
+		this.lastMessage = 0;
 
-		Object.defineProperty(this, "mode", {
-			get() {
-				// eslint-disable-next-line @typescript-eslint/no-unsafe-return
-				return this.modes[0] || "";
-			},
-		});
+		if (attr) {
+			Object.assign(this, attr);
+		}
 
 		this.setModes(this.modes, prefix || new Prefix([]));
+	}
+
+	get mode() {
+		return this.modes[0] || "";
 	}
 
 	setModes(modes: string[], prefix: Prefix) {


### PR DESCRIPTION
Val's PR apparently fixes the issue introduced by https://github.com/thelounge/thelounge/commit/e31c95e32d44d709d96c008cd77d6f6aca60ef40 in https://github.com/thelounge/thelounge/pull/4710

Meaning we can re-introduce the commits that were reverted after merging it.

However, I don't understand **why** the commit referenced above exposes the breakage that was apparently already there in the first place.
I'd appreciate it if someone could educate me / point my brain in the right direction