### PR TITLE
feat: add username modes

### DIFF
--- a/client/components/Username.vue
+++ b/client/components/Username.vue
@@ -1,6 +1,11 @@
 <template>
 	<span
-		:class="['user', {[nickColor]: store.state.settings.coloredNicks}, {active: active}]"
+		:class="[
+			'user ',
+			{[nickColor]: store.state.settings.coloredNicks},
+			{active: active},
+			[mode ? userModes[mode] : ''],
+		]"
 		:data-name="user.nick"
 		role="button"
 		v-on="onHover ? {mouseenter: hover} : {}"
@@ -72,7 +77,18 @@ export default defineComponent({
 
 		const store = useStore();
 
+		const userModes = {
+			"~": "owner",
+			"&": "admin",
+			"!": "admin",
+			"@": "op",
+			"%": "half-op",
+			"+": "voice",
+			"": "normal",
+		};
+
 		return {
+			userModes,
 			mode,
 			nickColor,
 			hover,


### PR DESCRIPTION
This adds username modes on both the chat message and the user list for to allow css styling. Users can then style names based on the username modes which only worked on the user list prior to this commit.

Currently it only exist on the userlist, e.g:

```html
<div class="user-mode op">
  <span class="user" data-name="thelounge01" role="button">@thelounge01</span>
  <span class="user" data-name="thelounge02" role="button">@thelounge02</span>
</div>

<div class="user-mode half-op">
  <span class="user" data-name="halfop01" role="button">%halfop01</span>
  <span class="user" data-name="halfop02" role="button">%halfop02</span>
  <span class="user" data-name="halfop03" role="button">%halfop03</span>
</div>
```

But not the chat message, e.g.:

```html
<div id="msg-2015949" class="msg" data-type="message" data-from="randomuser">
  <span
    aria-hidden="true"
    aria-label="7 February 2024, 14:07:27"
    class="time tooltipped tooltipped-e"
    >14:07</span
  >
  <span class="from">
    <span class="only-copy" aria-hidden="true">&lt;</span>
    <span class="only-copy" aria-hidden="true">&gt;&nbsp;</span>
  </span>
  <span class="user" data-name="randomuser" role="button">randomuser</span>
  <span class="content" dir="auto">Not working</span>
</div>
```

This PR aims to add user mode status on the username element so it'll show something like this both on the user list and chat message list:

```html
<span class="user op" data-name="op01" role="button">@op01</span>
<span class="user half-op" data-name="halfop01" role="button">@halfop01</span>
<span class="user voice" data-name="voice01" role="button">@voice01</span>
```