### PR TITLE
router: don't use next() in router guards

### DIFF
--- a/client/js/router.ts
+++ b/client/js/router.ts
@@ -110,26 +110,23 @@ router.beforeEach((to, from, next) => {
 	next();
 });
 
-router.beforeEach((to, from, next) => {
+router.beforeEach((to, from) => {
 	// Disallow navigating to non-existing routes
 	if (!to.matched.length) {
-		next(false);
-		return;
+		return false;
 	}
 
 	// Disallow navigating to invalid channels
 	if (to.name === "RoutedChat" && !store.getters.findChannel(Number(to.params.id))) {
-		next(false);
-		return;
+		return false;
 	}
 
 	// Disallow navigating to invalid networks
 	if (to.name === "NetworkEdit" && !store.getters.findNetwork(String(to.params.uuid))) {
-		next(false);
-		return;
+		return false;
 	}
 
-	next();
+	return true;
 });
 
 router.afterEach((to) => {


### PR DESCRIPTION
Vue wants to get rid of the next call.
https://router.vuejs.org/guide/advanced/navigation-guards.html#Optional-third-argument-next

For one of the router guards, it's easy enough to do so let's do that.