### PR TITLE
search: move color to themes

### DIFF
--- a/client/components/MessageSearchForm.vue
+++ b/client/components/MessageSearchForm.vue
@@ -36,13 +36,7 @@ form.message-search input {
 	height: auto !important;
 	margin: 7px 0;
 	border: 0;
-	color: inherit;
-	background-color: #fafafa;
 	appearance: none;
-}
-
-form.message-search input::placeholder {
-	color: rgba(0, 0, 0, 0.35);
 }
 
 @media (min-width: 480px) {
@@ -63,7 +57,6 @@ form.message-search .input-wrapper {
 	z-index: 1;
 	height: 0;
 	overflow: hidden;
-	background: var(--window-bg-color);
 }
 
 form.message-search .input-wrapper input {
@@ -76,7 +69,6 @@ form.message-search.opened .input-wrapper {
 
 #chat form.message-search button {
 	display: flex;
-	color: #607992;
 }
 </style>
 

--- a/client/themes/default.css
+++ b/client/themes/default.css
@@ -33,3 +33,21 @@
 		border-radius: 0;
 	}
 }
+
+/* Search Form */
+form.message-search input {
+	color: inherit;
+	background-color: #fafafa;
+}
+
+form.message-search input::placeholder {
+	color: rgba(0, 0, 0, 0.35);
+}
+
+form.message-search .input-wrapper {
+	background: var(--window-bg-color);
+}
+
+#chat form.message-search button {
+	color: #607992;
+}

--- a/client/themes/morning.css
+++ b/client/themes/morning.css
@@ -122,6 +122,15 @@ body {
 /* Search Form */
 form.message-search input {
 	background-color: #28333d;
+	color: inherit;
+}
+
+form.message-search input::placeholder {
+	color: rgba(0, 0, 0, 0.35);
+}
+
+form.message-search .input-wrapper {
+	background: var(--window-bg-color);
 }
 
 #chat form.message-search button {


### PR DESCRIPTION
Themes that differ from our built ins should not be forced to use very specific styles just to undo what the base style sets.

If they decide that all input fields should have a certain color, they should be able to just select on the input field. Our base style should just do layout.
The themes can then override the colors where needed.