### PR TITLE
client: Add headings for easier navigation by AT

### DIFF
--- a/client/components/Chat.vue
+++ b/client/components/Chat.vue
@@ -18,9 +18,10 @@
 			>
 				<div class="header">
 					<SidebarToggle />
-					<span class="title" :aria-label="'Currently open ' + channel.type">{{
-						channel.name
-					}}</span>
+					<span class="title" role="heading" aria-level="2">
+						<span class="sr-only">Currently open {{ channel.type }}:&nbsp;</span>
+						{{ channel.name }}
+					</span>
 					<div v-if="channel.editTopic === true" class="topic-container">
 						<input
 							ref="topicInput"

--- a/client/components/ChatUserList.vue
+++ b/client/components/ChatUserList.vue
@@ -5,6 +5,7 @@
 		:aria-label="'User list for ' + channel.name"
 		@mouseleave="removeHoverUser"
 	>
+		<h3 class="sr-only">Userlist</h3>
 		<div class="count">
 			<input
 				ref="input"

--- a/client/components/DateMarker.vue
+++ b/client/components/DateMarker.vue
@@ -1,8 +1,8 @@
 <template>
 	<div :aria-label="localeDate" class="date-marker-container tooltipped tooltipped-s">
-		<div class="date-marker">
-			<span :aria-label="friendlyDate()" class="date-marker-text" />
-		</div>
+		<h4 class="date-marker">
+			<span class="date-marker-text">{{ friendlyDate() }}</span>
+		</h4>
 	</div>
 </template>
 

--- a/client/components/MessageList.vue
+++ b/client/components/MessageList.vue
@@ -1,5 +1,6 @@
 <template>
 	<div ref="chat" class="chat" tabindex="-1">
+		<h3 class="sr-only">Chat Messages</h3>
 		<div v-show="channel.moreHistoryAvailable" class="show-more">
 			<button
 				ref="loadMoreButton"
@@ -25,13 +26,13 @@
 					:message="message as any"
 					:focused="message.id === focused"
 				/>
-				<div
+				<h4
 					v-if="shouldDisplayUnreadMarker(Number(message.id))"
 					:key="message.id + '-unread'"
 					class="unread-marker"
 				>
-					<span class="unread-marker-text" />
-				</div>
+					<span class="unread-marker-text">New messages</span>
+				</h4>
 
 				<MessageCondensed
 					v-if="message.type === 'condensed'"

--- a/client/components/NetworkList.vue
+++ b/client/components/NetworkList.vue
@@ -1,13 +1,10 @@
 <template>
-	<div
-		v-if="store.state.networks.length === 0"
-		class="empty"
-		role="navigation"
-		aria-label="Network and Channel list"
-	>
+	<div v-if="store.state.networks.length === 0" class="empty" role="navigation">
+		<h2 class="sr-only">Network and Channel List</h2>
 		You are not connected to any networks yet.
 	</div>
-	<div v-else ref="networklist" role="navigation" aria-label="Network and Channel list">
+	<div v-else ref="networklist" role="navigation">
+		<h2 class="sr-only">Network and Channel List</h2>
 		<div class="jump-to-input">
 			<input
 				ref="searchInput"

--- a/client/components/Sidebar.vue
+++ b/client/components/Sidebar.vue
@@ -2,17 +2,16 @@
 	<aside id="sidebar" ref="sidebar">
 		<div class="scrollable-area">
 			<div class="logo-container">
+				<h1 class="sr-only">The Lounge</h1>
 				<img
 					:src="`img/logo-${isPublic() ? 'horizontal-' : ''}transparent-bg.svg`"
 					class="logo"
-					alt="The Lounge"
-					role="presentation"
+					alt=""
 				/>
 				<img
 					:src="`img/logo-${isPublic() ? 'horizontal-' : ''}transparent-bg-inverted.svg`"
 					class="logo-inverted"
-					alt="The Lounge"
-					role="presentation"
+					alt=""
 				/>
 				<span
 					v-if="isDevelopment"

--- a/client/css/style.css
+++ b/client/css/style.css
@@ -1083,7 +1083,8 @@ textarea.input {
 
 .header .title {
 	font-size: 15px;
-	padding-left: 6px;
+	margin: 0;
+	padding: 0 0 0 6px;
 	flex-shrink: 1;
 	white-space: nowrap;
 	overflow: hidden;
@@ -1340,8 +1341,7 @@ textarea.input {
 	border-top: 1px solid var(--unread-marker-color);
 }
 
-#chat .unread-marker-text::before {
-	content: "New messages";
+#chat .unread-marker-text {
 	background-color: var(--window-bg-color);
 	color: var(--unread-marker-color);
 	padding: 0 10px;
@@ -1366,8 +1366,7 @@ textarea.input {
 	border-top: 1px solid var(--date-marker-color);
 }
 
-#chat .date-marker-text::before {
-	content: attr(aria-label);
+#chat .date-marker-text {
 	background-color: var(--window-bg-color);
 	color: var(--date-marker-color);
 	padding: 0 10px;


### PR DESCRIPTION
Refs #4311 (this should be a step in the right direction, though it does not fully implement every idea presented in that thread; Daniel has tested my changes and noted they're an improvement)

This adds headings to the following:

- Channel name above main chat area (added aria roles to title span to set heading level 2)
- User list (added h3 with `sr-only` class)
- Date markers (converted to h4; simplified markup to move label into innerHTML, out of aria-label)
- Unread marker (converted to h4; simplified markup to move label into innerHTML, out of CSS)
- Network and channel list (added h2 with `sr-only` class; moved content from `aria-label` in parent element)
- The Lounge title (added h1 with `sr-only`; relocated content from logo image alt text)

Anywhere that I changed an existing element's tag, I tested and changed CSS accordingly to preserve styles. I resorted to ARIA attributes for the channel name because it seemed like preserving the styles would've been less straightforward there.

If any of these seem like they'd be problematic for theme compatibility, maybe I can come up with alternatives.