### PR TITLE
Publish to npm with provenance

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: Build
 
+permissions:
+  contents: read
+
 on: [push, pull_request]
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,9 @@
 name: Release
 
+permissions:
+  contents: read
+  id-token: write
+
 on:
   push:
     tags: v*
@@ -29,15 +33,18 @@ jobs:
       - name: Test
         run: yarn test
 
+      - name: Update npm
+        run: npm install -g npm
+
       - name: Publish latest
         if: "!contains(github.ref, '-')"
-        run: npm publish --tag latest
+        run: npm publish --tag latest --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
 
       - name: Publish next
         if: contains(github.ref, '-')
-        run: npm publish --tag next
+        run: npm publish --tag next --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
 


### PR DESCRIPTION
Ref: https://github.blog/changelog/2023-04-19-npm-provenance-public-beta/

The release action defaults to node 18 already, which is fine.

This should work fine, but perhaps we want to cut a quick pre release just to check that it works.

I also added `permissions` to the actions, and added node 20 to the test matrix (we can drop node 14 after next release).