### PR TITLE
Ability to ignore provided user messages using regex

### DIFF
--- a/client/components/Special/ListIgnored.vue
+++ b/client/components/Special/ListIgnored.vue
@@ -3,12 +3,18 @@
 		<thead>
 			<tr>
 				<th class="hostmask">Hostmask</th>
+				<th class="message-regex">Message Regex</th>
 				<th class="when">Ignored At</th>
 			</tr>
 		</thead>
 		<tbody>
 			<tr v-for="user in channel.data" :key="user.hostmask">
-				<td class="hostmask"><ParsedMessage :network="network" :text="user.hostmask" /></td>
+				<td class="hostmask">
+					<ParsedMessage :network="network" :text="user.hostmask" />
+				</td>
+				<td class="message-regex">
+					{{ user.messageRegex?.trim() }}
+				</td>
 				<td class="when">{{ localetime(user.when) }}</td>
 			</tr>
 		</tbody>

--- a/client/css/style.css
+++ b/client/css/style.css
@@ -1520,6 +1520,7 @@ textarea.input {
 #chat table.ban-list .banned_by,
 #chat table.ban-list .banned_at,
 #chat table.ignore-list .hostmask,
+#chat table.ignore-list .message-regex,
 #chat table.ignore-list .when {
 	text-align: left;
 }

--- a/server/models/network.ts
+++ b/server/models/network.ts
@@ -4,7 +4,7 @@ import IrcFramework, {Client as IRCClient} from "irc-framework";
 import Chan, {ChanConfig, Channel} from "./chan";
 import Msg from "./msg";
 import Prefix from "./prefix";
-import Helper, {Hostmask} from "../helper";
+import Helper, {IgnoreEntry} from "../helper";
 import Config, {WebIRC} from "../config";
 import STSPolicies from "../plugins/sts";
 import ClientCertificate, {ClientCertificateType} from "../plugins/clientCertificate";
@@ -44,7 +44,7 @@ type NetworkStatus = {
 	secure: boolean;
 };
 
-export type IgnoreListItem = Hostmask & {
+export type IgnoreListItem = IgnoreEntry & {
 	when: number;
 };
 

--- a/server/plugins/inputs/ignore.ts
+++ b/server/plugins/inputs/ignore.ts
@@ -13,14 +13,15 @@ const input: PluginInputHandler = function (network, chan, cmd, args) {
 			client,
 			new Msg({
 				type: MessageType.ERROR,
-				text: `Usage: /${cmd} <nick>[!ident][@host]`,
+				text: `Usage: /${cmd} <nick>[!ident][@host] [messageRegex]`,
 			})
 		);
-
 		return;
 	}
 
 	const target = args[0].trim();
+	const targetRegex = args.slice(1).join(" ").trim(); // everything after hostmask is message regex (opt)
+
 	const hostmask = Helper.parseHostmask(target);
 
 	switch (cmd) {
@@ -38,40 +39,66 @@ const input: PluginInputHandler = function (network, chan, cmd, args) {
 			}
 
 			if (
-				network.ignoreList.some(function (entry) {
-					return Helper.compareHostmask(entry, hostmask);
-				})
+				network.ignoreList.some(
+					(entry) =>
+						Helper.compareHostmask(entry, hostmask) &&
+						(entry.messageRegex || "") === targetRegex
+				)
 			) {
 				chan.pushMessage(
 					client,
 					new Msg({
 						type: MessageType.ERROR,
-						text: "The specified user/hostmask is already ignored",
+						text: "The specified user/hostmask/regex is already ignored",
 					})
 				);
 				return;
 			}
 
+			let validRegex = "";
+
+			if (targetRegex !== "") {
+				try {
+					new RegExp(targetRegex);
+					validRegex = targetRegex;
+				} catch (e) {
+					chan.pushMessage(
+						client,
+						new Msg({
+							type: MessageType.ERROR,
+							text: `Invalid message regex: ${targetRegex}`,
+						})
+					);
+					return;
+				}
+			}
+
 			network.ignoreList.push({
 				...hostmask,
 				when: Date.now(),
+				messageRegex: validRegex,
 			});
 
 			client.save();
+
 			chan.pushMessage(
 				client,
 				new Msg({
-					type: MessageType.ERROR, // TODO: Successfully added via type.Error 🤔 ?
-					text: `\u0002${hostmask.nick}!${hostmask.ident}@${hostmask.hostname}\u000f added to ignorelist`,
+					type: MessageType.ERROR,
+					text:
+						`\u0002${hostmask.nick}!${hostmask.ident}@${hostmask.hostname}\u000f added to ignorelist` +
+						(validRegex ? ` with regex: /${validRegex}/` : ""),
 				})
 			);
 			return;
 		}
 
 		case "unignore": {
-			const idx = network.ignoreList.findIndex(function (entry) {
-				return Helper.compareHostmask(entry, hostmask);
-			});
+			const idx = network.ignoreList.findIndex(
+				(entry) =>
+					Helper.compareHostmask(entry, hostmask) &&
+					(entry.messageRegex || "") === targetRegex
+			);
 
 			if (idx === -1) {
 				chan.pushMessage(
@@ -87,11 +114,17 @@ const input: PluginInputHandler = function (network, chan, cmd, args) {
 			network.ignoreList.splice(idx, 1);
 			client.save();
 
+			let messageSuffix: string = "from ignorelist";
+
+			if (targetRegex !== "") {
+				messageSuffix = `with message regex \u0002${targetRegex}\u000f from ignorelist`;
+			}
+
 			chan.pushMessage(
 				client,
 				new Msg({
 					type: MessageType.ERROR, // TODO: Successfully removed via type.Error 🤔 ?
-					text: `Successfully removed \u0002${hostmask.nick}!${hostmask.ident}@${hostmask.hostname}\u000f from ignorelist`,
+					text: `Successfully removed \u0002${hostmask.nick}!${hostmask.ident}@${hostmask.hostname}\u000f ${messageSuffix}`,
 				})
 			);
 		}

--- a/server/plugins/inputs/ignorelist.ts
+++ b/server/plugins/inputs/ignorelist.ts
@@ -22,6 +22,7 @@ const input: PluginInputHandler = function (network, chan, _cmd, _args) {
 	const chanName = "Ignored users";
 	const ignored = network.ignoreList.map((data) => ({
 		hostmask: `${data.nick}!${data.ident}@${data.hostname}`,
+		messageRegex: data.messageRegex || null,
 		when: data.when,
 	}));
 	let newChan = network.getChannel(chanName);

--- a/server/plugins/irc-events/message.ts
+++ b/server/plugins/irc-events/message.ts
@@ -65,7 +65,7 @@ export default <IrcEventHandler>function (irc, network) {
 		const shouldIgnore =
 			!self &&
 			network.ignoreList.some(function (entry) {
-				return Helper.compareHostmask(entry, data);
+				return Helper.isIgnored(entry, data, data.message);
 			});
 
 		// Server messages that aren't targeted at a channel go to the server window


### PR DESCRIPTION
Add ability to filter out specific messages using regex using `ignore` command.

Check is run only when user is matched, as in we can't create global message regex but only limited to users.

- [x] backward compatible
- [x] optional regex can be set after hostmask under `ignore` command, normal ignore is working like it used to
- [x] removal using `unignore` is working for both cases
- [x] `ignorelist` extended by `Message Regex` column