### PR TITLE
client: Indicate active context menu item for screen readers

### DIFF
--- a/client/components/ContextMenu.vue
+++ b/client/components/ContextMenu.vue
@@ -19,12 +19,14 @@
 				left: style.left + 'px',
 			}"
 			tabindex="-1"
+			:aria-activedescendant="activeItem > -1 ? `context-menu-item-${activeItem}` : undefined"
 			@mouseleave="activeItem = -1"
 			@keydown.enter.prevent="clickActiveItem"
 		>
 			<!-- TODO: type -->
 			<template v-for="(item, id) of (items as any)" :key="item.name">
 				<li
+					:id="`context-menu-item-${id}`"
 					:class="[
 						'context-menu-' + item.type,
 						item.class ? 'context-menu-' + item.class : null,


### PR DESCRIPTION
The app's context menus include keyboard navigation support via arrow keys, but currently the active item is only indicated via a CSS class, which means screen readers have nothing to announce when the active item changes.

This PR hooks up `aria-activedescendant` to child IDs, which screen readers can announce.