### PR TITLE
cli: don't fail if stderr is not in json format

### DIFF
--- a/server/command-line/utils.ts
+++ b/server/command-line/utils.ts
@@ -143,11 +143,11 @@ class Utils {
 				data.toString()
 					.trim()
 					.split("\n")
-					.forEach((line) => {
+					.forEach((line: string) => {
 						try {
-							line = JSON.parse(line);
+							const json = JSON.parse(line);
 
-							if (line.type === "success") {
+							if (json.type === "success") {
 								success = true;
 							}
 						} catch (e: any) {
@@ -163,11 +163,26 @@ class Utils {
 					.trim()
 					.split("\n")
 					.forEach((line: string) => {
-						const json = JSON.parse(line);
+						try {
+							const json = JSON.parse(line);
 
-						if (json.type === "error") {
-							log.error(json.data);
+							switch (json.type) {
+								case "error":
+									log.error(json.data);
+									break;
+								case "warning":
+									// this includes pointless things like "ignored scripts due to flag"
+									// so let's hide it
+									break;
+							}
+
+							return;
+						} catch (e: any) {
+							// we simply fall through and log at debug... chances are there's nothing the user can do about it
+							// as it includes things like deprecation warnings, but we might want to know as developers
 						}
+
+						log.debug(line);
 					});
 			});
 


### PR DESCRIPTION
A user reported in the IRC chan that installing packages fails with

```
2023-12-13 20:02:34 [INFO] Installing thelounge-theme-solarized v1.1.9...
undefined:1
(node:3329) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
^
SyntaxError: Unexpected token '(', "(node:3329"... is not valid JSON
```

Now, this happens as yarn helpfully prints a deprecation warning that is shown in the stack trace.

Let's assume that we may get non json messages and log them at debug, as we don't know their severity.