### PR TITLE
Inline logger into changelog script

### DIFF
--- a/scripts/changelog.js
+++ b/scripts/changelog.js
@@ -53,12 +53,37 @@ const got = require("got");
 const dayjs = require("dayjs");
 const semver = require("semver");
 const util = require("util");
-const log = require("../server/log");
 const packageJson = require("../package.json");
 let token = process.env.CHANGELOG_TOKEN;
 
 const readFile = util.promisify(fs.readFile);
 const writeFile = util.promisify(fs.writeFile);
+
+function timestamp() {
+	const datetime = new Date().toISOString().split(".")[0].replace("T", " ");
+
+	return colors.dim(datetime);
+}
+
+const log = {
+	/* eslint-disable no-console */
+	error(...args) {
+		console.error(timestamp(), colors.red("[ERROR]"), ...args);
+	},
+	warn(...args) {
+		console.error(timestamp(), colors.yellow("[WARN]"), ...args);
+	},
+	info(...args) {
+		console.log(timestamp(), colors.blue("[INFO]"), ...args);
+	},
+	debug(...args) {
+		console.log(timestamp(), colors.green("[DEBUG]"), ...args);
+	},
+	raw(...args) {
+		console.log(...args);
+	},
+	/* eslint-enable no-console */
+};
 
 const changelogPath = path.resolve(__dirname, "..", "CHANGELOG.md");
 


### PR DESCRIPTION
We can't really import easily from our build without it being brittle. TL isn't meant to be used as a library.

Instead, just inline the logger as it is trivial enough.