### PR TITLE
server: remove version from CTCP response

### DIFF
--- a/server/plugins/irc-events/ctcp.ts
+++ b/server/plugins/irc-events/ctcp.ts
@@ -12,7 +12,7 @@ const ctcpResponses = {
 			.join(" "),
 	PING: ({message}: {message: string}) => message.substring(5),
 	SOURCE: () => pkg.repository.url,
-	VERSION: () => pkg.name + " " + Helper.getVersion() + " -- " + pkg.homepage,
+	VERSION: () => pkg.name + " -- " + pkg.homepage,
 };
 
 export default <IrcEventHandler>function (irc, network) {


### PR DESCRIPTION
Closes #1344 
Closes #4785 (?)

Instead of making this configurable as in #4780, just remove the version number altogether. See discussion: https://github.com/thelounge/thelounge/issues/4785#issuecomment-1825342142

cc @MaxLeiter @brunnre8 