### PR TITLE
Remove Node.js 16 from package.json and testing matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,19 +12,19 @@ jobs:
     strategy:
       matrix:
         include:
-          # EOL: April 2024
-          - os: ubuntu-latest
-            node_version: 16.x
+          # EOL: April 2025
           - os: macOS-latest
             node_version: 18.x
           - os: windows-latest
             node_version: 18.x
-          # EOL: April 2025
           - os: ubuntu-latest
             node_version: 18.x
           # EOL: April 2026
           - os: ubuntu-latest
             node_version: 20.x
+          # EOL: April June 2024
+          - os: ubuntu-latest
+            node_version: 21.x
 
     runs-on: ${{ matrix.os }}
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   ],
   "license": "MIT",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "files": [
     "./.thelounge_home",


### PR DESCRIPTION
Node.js 16 entered EOL in September 2023 (https://nodejs.org/en/blog/announcements/nodejs16-eol)

Changing the minimum node version probably means a major version bump.