### PR TITLE
Disable sasl if sasl isn't configured

### DIFF
--- a/server/models/network.ts
+++ b/server/models/network.ts
@@ -340,7 +340,10 @@ class Network {
 
 		if (!this.sasl) {
 			delete this.irc.options.sasl_mechanism;
-			delete this.irc.options.account;
+			// irc-framework has a funny fallback where it uses nick + server pw
+			// in the sasl handshake, if account is undefined, so we need an empty
+			// object here to really turn it off
+			this.irc.options.account = {};
 		} else if (this.sasl === "external") {
 			this.irc.options.sasl_mechanism = "EXTERNAL";
 			this.irc.options.account = {};


### PR DESCRIPTION
irc-framework has a funny fallback where it uses nick + server pw in the sasl handshake, if account is undefined in the options. This becomes a problem, as the nick might not actually be the account (happened for znc users), so we need to set it to an empty object to really turn it off.