### PR TITLE
Unbreak nick colors for existing themes

### DIFF
--- a/client/components/Chat.vue
+++ b/client/components/Chat.vue
@@ -6,6 +6,7 @@
 				'hide-motd': store.state.settings.motd,
 				'time-seconds': store.state.settings.showSeconds,
 				'time-12h': store.state.settings.use12hClock,
+				'colored-nicks': true, // TODO temporarily fixes themes, to be removed in next major version
 			}"
 		>
 			<div


### PR DESCRIPTION
https://github.com/thelounge/thelounge/pull/4649 broke existing themes by removing the colored-nicks class from chat.

Considering that we don't bump the major version, keep backwards compatibility for now