### PR TITLE
Block Referer header from being sent when clicking links

### DIFF
--- a/client/index.html.tpl
+++ b/client/index.html.tpl
@@ -46,6 +46,9 @@
 	<meta name="mobile-web-app-capable" content="yes">
 	<meta name="theme-color" content="<%- themeColor %>">
 
+	<!-- Block Referer header from being sent when clicking links -->
+	<meta name="referrer" content="no-referrer">
+
 	</head>
 	<body class="<%- public ? " public" : "" %>" data-transports="<%- JSON.stringify(transports) %>">
 		<div id="app"></div>


### PR DESCRIPTION
Before this change, any links a user clicks on will be sent the full The Lounge URL the user is coming from. While not too big of an issue, especially since URL fragments (channel IDs) aren't sent, this provides a little bit of a privacy improvement.