### PR TITLE
reverse locknetwork config selection

### DIFF
--- a/server/server.ts
+++ b/server/server.ts
@@ -900,7 +900,7 @@ function getClientConfiguration(): SharedConfiguration | LockedSharedConfigurati
 
 	// Only send defaults that are visible on the client
 	const defaults: LockedConfigNetDefaults = {
-		..._.pick(Config.values.defaults, ["name", "username", "password", "realname", "join"]),
+		..._.omit(Config.values.defaults, ["host", "name", "port", "tls", "rejectUnauthorized"]),
 		...defaultsOverride,
 	};
 

--- a/shared/types/config.ts
+++ b/shared/types/config.ts
@@ -34,9 +34,9 @@ export type ConfigNetDefaults = {
 	saslAccount: string;
 	saslPassword: string;
 };
-export type LockedConfigNetDefaults = Pick<
+export type LockedConfigNetDefaults = Omit<
 	ConfigNetDefaults,
-	"name" | "nick" | "username" | "password" | "realname" | "join"
+	"host" | "name" | "port" | "tls" | "rejectUnauthorized"
 >;
 
 export type LockedSharedConfiguration = SharedConfigurationBase & {


### PR DESCRIPTION
LockNetwork is documented as:
> When set to `true`, users will not be able to modify host, port and TLS
> settings and will be limited to the configured network.

Looking at the view, that also includes the name field (for some reason).

When leaveMessage was added to the defaults, the white list for the LockedConfigNetDefaults wasn't adjusted.

Rather than playing whack a mole, disallow the documented fields + name and export the rest.

Fixes: https://github.com/thelounge/thelounge/issues/4956