### PR TITLE
Prevent autocomplete space following username at login

### DIFF
--- a/client/components/Windows/SignIn.vue
+++ b/client/components/Windows/SignIn.vue
@@ -26,6 +26,7 @@
 				autocapitalize="none"
 				autocorrect="off"
 				autocomplete="username"
+				pattern="[^\s]+"
 				:value="getStoredUser()"
 				required
 				autofocus


### PR DESCRIPTION
No popup because this usually happens for reasons that aren't the user's fault.