### PR TITLE
server: disconnect the socket when authentication fails

### DIFF
--- a/client/js/socket-events/auth.ts
+++ b/client/js/socket-events/auth.ts
@@ -12,12 +12,14 @@ declare global {
 }
 
 socket.on("auth:success", function () {
+	store.commit("isAuthFailure", false);
 	store.commit("currentUserVisibleError", "Loading messages…");
 	updateLoadingMessage();
 });
 
 socket.on("auth:failed", async function () {
 	storage.remove("token");
+	store.commit("isAuthFailure", true);
 
 	if (store.state.appLoaded) {
 		return reloadPage("Authentication failed, reloading…");
@@ -27,6 +29,8 @@ socket.on("auth:failed", async function () {
 });
 
 socket.on("auth:start", async function (serverHash) {
+	store.commit("isAuthFailure", false);
+
 	// If we reconnected and serverHash differs, that means the server restarted
 	// And we will reload the page to grab the latest version
 	if (lastServerHash && serverHash !== lastServerHash) {

--- a/client/js/store.ts
+++ b/client/js/store.ts
@@ -45,6 +45,8 @@ export type State = {
 	activeChannel?: NetChan;
 	currentUserVisibleError: string | null;
 	desktopNotificationState: DesktopNotificationState;
+	disableReconnection: boolean;
+	isAuthFailure: boolean;
 	isAutoCompleting: boolean;
 	isConnected: boolean;
 	networks: ClientNetwork[];
@@ -88,6 +90,8 @@ const state = (): State => ({
 	activeChannel: undefined,
 	currentUserVisibleError: null,
 	desktopNotificationState: detectDesktopNotificationState(),
+	disableReconnection: false,
+	isAuthFailure: false,
 	isAutoCompleting: false,
 	isConnected: false,
 	networks: [],
@@ -201,6 +205,8 @@ type Mutations = {
 	activeChannel(state: State, netChan: State["activeChannel"]): void;
 	currentUserVisibleError(state: State, error: State["currentUserVisibleError"]): void;
 	refreshDesktopNotificationState(state: State): void;
+	disableReconnection(state: State, payload: State["disableReconnection"]): void;
+	isAuthFailure(state: State, payload: State["isAuthFailure"]): void;
 	isAutoCompleting(state: State, isAutoCompleting: State["isAutoCompleting"]): void;
 	isConnected(state: State, payload: State["isConnected"]): void;
 	networks(state: State, networks: State["networks"]): void;
@@ -244,6 +250,12 @@ const mutations: Mutations = {
 	},
 	refreshDesktopNotificationState(state) {
 		state.desktopNotificationState = detectDesktopNotificationState();
+	},
+	disableReconnection(state, payload) {
+		state.disableReconnection = payload;
+	},
+	isAuthFailure(state, payload) {
+		state.isAuthFailure = payload;
 	},
 	isAutoCompleting(state, isAutoCompleting) {
 		state.isAutoCompleting = isAutoCompleting;

--- a/client/service-worker.js
+++ b/client/service-worker.js
@@ -7,6 +7,7 @@ const cacheName = "__HASH__";
 const excludedPathsFromCache = /^(?:socket\.io|storage|uploads|cdn-cgi)\//;
 
 self.addEventListener("install", function () {
+	self.shutdown = false;
 	self.skipWaiting();
 });
 
@@ -25,6 +26,10 @@ self.addEventListener("activate", function (event) {
 });
 
 self.addEventListener("fetch", function (event) {
+	if (self.shutdown) {
+		return;
+	}
+
 	if (event.request.method !== "GET") {
 		return;
 	}
@@ -110,6 +115,10 @@ async function networkOrCache(event) {
 }
 
 self.addEventListener("message", function (event) {
+	if (event.data.type === "shutdown") {
+		self.shutdown = true;
+	}
+
 	showNotification(event, event.data);
 });
 

--- a/server/server.ts
+++ b/server/server.ts
@@ -1024,6 +1024,9 @@ function performAuthentication(this: Socket, data: AuthPerformData) {
 			}
 
 			socket.emit("auth:failed");
+			// disconnect the socket to avoid bypassing firewall
+			// protections against bulk password guessing attacks
+			socket.disconnect();
 			return;
 		}
 


### PR DESCRIPTION
Fixes a security issue where thelounge is open to bulk password guessing attacks: 

Without the patch, thelounge client opens a websocket connection to the server using HTTP GET Connection: Upgrade and then submits the authentication form using that websocket. If authentication fails, the next submission happens on the same open websocket. Although the authentication failure is logged, thelounge server doesn't take any other action. As common firewalls, such as cloudflare's IP Lists and fail2ban/iptables, apply to the opening of a connection, this behavior allows to bypass them and do bulk password guessing attacks.

With the patch, thelounge server will close the websocket when authentication fails, thus forcing the client to open a new websocket connection using HTTP GET Connection: Upgrade, allowing firewalls to block that request if given conditions are triggered.