### PR TITLE
Added a channel (or network) toggle to notify on all messages

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -372,6 +372,7 @@ p {
 .context-menu-edit::before { content: "\f303"; /* https://fontawesome.com/icons/pencil-alt?style=solid */ }
 .context-menu-clear-history::before { content: "\f1f8"; /* https://fontawesome.com/icons/trash?style=solid */ }
 .context-menu-mute::before { content: "\f6a9"; /* https://fontawesome.com/v5.15/icons/volume-mute?style=solid */ }
+.context-menu-notify-all::before { content: "\f028"; /* https://fontawesome.com/v5.15/icons/volume-up?style=solid */ }
 
 .channel-list-item .not-secure-icon::before {
 	content: "\f071"; /* https://fontawesome.com/icons/exclamation-triangle?style=solid */

--- a/client/js/helpers/contextMenu.ts
+++ b/client/js/helpers/contextMenu.ts
@@ -223,6 +223,20 @@ export function generateChannelContextMenu(
 				});
 			},
 		});
+
+		items.push({
+			label: channel.notifyAll
+				? `Don't notify on all messages for ${chanType}`
+				: `Notify on all messages for ${chanType}`,
+			type: "item",
+			class: "notify-all",
+			action() {
+				socket.emit("notifyAll:change", {
+					target: channel.id,
+					setNotifyAllTo: !channel.notifyAll,
+				});
+			},
+		});
 	}
 
 	// Add close menu item

--- a/client/js/socket-events/index.ts
+++ b/client/js/socket-events/index.ts
@@ -25,3 +25,4 @@ import "./history_clear";
 import "./mentions";
 import "./search";
 import "./mute_changed";
+import "./notify_all_changed";

--- a/client/js/socket-events/msg.ts
+++ b/client/js/socket-events/msg.ts
@@ -105,7 +105,11 @@ function notifyMessage(
 		return;
 	}
 
-	if (msg.highlight || (store.state.settings.notifyAllMessages && msg.type === "message")) {
+	if (
+		channel.notifyAll ||
+		msg.highlight ||
+		(store.state.settings.notifyAllMessages && msg.type === "message")
+	) {
 		if (!document.hasFocus() || !activeChannel || activeChannel.channel !== channel) {
 			if (store.state.settings.notification) {
 				try {

--- a/client/js/socket-events/notify_all_changed.ts
+++ b/client/js/socket-events/notify_all_changed.ts
@@ -1,0 +1,18 @@
+import socket from "../socket";
+import {store} from "../store";
+
+socket.on("notifyAll:changed", (response) => {
+	const {target, status} = response;
+
+	const netChan = store.getters.findChannel(target);
+
+	if (netChan?.channel.type === "lobby") {
+		for (const chan of netChan.network.channels) {
+			if (chan.type !== "special") {
+				chan.notifyAll = status;
+			}
+		}
+	} else if (netChan) {
+		netChan.channel.notifyAll = status;
+	}
+});

--- a/server/client.ts
+++ b/server/client.ts
@@ -267,6 +267,7 @@ class Client {
 						key: chan.key || "",
 						type: type,
 						muted: chan.muted,
+						notifyAll: chan.notifyAll,
 					})
 				);
 			});

--- a/server/models/chan.ts
+++ b/server/models/chan.ts
@@ -37,6 +37,7 @@ export type ChanConfig = {
 	name: string;
 	key?: string;
 	muted?: boolean;
+	notifyAll?: boolean;
 	type?: string;
 };
 
@@ -52,6 +53,7 @@ class Chan {
 	highlight!: number;
 	users!: Map<string, User>;
 	muted!: boolean;
+	notifyAll!: boolean;
 	type!: ChanType;
 	state!: ChanState;
 
@@ -76,6 +78,7 @@ class Chan {
 			highlight: 0,
 			users: new Map(),
 			muted: false,
+			notifyAll: false,
 		});
 	}
 
@@ -331,6 +334,9 @@ class Chan {
 	}
 	setMuteStatus(muted: boolean) {
 		this.muted = !!muted;
+	}
+	setNotifyAll(notifyAll: boolean) {
+		this.notifyAll = !!notifyAll;
 	}
 }
 

--- a/server/models/network.ts
+++ b/server/models/network.ts
@@ -199,6 +199,8 @@ class Network {
 				muted:
 					this.channels.length >= 1 &&
 					this.channels.every((chan) => chan.muted || chan.type === ChanType.SPECIAL),
+				notifyAll:
+					this.channels.length >= 1 && this.channels.every((chan) => chan.notifyAll),
 			})
 		);
 	}
@@ -651,7 +653,7 @@ class Network {
 				return channel.type === ChanType.CHANNEL || channel.type === ChanType.QUERY;
 			})
 			.map(function (chan) {
-				const keys = ["name", "muted"];
+				const keys = ["name", "muted", "notifyAll"];
 
 				if (chan.type === ChanType.CHANNEL) {
 					keys.push("key");

--- a/server/plugins/irc-events/message.ts
+++ b/server/plugins/irc-events/message.ts
@@ -177,7 +177,11 @@ export default <IrcEventHandler>function (irc, network) {
 		chan.pushMessage(client, msg, !msg.self);
 
 		// Do not send notifications if the channel is muted or for messages older than 15 minutes (znc buffer for example)
-		if (!chan.muted && msg.highlight && (!data.time || data.time > Date.now() - 900000)) {
+		if (
+			!chan.muted &&
+			(msg.highlight || chan.notifyAll) &&
+			(!data.time || data.time > Date.now() - 900000)
+		) {
 			let title = chan.name;
 			let body = cleanMessage;
 

--- a/server/types/socket-events.d.ts
+++ b/server/types/socket-events.d.ts
@@ -49,6 +49,8 @@ interface ServerToClientEvents {
 
 	"mute:changed": (response: {target: number; status: boolean}) => void;
 
+	"notifyAll:changed": (response: {target: number; status: boolean}) => void;
+
 	names: (data: {id: number; users: User[]}) => void;
 
 	network: (data: {networks: ClientNetwork[]}) => void;
@@ -157,6 +159,8 @@ interface ClientToServerEvents {
 	"upload:ping": (token: string) => void;
 
 	"mute:change": (response: {target: number; setMutedTo: boolean}) => void;
+
+	"notifyAll:change": (response: {target: number; setNotifyAllTo: boolean}) => void;
 
 	"push:register": (subscriptionJson: PushSubscriptionJSON) => void;
 	"push:unregister": () => void;

--- a/test/models/chan.ts
+++ b/test/models/chan.ts
@@ -214,6 +214,7 @@ describe("Chan", function () {
 					"key",
 					"messages",
 					"muted",
+					"notifyAll",
 					"totalMessages",
 					"name",
 					"state",

--- a/test/models/network.ts
+++ b/test/models/network.ts
@@ -89,7 +89,7 @@ describe("Network", function () {
 				saslAccount: "testaccount",
 				saslPassword: "testpassword",
 				channels: [
-					new Chan({name: "#thelounge", key: "", muted: false}),
+					new Chan({name: "#thelounge", key: "", muted: false, notifyAll: true}),
 					new Chan({name: "&foobar", key: "", muted: false}),
 					new Chan({name: "#secret", key: "foo", muted: false}),
 					new Chan({name: "&secure", key: "bar", muted: true}),
@@ -123,11 +123,11 @@ describe("Network", function () {
 				proxyPassword: "",
 				proxyUsername: "",
 				channels: [
-					{name: "#thelounge", key: "", muted: false},
-					{name: "&foobar", key: "", muted: false},
-					{name: "#secret", key: "foo", muted: false},
-					{name: "&secure", key: "bar", muted: true},
-					{name: "PrivateChat", type: "query", muted: true},
+					{name: "#thelounge", key: "", muted: false, notifyAll: true},
+					{name: "&foobar", key: "", muted: false, notifyAll: false},
+					{name: "#secret", key: "foo", muted: false, notifyAll: false},
+					{name: "&secure", key: "bar", muted: true, notifyAll: false},
+					{name: "PrivateChat", type: "query", muted: true, notifyAll: false},
 				],
 				ignoreList: [],
 			});


### PR DESCRIPTION
This PR adds a toggle on channels (or networks) to notify on all messages. 

<img width="265" alt="image" src="https://github.com/thelounge/thelounge/assets/6239308/8857fd26-8f8a-4823-9a70-8f5fb7c1806c">
and 
<img width="297" alt="image" src="https://github.com/thelounge/thelounge/assets/6239308/1009f1af-b628-4d66-a2c6-3fc9a0fe6ac8">

I probably should've asked for comment on what to use for the icon and toggle text. As of now, the icon is [volume-up](ttps://fontawesome.com/v5.15/icons/volume-up?style=solid) and the text is:

When all notifications enabled:
```
Don't notify on all messages for ${chanType}
```

When all notifications disabled:
```
Notify on all messages for ${chanType}
```

`${chanType}` is either `channel` or `network`.
