### PR TITLE
client: suppress "***" in joins/parts/etc. for screen readers

### DIFF
--- a/client/components/Message.vue
+++ b/client/components/Message.vue
@@ -28,7 +28,7 @@
 			</span>
 		</template>
 		<template v-else-if="isAction()">
-			<span class="from"><span class="only-copy">***&nbsp;</span></span>
+			<span class="from"><span class="only-copy" aria-hidden="true">***&nbsp;</span></span>
 			<component :is="messageComponent" :network="network" :message="message" />
 		</template>
 		<template v-else-if="message.type === 'action'">


### PR DESCRIPTION
I noticed while testing with screen readers that events such as joins and parts have a non-printed `***` that is given the class `only-copy` but currently not `aria-hidden="true"`, resulting in screen readers announcing "star star star" before every one of these events. I suspect this was an oversight, as most `only-copy` elements do have `aria-hidden="true"`.