### PR TITLE
feat: support custom CTCP VERSION responses

### DIFF
--- a/defaults/config.js
+++ b/defaults/config.js
@@ -218,6 +218,19 @@ module.exports = {
 	// default.
 	leaveMessage: "The Lounge - https://thelounge.chat",
 
+	// ### `versionResponse`
+	//
+	// A template string to format thelounge's response to CTCP VERSION requests. The
+	// tokens `%product-name%`, `%version%`, and `%url%` will be replaced by the
+	// appropriate values for the currently running version of The Lounge.
+	//
+	// You can use this to remove version information from the CTCP VERSION response
+	// for hardening.
+	//
+	// The default template string results in a response of
+	// `thelounge vX.Y.Z -- https://thelounge.chat`.
+	versionResponse: "%product-name% %version% -- %url%",
+
 	// ## Default network
 
 	// ### `defaults`

--- a/server/config.ts
+++ b/server/config.ts
@@ -94,6 +94,7 @@ export type ConfigType = {
 	fileUpload: FileUpload;
 	transports: string[];
 	leaveMessage: string;
+	versionResponse: string;
 	defaults: Defaults;
 	lockNetwork: boolean;
 	messageStorage: string[];

--- a/server/plugins/irc-events/ctcp.ts
+++ b/server/plugins/irc-events/ctcp.ts
@@ -1,4 +1,5 @@
 import _ from "lodash";
+import Config from "../../config";
 import {IrcEventHandler} from "../../client";
 import Helper from "../../helper";
 import Msg, {MessageType} from "../../models/msg";
@@ -12,7 +13,11 @@ const ctcpResponses = {
 			.join(" "),
 	PING: ({message}: {message: string}) => message.substring(5),
 	SOURCE: () => pkg.repository.url,
-	VERSION: () => pkg.name + " " + Helper.getVersion() + " -- " + pkg.homepage,
+	VERSION: () =>
+		Config.values.versionResponse
+			.replace("%product-name%", pkg.name)
+			.replace("%version%", Helper.getVersion())
+			.replace("%url%", pkg.homepage),
 };
 
 export default <IrcEventHandler>function (irc, network) {


### PR DESCRIPTION
Closes #1344

Adds a new config option, `versionResponse`, which is described as follows:

> A template string to format thelounge's response to CTCP VERSION requests. The
> tokens `%product-name%`, `%version%`, and `%url%` will be replaced by the
> appropriate values for the currently running version of The Lounge.
> 
> You can use this to remove version information from the CTCP VERSION response
> for hardening.
> 
> The default template string results in a response of
>  `thelounge vX.Y.Z -- https://thelounge.chat/`.

The goals of this, in descending order of importance, are:

1. Make thelounge users less fingerprintable by hiding build/version info in VERSION responses
	* thelounge's user base is likely small enough that users can be tracked between identities by the Git commit hash/version number exposed in CTCP VERSION responses
	* Similar reasoning was used when browser vendors decided to freeze the `User-Agent` string: https://css-tricks.com/freezing-user-agent-strings/
	* Extensive discussion on this exact issue on znc's repo: https://github.com/znc/znc/issues/820
2. Add "Security By Obscurity" by not giving the exact version of thelounge that is running
3. Match the behavior of almost all other IRC clients (all that I've used, certainly) by allowing users to customize VERSION
4. Allow users to have silly novelty VERSION strings (least important)

I originally wanted to just have a static `versionResponse` string, but I saw that `defaults/config` lives outside of `server`, so it wouldn't be right to pull in `Helper.getVersion` there. Another option would be to treat `versionResponse` as an "override" that's only used when defined so it doesn't need to be template-able, or to move `getVersion` to `shared`.

I tested this locally via `node ./dist/server/command-line/index.js start -c versionResponse=foo` and confirmed it works as expected, and also confirmed the default works as expected.

No support is added in this PR for *disabling* VERSION responses entirely. This is because CLIENTINFO and SOURCE CTCP responses also expose that thelounge is running, so there would be little point in disabling only VERSION. A future PR could add an option to disable/obfuscate all 3. Passing `versionResponse=` will result in a blank VERSION response only.

Please let me know if you have feedback on the API design here, I'm open to making changes.

Pre-merge tasks:

- [ ] Open corresponding PR in https://github.com/thelounge/thelounge.github.io