### PR TITLE
scripts: fix generate-config-doc, handle usage errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "coverage": "run-s test:* && nyc --nycrc-path=test/.nycrc-report.json report",
     "dev": "cross-env NODE_ENV=development ts-node --project server/tsconfig.json server/index.ts start --dev",
     "format:prettier": "prettier --write \"**/*.*\"",
+    "generate:config:doc": "ts-node scripts/generate-config-doc.js",
     "lint:check-eslint": "eslint-config-prettier .eslintrc.cjs",
     "lint:eslint": "eslint . --report-unused-disable-directives --color",
     "lint:prettier": "prettier --list-different \"**/*.*\"",

--- a/scripts/generate-config-doc.js
+++ b/scripts/generate-config-doc.js
@@ -1,16 +1,16 @@
 "use strict";
 
-// Usage: `node generate-config-doc.js DOC_REPO_PATH`
+// Usage: `npm run generate:config:doc DOC_REPO_PATH`
 //
 // Example:
 //
 // ```sh
-// node scripts/generate-config-doc.js ../thelounge.github.io/
+// npm run generate:config:doc ../thelounge.github.io/
 // ```
 
 const {readFileSync, writeFileSync} = require("fs");
 const colors = require("chalk");
-const log = require("../server/log");
+const log = require("../server/log").default;
 const {join} = require("path");
 const {spawnSync} = require("child_process");
 
@@ -20,7 +20,17 @@ function getGitUsername() {
 
 const configContent = readFileSync(join(__dirname, "..", "defaults", "config.js"), "utf8");
 
+const docRoot = process.argv[2];
+
+if (!docRoot) {
+	log.error("Missing DOC_REPO_PATH. Pass the path to the cloned `thelounge.github.io` repo.");
+	process.exit(1);
+}
+
 const docPath = join(process.argv[2], "_includes", "config.js.md");
+
+/** @type {string[]} */
+const acc = [];
 
 const extractedDoc = configContent
 	.replace(/https:\/\/thelounge\.chat\/docs/g, "/docs") // make links relative
@@ -37,7 +47,7 @@ const extractedDoc = configContent
 		}
 
 		return acc;
-	}, [])
+	}, acc)
 	.join("\n");
 
 const infoBlockHeader = `<!--


### PR DESCRIPTION
When trying to update the docs for #1344 I noticed that the `generate-config-doc` script was broken because it was no longer correctly importing `server/log`, my guess is it just got missed during TS conversion. I fixed the default import in this PR.

This PR also fixes the types in `generate-config-doc.js`, which are checked because `checkJs` is enabled in `tsconfig.json`. I did not convert the file to TypeScript because it is not part of the eslint TS config and I was unsure about making changes to the lint setup. The only type change required was marking `acc` as `string[]` instead of `never[]`.

Since `generate-config-doc` requires TS imports, the comments suggesting to use `node ./scripts/...` to execute it are wrong. I switched the comments to use a `npm` script which runs `ts-node` for the user.

Additionally, I added a check that the DOC_ROOT_PATH is supplied, so the script exits with a nice error instead of a less useful uncaught exception from `writeFileSync`.

Running this revealed that some of the existing config docs are out-of-date, so I opened a PR to sync up: thelounge/thelounge.github.io#275