### PR TITLE
client: use topic command in topic change

### DIFF
--- a/client/components/Chat.vue
+++ b/client/components/Chat.vue
@@ -211,7 +211,7 @@ export default defineComponent({
 
 			if (props.channel.topic !== newTopic) {
 				const target = props.channel.id;
-				const text = `/raw TOPIC ${props.channel.name} :${newTopic}`;
+				const text = `/topic ${newTopic}`;
 				socket.emit("input", {target, text});
 			}
 		};


### PR DESCRIPTION
A user on IRC reported a bug where the topic would change to ":hello" when the topic was modified to "hello" via the channel topic edit field.

The reason is that irc-framework also sanitizes /RAW commands and hence our manually escaped trailing param gets another ":" (which I'm not exactly sure it should be doing... /raw means raw in my world, but oh well).

We do have a proper /topic command a user could be using, so the fix is to just do that in the input box as well.