### PR TITLE
issue ban before kick in kickban

### DIFF
--- a/server/plugins/inputs/ban.ts
+++ b/server/plugins/inputs/ban.ts
@@ -33,8 +33,10 @@ const input: PluginInputHandler = function ({irc}, chan, cmd, args) {
 
 	switch (cmd) {
 		case "kickban":
+			// issue ban first to avoid race condition
+			irc.ban(chan.name, args[0]);
 			irc.raw("KICK", chan.name, args[0], args.slice(1).join(" "));
-		// fall through
+			break;
 		case "ban":
 			irc.ban(chan.name, args[0]);
 			break;


### PR DESCRIPTION
Common practice for kickbans is to issue the ban first to avoid a race condition with the kicked person's client auto-rejoining the channel before the banning client is able to set the ban.