### PR TITLE
Fix showing multiple certificate fingerprints on InspIRCd v4.

### DIFF
--- a/client/components/MessageTypes/whois.vue
+++ b/client/components/MessageTypes/whois.vue
@@ -91,9 +91,11 @@
 				<dd>Yes</dd>
 			</template>
 
-			<template v-if="message.whois.certfp">
-				<dt>Certificate:</dt>
-				<dd>{{ message.whois.certfp }}</dd>
+			<template v-if="message.whois.certfps">
+				<template v-for="certfp in message.whois.certfps" :key="certfp">
+					<dt>Certificate:</dt>
+					<dd>{{ certfp }}</dd>
+				</template>
 			</template>
 
 			<template v-if="message.whois.server">


### PR DESCRIPTION
InspIRCd v4 will send multiple certificate fingerprints in WHOIS if a server is migrating from an old fingerprint (e.g. md5) to a new one (e.g. sha256). Currently The Lounge will only show the last (latest release) or first (latest git with the updated irc-fw) of these fingerprints.

Example of this from the InspIRCd testnet at testnet.inspircd.org with a sha3-256 and sha256 hash:

![Screenshot from 2024-10-14 18-07-59](https://github.com/user-attachments/assets/27b3f678-125c-4f32-8e11-c8ce0822d324)
