### PR TITLE
Add sqlite cleanup functionality

### DIFF
--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -11,6 +11,7 @@
     "../server/log.ts",
     "../server/config.ts",
     "../server/client.ts",
+    "../server/storageCleaner.ts",
     "../server/clientManager.ts",
     "../server/identification.ts",
     "../server/plugins/changelog.ts",

--- a/defaults/config.js
+++ b/defaults/config.js
@@ -304,6 +304,26 @@ module.exports = {
 	// This value is set to `["sqlite", "text"]` by default.
 	messageStorage: ["sqlite", "text"],
 
+	// ### `storagePolicy`
+
+	// When the sqlite storage is in use, control the maximum storage duration.
+	// A background task will periodically clean up messages older than the limit.
+
+	// The available keys for the `storagePolicy` object are:
+	//
+	// - `enabled`: If this is false, the cleaning task is not running.
+	// - `maxAgeDays`: Maximum age of an entry in days.
+	// - `deletionPolicy`: Controls what types of messages are being deleted.
+	//   Valid options are:
+	//   - `statusOnly`: Only delete message types which are status related (e.g. away, back, join, parts, mode, ctcp...)
+	//     but keep actual messages from nicks. This keeps the DB size down while retaining "precious" messages.
+	//   - `everything`: Delete everything, including messages from irc nicks
+	storagePolicy: {
+		enabled: false,
+		maxAgeDays: 7,
+		deletionPolicy: "statusOnly",
+	},
+
 	// ### `useHexIp`
 	//
 	// When set to `true`, users' IP addresses will be encoded as hex.

--- a/server/client.ts
+++ b/server/client.ts
@@ -18,6 +18,7 @@ import TextFileMessageStorage from "./plugins/messageStorage/text";
 import Network, {IgnoreListItem, NetworkConfig, NetworkWithIrcFramework} from "./models/network";
 import ClientManager from "./clientManager";
 import {MessageStorage, SearchQuery, SearchResponse} from "./plugins/messageStorage/types";
+import {StorageCleaner} from "./storageCleaner";
 
 type OrderItem = Chan["id"] | Network["uuid"];
 type Order = OrderItem[];
@@ -138,6 +139,15 @@ class Client {
 		if (!Config.values.public && client.config.log) {
 			if (Config.values.messageStorage.includes("sqlite")) {
 				client.messageProvider = new SqliteMessageStorage(client.name);
+
+				if (Config.values.storagePolicy.enabled) {
+					log.info(
+						`Activating storage cleaner. Policy: ${Config.values.storagePolicy.deletionPolicy}. MaxAge: ${Config.values.storagePolicy.maxAgeDays} days`
+					);
+					const cleaner = new StorageCleaner(client.messageProvider);
+					cleaner.start();
+				}
+
 				client.messageStorage.push(client.messageProvider);
 			}
 

--- a/server/command-line/storage.ts
+++ b/server/command-line/storage.ts
@@ -3,6 +3,7 @@ import {Command} from "commander";
 import ClientManager from "../clientManager";
 import Utils from "./utils";
 import SqliteMessageStorage from "../plugins/messageStorage/sqlite";
+import {StorageCleaner} from "../storageCleaner";
 
 const program = new Command("storage").description(
 	"various utilities related to the message storage"
@@ -10,7 +11,7 @@ const program = new Command("storage").description(
 
 program
 	.command("migrate")
-	.argument("[user]", "migrate a specific user only, all if not provided")
+	.argument("[username]", "migrate a specific user only, all if not provided")
 	.description("Migrate message storage where needed")
 	.on("--help", Utils.extraHelp)
 	.action(function (user) {
@@ -20,7 +21,19 @@ program
 		});
 	});
 
-async function runMigrations(user: string) {
+program
+	.command("clean")
+	.argument("[user]", "clean messages for a specific user only, all if not provided")
+	.description("Delete messages from the DB based on the storage policy")
+	.on("--help", Utils.extraHelp)
+	.action(function (user) {
+		runCleaning(user).catch((err) => {
+			log.error(err.toString());
+			process.exit(1);
+		});
+	});
+
+async function runMigrations(user?: string) {
 	const manager = new ClientManager();
 	const users = manager.getUsers();
 
@@ -63,6 +76,48 @@ function isUserLogEnabled(manager: ClientManager, user: string): boolean {
 	}
 
 	return conf.log;
+}
+
+async function runCleaning(user: string) {
+	const manager = new ClientManager();
+	const users = manager.getUsers();
+
+	if (user) {
+		if (!users.includes(user)) {
+			throw new Error(`invalid user ${user}`);
+		}
+
+		return cleanUser(manager, user);
+	}
+
+	for (const name of users) {
+		await cleanUser(manager, name);
+		// if any migration fails we blow up,
+		// chances are the rest won't complete either
+	}
+}
+
+async function cleanUser(manager: ClientManager, user: string) {
+	log.info("handling user", user);
+
+	if (!isUserLogEnabled(manager, user)) {
+		log.info("logging disabled for user", user, ". Skipping");
+		return;
+	}
+
+	const sqlite = new SqliteMessageStorage(user);
+	await sqlite.enable();
+	const cleaner = new StorageCleaner(sqlite);
+	const num_deleted = await cleaner.runDeletesNoLimit();
+	log.info(`deleted ${num_deleted} messages`);
+	log.info("running a vacuum now, this might take a while");
+
+	if (num_deleted > 0) {
+		await sqlite.vacuum();
+	}
+
+	await sqlite.close();
+	log.info(`cleaning messages for ${user} has been successful`);
 }
 
 export default program;

--- a/server/config.ts
+++ b/server/config.ts
@@ -76,6 +76,12 @@ type Debug = {
 	raw: boolean;
 };
 
+type StoragePolicy = {
+	enabled: boolean;
+	maxAgeDays: number;
+	deletionPolicy: "statusOnly" | "everything";
+};
+
 export type ConfigType = {
 	public: boolean;
 	host: string | undefined;
@@ -97,6 +103,7 @@ export type ConfigType = {
 	defaults: Defaults;
 	lockNetwork: boolean;
 	messageStorage: string[];
+	storagePolicy: StoragePolicy;
 	useHexIp: boolean;
 	webirc?: WebIRC;
 	identd: Identd;

--- a/server/plugins/messageStorage/sqlite.ts
+++ b/server/plugins/messageStorage/sqlite.ts
@@ -26,7 +26,7 @@ try {
 type Migration = {version: number; stmts: string[]};
 type Rollback = {version: number; rollback_forbidden?: boolean; stmts: string[]};
 
-export const currentSchemaVersion = 1679743888000; // use `new Date().getTime()`
+export const currentSchemaVersion = 1703322560448; // use `new Date().getTime()`
 
 // Desired schema, adapt to the newest version and add migrations to the array below
 const schema = [
@@ -45,6 +45,7 @@ const schema = [
 	)`,
 	"CREATE INDEX network_channel ON messages (network, channel)",
 	"CREATE INDEX time ON messages (time)",
+	"CREATE INDEX msg_type_idx on messages (type)", // needed for efficient storageCleaner queries
 ];
 
 // the migrations will be executed in an exclusive transaction as a whole
@@ -78,6 +79,10 @@ export const migrations: Migration[] = [
 			)`,
 		],
 	},
+	{
+		version: 1703322560448,
+		stmts: ["CREATE INDEX msg_type_idx on messages (type)"],
+	},
 ];
 
 // down migrations need to restore the state of the prior version.
@@ -90,6 +95,10 @@ export const rollbacks: Rollback[] = [
 	{
 		version: 1679743888000,
 		stmts: [], // here we can't drop the tables, as we use them in the code, so just leave those in
+	},
+	{
+		version: 1703322560448,
+		stmts: ["drop INDEX msg_type_idx"],
 	},
 ];
 

--- a/server/plugins/messageStorage/types.d.ts
+++ b/server/plugins/messageStorage/types.d.ts
@@ -4,6 +4,13 @@ import {Channel} from "../../models/channel";
 import {Message} from "../../models/message";
 import {Network} from "../../models/network";
 import Client from "../../client";
+import type {MessageType} from "../../models/msg";
+
+export type DeletionRequest = {
+	olderThanDays: number;
+	messageTypes: MessageType[] | null; // null means no restriction
+	limit: number; // -1 means unlimited
+};
 
 interface MessageStorage {
 	isEnabled: boolean;

--- a/server/storageCleaner.ts
+++ b/server/storageCleaner.ts
@@ -1,0 +1,148 @@
+import SqliteMessageStorage from "./plugins/messageStorage/sqlite";
+import {MessageType} from "./models/msg";
+import Config from "./config";
+import {DeletionRequest} from "./plugins/messageStorage/types";
+import log from "./log";
+
+const status_types = [
+	MessageType.AWAY,
+	MessageType.BACK,
+	MessageType.INVITE,
+	MessageType.JOIN,
+	MessageType.KICK,
+	MessageType.MODE,
+	MessageType.MODE_CHANNEL,
+	MessageType.MODE_USER,
+	MessageType.NICK,
+	MessageType.PART,
+	MessageType.QUIT,
+	MessageType.CTCP, // not technically a status, but generally those are only of interest temporarily
+	MessageType.CTCP_REQUEST,
+	MessageType.CHGHOST,
+	MessageType.TOPIC,
+	MessageType.TOPIC_SET_BY,
+];
+
+export class StorageCleaner {
+	db: SqliteMessageStorage;
+	olderThanDays: number;
+	messageTypes: MessageType[] | null;
+	limit: number;
+	ticker?: ReturnType<typeof setTimeout>;
+	errCount: number;
+	isStopped: boolean;
+
+	constructor(db: SqliteMessageStorage) {
+		this.errCount = 0;
+		this.isStopped = true;
+		this.db = db;
+		this.limit = 200;
+		const policy = Config.values.storagePolicy;
+		this.olderThanDays = policy.maxAgeDays;
+
+		switch (policy.deletionPolicy) {
+			case "statusOnly":
+				this.messageTypes = status_types;
+				break;
+			case "everything":
+				this.messageTypes = null;
+				break;
+			default:
+				// exhaustive switch guard, blows up when user specifies a invalid policy enum
+				this.messageTypes = assertNoBadPolicy(policy.deletionPolicy);
+		}
+	}
+
+	private genDeletionRequest(): DeletionRequest {
+		return {
+			limit: this.limit,
+			messageTypes: this.messageTypes,
+			olderThanDays: this.olderThanDays,
+		};
+	}
+
+	async runDeletesNoLimit(): Promise<number> {
+		if (!Config.values.storagePolicy.enabled) {
+			// this is meant to be used by cli tools, so we guard against this
+			throw new Error("storage policy is disabled");
+		}
+
+		const req = this.genDeletionRequest();
+		req.limit = -1; // unlimited
+		const num_deleted = await this.db.deleteMessages(req);
+		return num_deleted;
+	}
+
+	private async runDeletes() {
+		if (this.isStopped) {
+			return;
+		}
+
+		if (!this.db.isEnabled) {
+			// TODO: remove this once the server is intelligent enough to wait for init
+			this.schedule(30 * 1000);
+			return;
+		}
+
+		const req = this.genDeletionRequest();
+
+		let num_deleted = 0;
+
+		try {
+			num_deleted = await this.db.deleteMessages(req);
+			this.errCount = 0; // reset when it works
+		} catch (err: any) {
+			this.errCount++;
+			log.error("can't clean messages", err.message);
+
+			if (this.errCount === 2) {
+				log.error("Cleaning failed too many times, will not retry");
+				this.stop();
+				return;
+			}
+		}
+
+		// need to recheck here as the field may have changed since the await
+		if (this.isStopped) {
+			return;
+		}
+
+		if (num_deleted < req.limit) {
+			this.schedule(5 * 60 * 1000);
+		} else {
+			this.schedule(5000); // give others a chance to execute queries
+		}
+	}
+
+	private schedule(ms: number) {
+		const self = this;
+
+		this.ticker = setTimeout(() => {
+			self.runDeletes().catch((err) => {
+				log.error("storageCleaner: unexpected failure");
+				throw err;
+			});
+		}, ms);
+	}
+
+	start() {
+		this.isStopped = false;
+		this.schedule(0);
+	}
+
+	stop() {
+		this.isStopped = true;
+
+		if (!this.ticker) {
+			return;
+		}
+
+		clearTimeout(this.ticker);
+	}
+}
+
+function assertNoBadPolicy(_: never): never {
+	throw new Error(
+		`Invalid deletion policy "${Config.values.storagePolicy.deletionPolicy}" in the \`storagePolicy\` object, fix your config.`
+	);
+}


### PR DESCRIPTION
Once this is getting hooked up, it'll periodically delete old
messages.

The StoragePolicy can be chosen by the user, currently there's
two versions, delete everything based on age is the obvious.

The other is for the data hoarders among us. It'll only delete
message types which can be considered low value... Types with
a time aspect like away / back... joins / parts etc.

It tries to do that in a sensible way, so that we don't block
all other db writers that are ongoing.
The "periodically" interval is by design not exposed to the user.

Fixes: https://github.com/thelounge/thelounge/issues/2822