### PR TITLE
Fix semver for prerelease versions

### DIFF
--- a/server/command-line/install.ts
+++ b/server/command-line/install.ts
@@ -74,7 +74,9 @@ program
 
 				if (
 					json.thelounge.supports &&
-					!semver.satisfies(Helper.getVersionNumber(), json.thelounge.supports)
+					!semver.satisfies(Helper.getVersionNumber(), json.thelounge.supports, {
+						includePrerelease: true,
+					})
 				) {
 					log.error(
 						`${colors.red(


### PR DESCRIPTION
Noticed this issue while trying to install a plugin on 4.4.1-rc2.

```
> semver.default.satisfies("4.4.1-rc2", ">=4.3.0")
false
> semver.default.satisfies("4.4.1-rc2", ">=4.3.0", {includePrerelease: true})
true
```