### PR TITLE
Fix scoped package install & theme loading

### DIFF
--- a/server/command-line/install.ts
+++ b/server/command-line/install.ts
@@ -47,9 +47,15 @@ program
 				.readFile(path.join(packageName.substring("file:".length), "package.json"), "utf-8")
 				.then((data) => JSON.parse(data) as typeof packageJson);
 		} else {
-			const split = packageName.split("@");
-			packageName = split[0];
-			const packageVersion = split[1] || "latest";
+			// properly split scoped and non-scoped npm packages
+			// into their name and version
+			let packageVersion = "latest";
+			const atIndex = packageName.indexOf("@", 1);
+
+			if (atIndex !== -1) {
+				packageVersion = packageName.slice(atIndex + 1);
+				packageName = packageName.slice(0, atIndex);
+			}
 
 			readFile = packageJson.default(packageName, {
 				fullMetadata: true,

--- a/server/plugins/packages/themes.ts
+++ b/server/plugins/packages/themes.ts
@@ -85,7 +85,7 @@ function makePackageThemeObject(
 	return {
 		displayName: module.name || moduleName,
 		filename: path.join(modulePath, module.css),
-		name: moduleName,
+		name: encodeURIComponent(moduleName),
 		themeColor: themeColor,
 	};
 }

--- a/server/server.ts
+++ b/server/server.ts
@@ -107,7 +107,7 @@ export default async function (
 	// handler. Remember this if you make changes to this function, serving of
 	// local themes will not get those changes.
 	app.get("/themes/:theme.css", (req, res) => {
-		const themeName = req.params.theme;
+		const themeName = encodeURIComponent(req.params.theme);
 		const theme = themes.getByName(themeName);
 
 		if (theme === undefined || theme.filename === undefined) {


### PR DESCRIPTION
Hello, there has been this issue for quite some time now that breaks `thelounge install` for scoped npm packages: https://github.com/thelounge/thelounge/issues/4295

This pr fixes this by checking whether the package is scoped or not, and then performing the same split operations so now every one of these options can be installed through `thelounge install`:
```
thelounge install @scope/package (defaults to latest)
thelounge install @scope/package@2.0.0
thelounge install package (defaults to latest)
thelounge install package@2.0.0
```

The other problem in the linked issue is that themes from scoped packages don't get loaded when they are selected, because of the `/` in their name, I fixed this by encoding the URI at the two relevant sections. Now themes from scoped packages load when they are selected in the appearance menu, and also stay loaded when reloading the website.