### PR TITLE
Add web+ prefix to linkified URI schemes

### DIFF
--- a/test/shared/findLinks.ts
+++ b/test/shared/findLinks.ts
@@ -372,4 +372,34 @@ describe("findLinks", () => {
 
 		expect(actual).to.deep.equal(expected);
 	});
+
+	it("should find web+ap urls", () => {
+		const input = "web+ap://instance.example/@Example";
+		const expected = [
+			{
+				link: "web+ap://instance.example/@Example",
+				start: 0,
+				end: 34,
+			},
+		];
+
+		const actual = findLinks(input);
+
+		expect(actual).to.deep.equal(expected);
+	});
+
+	it("should find web+ap urls if scheme required flag is specified", () => {
+		const input = "web+ap://instance.example/@Example";
+		const expected = [
+			{
+				link: "web+ap://instance.example/@Example",
+				start: 0,
+				end: 34,
+			},
+		];
+
+		const actual = findLinksWithSchema(input);
+
+		expect(actual).to.deep.equal(expected);
+	});
 });


### PR DESCRIPTION
Briefly discussed on the IRC. For tokodon/tuba/feditext and future web-based protocols.

(Also they are called schemes, as per RFC 3986 and whatnot. Whether to be consistent with the RFC or with the linkify library tho, :shrug: )