### PR TITLE
linkify: simplify noscheme detection logic

### DIFF
--- a/test/shared/findLinks.ts
+++ b/test/shared/findLinks.ts
@@ -353,6 +353,26 @@ describe("findLinks", () => {
 		expect(actual).to.deep.equal(expected);
 	});
 
+	it("should parse mailto links", () => {
+		const input = "mail@example.com mailto:mail@example.org";
+		const expected = [
+			{
+				link: "mailto:mail@example.com",
+				start: 0,
+				end: 16,
+			},
+			{
+				link: "mailto:mail@example.org",
+				start: 17,
+				end: 40,
+			},
+		];
+
+		const actual = findLinks(input);
+
+		expect(actual).to.deep.equal(expected);
+	});
+
 	it("should not return urls with no schema if flag is specified", () => {
 		const input = "https://example.global //example.com http://example.group example.py";
 		const expected = [
@@ -369,6 +389,21 @@ describe("findLinks", () => {
 		];
 
 		const actual = findLinksWithSchema(input);
+
+		expect(actual).to.deep.equal(expected);
+	});
+
+	it("should use http for protocol-less URLs", () => {
+		const input = "//example.com";
+		const expected = [
+			{
+				link: "http://example.com",
+				start: 0,
+				end: 13,
+			},
+		];
+
+		const actual = findLinks(input);
 
 		expect(actual).to.deep.equal(expected);
 	});


### PR DESCRIPTION
Overriding the built in is poor form, as this prevents adding a new type handler with its own normalize handler.

We only ever want to override protocol-less URLs to http, so we just do so explicitly in the "//" schema normalizer.

This also means that we don't need all that type conversion dance, we simply set the schema to null when we patch it and filter on the schema directly

Take 2, as the first approach wasn't working.