### PR TITLE
whois: support actual_username field

### DIFF
--- a/client/components/MessageTypes/whois.vue
+++ b/client/components/MessageTypes/whois.vue
@@ -34,6 +34,11 @@
 				</dd>
 			</template>
 
+			<template v-if="message.whois.actual_username">
+				<dt>Actual username:</dt>
+				<dd>{{ message.whois.actual_username }}</dd>
+			</template>
+
 			<template v-if="message.whois.real_name">
 				<dt>Real name:</dt>
 				<dd><ParsedMessage :network="network" :text="message.whois.real_name" /></dd>


### PR DESCRIPTION
Some servers (e.g. InspIRCd v4) support the concept of a real username, i.e. the username that was originally sent as distinct from their virtual username set by services.

Closes: https://github.com/thelounge/thelounge/issues/4900