### PR TITLE
push: remove iOS warning

### DIFF
--- a/client/components/Settings/Notifications.vue
+++ b/client/components/Settings/Notifications.vue
@@ -28,17 +28,6 @@
 				<div v-if="store.state.pushNotificationState === 'unsupported'" class="error">
 					<strong>Warning</strong>:
 					<span>Push notifications are not supported by your browser.</span>
-
-					<div v-if="isIOS" class="apple-push-unsupported">
-						Safari does
-						<a
-							href="https://bugs.webkit.org/show_bug.cgi?id=182566"
-							target="_blank"
-							rel="noopener"
-							>not support the web push notification specification</a
-						>, and because all browsers on iOS use Safari under the hood, The Lounge is
-						unable to provide push notifications on iOS devices.
-					</div>
 				</div>
 			</div>
 		</template>

--- a/client/css/style.css
+++ b/client/css/style.css
@@ -1928,7 +1928,6 @@ part/quit messages where we don't load previews (adds a blank line otherwise) */
 	width: 100%;
 }
 
-#settings .apple-push-unsupported,
 #settings .settings-sync-panel {
 	padding: 10px;
 	margin-bottom: 16px;
@@ -1956,11 +1955,6 @@ part/quit messages where we don't load previews (adds a blank line otherwise) */
 #settings .settings-sync-panel .btn:active,
 #settings .settings-sync-panel .btn:focus {
 	box-shadow: 0 0 0 3px rgb(0 123 255 / 50%);
-}
-
-#settings .apple-push-unsupported a {
-	color: inherit;
-	text-decoration: underline;
 }
 
 #settings .opt {


### PR DESCRIPTION
iOS 16.4 introduced webpush, we can get rid of the special case in our settings panel.