### PR TITLE
store: use return type over a type cast

### DIFF
--- a/client/js/store.ts
+++ b/client/js/store.ts
@@ -90,31 +90,30 @@ export type State = {
 	searchEnabled: boolean;
 };
 
-const state = () =>
-	({
-		appLoaded: false,
-		activeChannel: undefined,
-		currentUserVisibleError: null,
-		desktopNotificationState: detectDesktopNotificationState(),
-		isAutoCompleting: false,
-		isConnected: false,
-		networks: [],
-		mentions: [],
-		hasServiceWorker: false,
-		pushNotificationState: "unsupported",
-		serverConfiguration: null,
-		sessions: [],
-		sidebarOpen: false,
-		sidebarDragging: false,
-		userlistOpen: storage.get("thelounge.state.userlist") !== "false",
-		versionData: null,
-		versionStatus: "loading",
-		versionDataExpired: false,
-		serverHasSettings: false,
-		messageSearchResults: null,
-		messageSearchPendingQuery: null,
-		searchEnabled: false,
-	} as State);
+const state = (): State => ({
+	appLoaded: false,
+	activeChannel: undefined,
+	currentUserVisibleError: null,
+	desktopNotificationState: detectDesktopNotificationState(),
+	isAutoCompleting: false,
+	isConnected: false,
+	networks: [],
+	mentions: [],
+	hasServiceWorker: false,
+	pushNotificationState: "unsupported",
+	serverConfiguration: null,
+	sessions: [],
+	sidebarOpen: false,
+	sidebarDragging: false,
+	userlistOpen: storage.get("thelounge.state.userlist") !== "false",
+	versionData: null,
+	versionStatus: "loading",
+	versionDataExpired: false,
+	serverHasSettings: false,
+	messageSearchResults: null,
+	messageSearchPendingQuery: null,
+	searchEnabled: false,
+});
 
 type Getters = {
 	findChannelOnCurrentNetwork: (state: State) => (name: string) => ClientChan | undefined;


### PR DESCRIPTION
Not sure about idiomatic TS, but I'm fairly sure type casts should be avoided wherever possible.

In this case the compiler is still smart enough to catch mistakes both ways, but normally type casts can prevent the compiler from flagging type mismatches as errors so let's not do them.