### PR TITLE
fix motd display to match settings

### DIFF
--- a/client/components/Chat.vue
+++ b/client/components/Chat.vue
@@ -3,7 +3,7 @@
 		<div
 			id="chat"
 			:class="{
-				'hide-motd': store.state.settings.motd,
+				'hide-motd': !store.state.settings.motd,
 				'time-seconds': store.state.settings.showSeconds,
 				'time-12h': store.state.settings.use12hClock,
 				'colored-nicks': true, // TODO temporarily fixes themes, to be removed in next major version


### PR DESCRIPTION
The show MOTD setting is inverted, it hides the MOTD if "show MOTD" is checked and vice versa. The origin for this bug seems to be that an exclamation mark was accidentally removed [here](https://github.com/thelounge/thelounge/pull/4559/files#diff-4e246c0c7479589e2f5e10a83c90e9b27783480737493f5892ea80900fb7c22b).