### PR TITLE
Prune old events from sqlite database

### DIFF
--- a/defaults/config.js
+++ b/defaults/config.js
@@ -60,14 +60,6 @@ module.exports = {
 	// This value is set to `10000` by default.
 	maxHistory: 10000,
 
-	// ### `dbHistoryDays`
-	//
-	// Defines the maximum number of days of history to store in the database.
-	// Undefined/-1/0 is treated an unlimited.
-	// The limit is seen as a soft target but not an exact goal. Only a few
-	// thousand rows are pruned at a time to avoid slowing down the service.
-	dbHistoryDays: undefined,
-
 	// ### `https`
 	//
 	// These settings are used to run The Lounge's web server using encrypted TLS.
@@ -311,6 +303,16 @@ module.exports = {
 	//
 	// This value is set to `["sqlite", "text"]` by default.
 	messageStorage: ["sqlite", "text"],
+
+	// ### `sqliteConfig`
+	//
+	// `maxDaysHistory`:
+	// 		Defines the maximum number of days of history to keep in the database.
+	// 		Undefined/-1/0 is treated an unlimited.
+	//		Users can overwrite setting to make the duration shorter
+	sqliteConfig: {
+		maxDaysHistory: undefined,
+	},
 
 	// ### `useHexIp`
 	//

--- a/defaults/config.js
+++ b/defaults/config.js
@@ -60,6 +60,14 @@ module.exports = {
 	// This value is set to `10000` by default.
 	maxHistory: 10000,
 
+	// ### `dbHistoryDays`
+	//
+	// Defines the maximum number of days of history to store in the database.
+	// Undefined/-1/0 is treated an unlimited.
+	// The limit is seen as a soft target but not an exact goal. Only a few
+	// thousand rows are pruned at a time to avoid slowing down the service.
+	dbHistoryDays: undefined,
+
 	// ### `https`
 	//
 	// These settings are used to run The Lounge's web server using encrypted TLS.

--- a/server/client.ts
+++ b/server/client.ts
@@ -69,6 +69,7 @@ export type UserConfig = {
 			pushSubscription?: ClientPushSubscription;
 		};
 	};
+	storage: typeof Config.values.sqliteConfig;
 	clientSettings: {
 		[key: string]: any;
 	};
@@ -137,7 +138,10 @@ class Client {
 
 		if (!Config.values.public && client.config.log) {
 			if (Config.values.messageStorage.includes("sqlite")) {
-				client.messageProvider = new SqliteMessageStorage(client.name);
+				client.messageProvider = new SqliteMessageStorage(
+					client.name,
+					client.config.storage
+				);
 				client.messageStorage.push(client.messageProvider);
 			}
 

--- a/server/config.ts
+++ b/server/config.ts
@@ -76,6 +76,12 @@ type Debug = {
 	raw: boolean;
 };
 
+type SqliteConfig =
+	| {
+			maxDaysHistory: number | undefined;
+	  }
+	| undefined;
+
 export type ConfigType = {
 	public: boolean;
 	host: string | undefined;
@@ -83,7 +89,6 @@ export type ConfigType = {
 	bind: string | undefined;
 	reverseProxy: boolean;
 	maxHistory: number;
-	dbHistoryDays: number | undefined;
 	https: Https;
 	theme: string;
 	prefetch: boolean;
@@ -98,6 +103,7 @@ export type ConfigType = {
 	defaults: Defaults;
 	lockNetwork: boolean;
 	messageStorage: string[];
+	sqliteConfig: SqliteConfig;
 	useHexIp: boolean;
 	webirc?: WebIRC;
 	identd: Identd;

--- a/server/config.ts
+++ b/server/config.ts
@@ -83,6 +83,7 @@ export type ConfigType = {
 	bind: string | undefined;
 	reverseProxy: boolean;
 	maxHistory: number;
+	dbHistoryDays: number | undefined;
 	https: Https;
 	theme: string;
 	prefetch: boolean;

--- a/test/client.ts
+++ b/test/client.ts
@@ -57,6 +57,7 @@ describe("Client", function () {
 			sessions: {},
 			clientSettings: {},
 			networks: [networkConfig],
+			storage: undefined,
 		});
 
 		// The client would normally do it as part of client.connect();
@@ -92,6 +93,7 @@ describe("Client", function () {
 			sessions: {},
 			clientSettings: {},
 			networks: [networkConfig],
+			storage: undefined,
 		});
 
 		// The client would normally do it as part of client.connect();


### PR DESCRIPTION
Adds a new config `dbHistoryDays` which defaults to undefined.

At start up, each database handler reads the config. If the value is set, then a reoccuring task is scheduled to clean up old events. Events older than `dbHistoryDays` are targeted but only a few thousand events are cleaned up per iteration to avoid freezing the server.

Adds unit tests to validate the cleanup logic as well.

Fixes #2822