### PR TITLE
Trim username in sign-in form

### DIFF
--- a/client/components/Windows/SignIn.vue
+++ b/client/components/Windows/SignIn.vue
@@ -19,7 +19,7 @@
 			<label for="signin-username">Username</label>
 			<input
 				id="signin-username"
-				v-model="username"
+				v-model.trim="username"
 				class="input"
 				type="text"
 				name="username"


### PR DESCRIPTION
with e.g. autocompletion it's easy to get spaces in there which results in bad UX