### PR TITLE
server: decode link-preview text using document/transport-specified encoding

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "ua-parser-js": "1.0.39",
     "uuid": "8.3.2",
     "web-push": "3.4.5",
+    "whatwg-mimetype": "4.0.0",
     "yarn": "1.22.22"
   },
   "optionalDependencies": {
@@ -96,7 +97,6 @@
     "@textcomplete/textarea": "0.1.13",
     "@types/bcryptjs": "2.4.6",
     "@types/chai": "4.3.5",
-    "@types/cheerio": "0.22.35",
     "@types/content-disposition": "0.5.8",
     "@types/express": "4.17.21",
     "@types/is-utf8": "0.2.3",
@@ -116,6 +116,7 @@
     "@types/web-push": "3.3.2",
     "@types/webpack-env": "1.16.4",
     "@types/webpack-hot-middleware": "2.25.6",
+    "@types/whatwg-mimetype": "3.0.2",
     "@types/ws": "8.5.12",
     "@typescript-eslint/eslint-plugin": "7.8.0",
     "@typescript-eslint/parser": "7.8.0",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "tlds": "1.228.0",
     "ua-parser-js": "1.0.39",
     "web-push-neo": "0.1.2",
+    "whatwg-mimetype": "4.0.0",
     "yarn": "1.22.22"
   },
   "devDependencies": {
@@ -84,7 +85,6 @@
     "@textcomplete/core": "0.1.10",
     "@textcomplete/textarea": "0.1.10",
     "@types/bcryptjs": "2.4.6",
-    "@types/cheerio": "0.22.35",
     "@types/content-disposition": "0.5.8",
     "@types/express": "4.17.21",
     "@types/ldapjs": "2.2.5",
@@ -97,6 +97,7 @@
     "@types/semver": "7.3.9",
     "@types/sortablejs": "1.15.8",
     "@types/ua-parser-js": "0.7.39",
+    "@types/whatwg-mimetype": "3.0.2",
     "@types/ws": "8.5.12",
     "@typescript-eslint/eslint-plugin": "7.8.0",
     "@typescript-eslint/parser": "7.8.0",

--- a/server/plugins/irc-events/link.ts
+++ b/server/plugins/irc-events/link.ts
@@ -3,6 +3,7 @@ import type {Element} from "domhandler";
 import got from "got";
 import {URL} from "url";
 import mime from "mime-types";
+import MIMEType from "whatwg-mimetype";
 
 import log from "../../log";
 import Config from "../../config";
@@ -16,6 +17,7 @@ import Msg from "../../models/msg";
 type FetchRequest = {
 	data: Buffer;
 	type: string;
+	charset: string | undefined;
 	size: number;
 };
 const currentFetchPromises = new Map<string, Promise<FetchRequest>>();
@@ -79,8 +81,9 @@ function parseHtml(preview, res, client: Client) {
 	// TODO:
 	// eslint-disable-next-line @typescript-eslint/no-misused-promises
 	return new Promise((resolve: (preview: FetchRequest | null) => void) => {
-		const $ = cheerio.load(res.data);
-
+		const $ = cheerio.loadBuffer(res.data, {
+			encoding: {transportLayerEncodingLabel: res.charset},
+		});
 		return parseHtmlMedia($, preview, client)
 			.then((newRes) => resolve(newRes))
 			.catch(() => {
@@ -140,8 +143,7 @@ function parseHtml(preview, res, client: Client) {
 	});
 }
 
-// TODO: type $
-function parseHtmlMedia($: any, preview, client: Client): Promise<FetchRequest> {
+function parseHtmlMedia($: cheerio.CheerioAPI, preview, client: Client): Promise<FetchRequest> {
 	return new Promise((resolve, reject) => {
 		if (Config.values.disableMediaPreview) {
 			reject();
@@ -467,15 +469,22 @@ function fetch(uri: string, headers: Record<string, string>) {
 				.on("end", () => gotStream.destroy())
 				.on("close", () => {
 					let type = "";
+					let charset;
 
 					// If we downloaded more data then specified in Content-Length, use real data size
 					const size = contentLength > buffer.length ? contentLength : buffer.length;
 
 					if (contentType) {
-						type = contentType.split(/ *; */).shift() || "";
+						try {
+							const mimeType = new MIMEType(contentType);
+							type = mimeType.essence;
+							charset = getTransportLayerEncodingLabel(mimeType);
+						} catch {
+							// the Content-Type value isn't valid; ignore it
+						}
 					}
 
-					resolve({data: buffer, type, size});
+					resolve({data: buffer, type, charset, size});
 				});
 		} catch (e: any) {
 			return reject(e);
@@ -489,6 +498,14 @@ function fetch(uri: string, headers: Record<string, string>) {
 	currentFetchPromises.set(cacheKey, promise);
 
 	return promise;
+}
+
+function getTransportLayerEncodingLabel(mimeType: MIMEType): string | undefined {
+	try {
+		return mimeType.parameters.get("charset");
+	} catch (error) {
+		return undefined;
+	}
 }
 
 function normalizeURL(link: string, baseLink?: string, disallowHttp = false) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1501,13 +1501,6 @@
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.3.5.tgz#ae69bcbb1bebb68c4ac0b11e9d8ed04526b3562b"
   integrity sha512-mEo1sAde+UCE6b2hxn332f1g1E8WfYRu6p5SvTKr2ZKC1f7gFJXk4h5PyGP9Dt6gCaG8y8XhwnXWC6Iy2cmBng==
 
-"@types/cheerio@0.22.35":
-  version "0.22.35"
-  resolved "https://registry.yarnpkg.com/@types/cheerio/-/cheerio-0.22.35.tgz#0d16dc1f24d426231c181b9c31847f673867595f"
-  integrity sha512-yD57BchKRvTV+JD53UZ6PD8KWY5g5rvvMLRnZR3EQBCZXiDT/HR+pKpMzFGlWNhFrXlo7VPZXtKvIEwZkAWOIA==
-  dependencies:
-    "@types/node" "*"
-
 "@types/connect@*":
   version "3.4.35"
   resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.35.tgz#5fcf6ae445e4021d1fc2219a4873cc73a3bb2ad1"
@@ -1804,6 +1797,11 @@
     "@types/connect" "*"
     tapable "^2.2.0"
     webpack "^5"
+
+"@types/whatwg-mimetype@3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz#e5e06dcd3e92d4e622ef0129637707d66c28d6a4"
+  integrity sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==
 
 "@types/ws@8.5.12":
   version "8.5.12"
@@ -9163,7 +9161,7 @@ whatwg-encoding@^3.1.1:
   dependencies:
     iconv-lite "0.6.3"
 
-whatwg-mimetype@^4.0.0:
+whatwg-mimetype@4.0.0, whatwg-mimetype@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz#bc1bf94a985dc50388d54a9258ac405c3ca2fc0a"
   integrity sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -981,13 +981,6 @@
     "@types/deep-eql" "*"
     assertion-error "^2.0.1"
 
-"@types/cheerio@0.22.35":
-  version "0.22.35"
-  resolved "https://registry.yarnpkg.com/@types/cheerio/-/cheerio-0.22.35.tgz#0d16dc1f24d426231c181b9c31847f673867595f"
-  integrity sha512-yD57BchKRvTV+JD53UZ6PD8KWY5g5rvvMLRnZR3EQBCZXiDT/HR+pKpMzFGlWNhFrXlo7VPZXtKvIEwZkAWOIA==
-  dependencies:
-    "@types/node" "*"
-
 "@types/connect@*":
   version "3.4.38"
   resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.38.tgz#5ba7f3bc4fbbdeaff8dded952e5ff2cc53f8d858"
@@ -1213,6 +1206,11 @@
   version "0.7.39"
   resolved "https://registry.yarnpkg.com/@types/ua-parser-js/-/ua-parser-js-0.7.39.tgz#832c58e460c9435e4e34bb866e85e9146e12cdbb"
   integrity sha512-P/oDfpofrdtF5xw433SPALpdSchtJmY7nsJItf8h3KXqOslkbySh8zq4dSWXH2oTjRvJ5PczVEoCZPow6GicLg==
+
+"@types/whatwg-mimetype@3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz#e5e06dcd3e92d4e622ef0129637707d66c28d6a4"
+  integrity sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==
 
 "@types/ws@8.5.12":
   version "8.5.12"
@@ -6251,7 +6249,7 @@ whatwg-encoding@^3.1.1:
   dependencies:
     iconv-lite "0.6.3"
 
-whatwg-mimetype@^4.0.0:
+whatwg-mimetype@4.0.0, whatwg-mimetype@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz#bc1bf94a985dc50388d54a9258ac405c3ca2fc0a"
   integrity sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==


### PR DESCRIPTION
This change detects the specified encoding of any document posted as a link, and uses that encoding to display the preview text for the link.

Otherwise, without this change, the link-preview text for documents with legacy encodings (such as Shift_JIS) doesn’t get displayed as expected, but instead gets garbled.