### PR TITLE
feat: Add option to not send mobile push notifications if there is any active session

### DIFF
--- a/client/components/Settings/Notifications.vue
+++ b/client/components/Settings/Notifications.vue
@@ -30,6 +30,16 @@
 					<span>Push notifications are not supported by your browser.</span>
 				</div>
 			</div>
+			<div>
+				<label class="opt">
+					<input
+						:checked="store.state.settings.onlyPushWhenInactive"
+						type="checkbox"
+						name="onlyPushWhenInactive"
+					/>
+					Only send push notifications when all sessions are inactive
+				</label>
+			</div>
 		</template>
 
 		<h2>Browser Notifications</h2>
@@ -87,17 +97,6 @@
 					name="notifyAllMessages"
 				/>
 				Enable notification for all messages
-			</label>
-		</div>
-
-		<div v-if="!store.state.serverConfiguration?.public">
-			<label class="opt">
-				<input
-					:checked="store.state.settings.onlyPushWhenInactive"
-					type="checkbox"
-					name="onlyPushWhenInactive"
-				/>
-				Only send push notifications when all sessions are inactive
 			</label>
 		</div>
 

--- a/client/components/Settings/Notifications.vue
+++ b/client/components/Settings/Notifications.vue
@@ -33,9 +33,9 @@
 			<div>
 				<label class="opt">
 					<input
-						:checked="store.state.settings.onlyPushWhenInactive"
+						:checked="store.state.settings.notifications.onlyPushWhenAllSocketsClosed"
 						type="checkbox"
-						name="onlyPushWhenInactive"
+						name="notifications.onlyPushWhenAllSocketsClosed"
 					/>
 					Only send push notifications when all sessions are inactive
 				</label>

--- a/client/components/Settings/Notifications.vue
+++ b/client/components/Settings/Notifications.vue
@@ -92,6 +92,24 @@
 
 		<div v-if="!store.state.serverConfiguration?.public">
 			<label class="opt">
+				<input
+					:checked="store.state.settings.skipMobilePushWhenDesktopActive"
+					type="checkbox"
+					name="skipMobilePushWhenDesktopActive"
+				/>
+				Only send mobile notifications if desktop session is inactive
+				<span
+					class="tooltipped tooltipped-n tooltipped-no-delay"
+					aria-label="When enabled, mobile push notifications will be skipped
+if you have an active desktop session."
+				>
+					<button class="extra-help" />
+				</span>
+			</label>
+		</div>
+
+		<div v-if="!store.state.serverConfiguration?.public">
+			<label class="opt">
 				<label for="highlights" class="opt">
 					Custom highlights
 					<span

--- a/client/components/Settings/Notifications.vue
+++ b/client/components/Settings/Notifications.vue
@@ -93,18 +93,11 @@
 		<div v-if="!store.state.serverConfiguration?.public">
 			<label class="opt">
 				<input
-					:checked="store.state.settings.skipMobilePushWhenDesktopActive"
+					:checked="store.state.settings.onlyPushWhenInactive"
 					type="checkbox"
-					name="skipMobilePushWhenDesktopActive"
+					name="onlyPushWhenInactive"
 				/>
-				Only send mobile notifications if desktop session is inactive
-				<span
-					class="tooltipped tooltipped-n tooltipped-no-delay"
-					aria-label="When enabled, mobile push notifications will be skipped
-if you have an active desktop session."
-				>
-					<button class="extra-help" />
-				</span>
+				Only send push notifications when all sessions are inactive
 			</label>
 		</div>
 

--- a/client/components/Windows/Settings.vue
+++ b/client/components/Windows/Settings.vue
@@ -45,6 +45,25 @@ export default defineComponent({
 				value = (event.target as HTMLInputElement).value;
 			}
 
+			// Handle nested settings
+			if (name.includes(".")) {
+				const [parentKey, childKey] = name.split(".");
+				const currentParentValue = store.state.settings[parentKey];
+
+				if (typeof currentParentValue === "object" && currentParentValue !== null) {
+					const newParentValue = {
+						...currentParentValue,
+						[childKey]: value,
+					};
+					void store.dispatch("settings/update", {
+						name: parentKey,
+						value: newParentValue,
+						sync: true,
+					});
+					return;
+				}
+			}
+
 			void store.dispatch("settings/update", {name, value, sync: true});
 		};
 

--- a/client/js/settings.ts
+++ b/client/js/settings.ts
@@ -145,8 +145,10 @@ const defaultConfig = {
 	searchEnabled: {
 		default: false,
 	},
-	onlyPushWhenInactive: {
-		default: false,
+	notifications: {
+		default: {
+			onlyPushWhenAllSocketsClosed: false,
+		},
 		sync: "always",
 	},
 };

--- a/client/js/settings.ts
+++ b/client/js/settings.ts
@@ -145,6 +145,10 @@ const defaultConfig = {
 	searchEnabled: {
 		default: false,
 	},
+	skipMobilePushWhenDesktopActive: {
+		default: false,
+		sync: "always",
+	},
 };
 
 export const config = normalizeConfig(defaultConfig);

--- a/client/js/settings.ts
+++ b/client/js/settings.ts
@@ -145,7 +145,7 @@ const defaultConfig = {
 	searchEnabled: {
 		default: false,
 	},
-	skipMobilePushWhenDesktopActive: {
+	onlyPushWhenInactive: {
 		default: false,
 		sync: "always",
 	},

--- a/client/js/store-settings.ts
+++ b/client/js/store-settings.ts
@@ -110,7 +110,19 @@ function assignStoredSettings(
 			typeof storedSettings[key] !== "undefined" &&
 			typeof defaultSettings[key] === typeof storedSettings[key]
 		) {
-			newSettings[key] = storedSettings[key];
+			// Handle nested objects by merging them
+			if (
+				typeof defaultSettings[key] === "object" &&
+				defaultSettings[key] !== null &&
+				!Array.isArray(defaultSettings[key])
+			) {
+				newSettings[key] = {
+					...defaultSettings[key],
+					...storedSettings[key],
+				};
+			} else {
+				newSettings[key] = storedSettings[key];
+			}
 		}
 	}
 

--- a/server/plugins/webpush.ts
+++ b/server/plugins/webpush.ts
@@ -64,17 +64,13 @@ class WebPush {
 
 		WebPushAPI.setVapidDetails(
 			"https://github.com/thelounge/thelounge",
-			this.vapidKeys!.publicKey,
-			this.vapidKeys!.privateKey
+			this.vapidKeys.publicKey,
+			this.vapidKeys.privateKey
 		);
 	}
 
 	push(client: Client, payload: any, onlyToOffline: boolean) {
-		// Check if the user has enabled the setting to only send push when all sessions are inactive
-		const onlyPushWhenInactive = client.config.clientSettings?.onlyPushWhenInactive === true;
-		
-		// If the setting is enabled and there are active sessions, don't send any push notifications
-		if (onlyPushWhenInactive && _.size(client.attachedClients) > 0) {
+		if (client.config.clientSettings?.onlyPushWhenInactive === true && _.size(client.attachedClients) > 0) {
 			return;
 		}
 		
@@ -110,7 +106,6 @@ class WebPush {
 			log.error(`WebPush Error (${String(error)})`);
 		});
 	}
-
 }
 
 export default WebPush;

--- a/server/plugins/webpush.ts
+++ b/server/plugins/webpush.ts
@@ -70,7 +70,7 @@ class WebPush {
 	}
 
 	push(client: Client, payload: any, onlyToOffline: boolean) {
-		if (client.config.clientSettings?.onlyPushWhenInactive === true && _.size(client.attachedClients) > 0) {
+		if (client.config.clientSettings?.notifications?.onlyPushWhenAllSocketsClosed === true && _.size(client.attachedClients) > 0) {
 			return;
 		}
 		

--- a/server/plugins/webpush.ts
+++ b/server/plugins/webpush.ts
@@ -64,8 +64,8 @@ class WebPush {
 
 		WebPushAPI.setVapidDetails(
 			"https://github.com/thelounge/thelounge",
-			this.vapidKeys.publicKey,
-			this.vapidKeys.privateKey
+			this.vapidKeys!.publicKey,
+			this.vapidKeys!.privateKey
 		);
 	}
 

--- a/server/plugins/webpush.ts
+++ b/server/plugins/webpush.ts
@@ -70,6 +70,9 @@ class WebPush {
 	}
 
 	push(client: Client, payload: any, onlyToOffline: boolean) {
+		// Check if the user has enabled the setting to skip mobile push when desktop is active
+		const skipMobilePushWhenDesktopActive = client.config.clientSettings?.skipMobilePushWhenDesktopActive !== false;
+		
 		// Check if there are any active desktop sessions
 		const hasActiveDesktopSession = this.hasActiveDesktopSession(client);
 		
@@ -79,9 +82,11 @@ class WebPush {
 					return;
 				}
 
-				// Skip mobile push notifications only if there's an active desktop session 
-				// AND this mobile session is not currently active (closed)
-				if (hasActiveDesktopSession && this.isMobileDevice(agent)) {
+				// Skip mobile push notifications only if:
+				// 1. The setting is enabled (default: false) AND
+				// 2. There's an active desktop session  AND
+				// 3. This mobile session is not currently active (closed)
+				if (skipMobilePushWhenDesktopActive && hasActiveDesktopSession && this.isMobileDevice(agent)) {
 					const isThisMobileSessionActive = _.find(client.attachedClients, {token}) !== undefined;
 					if (!isThisMobileSessionActive) {
 						return;

--- a/server/plugins/webpush.ts
+++ b/server/plugins/webpush.ts
@@ -70,27 +70,18 @@ class WebPush {
 	}
 
 	push(client: Client, payload: any, onlyToOffline: boolean) {
-		// Check if the user has enabled the setting to skip mobile push when desktop is active
-		const skipMobilePushWhenDesktopActive = client.config.clientSettings?.skipMobilePushWhenDesktopActive !== false;
+		// Check if the user has enabled the setting to only send push when all sessions are inactive
+		const onlyPushWhenInactive = client.config.clientSettings?.onlyPushWhenInactive === true;
 		
-		// Check if there are any active desktop sessions
-		const hasActiveDesktopSession = this.hasActiveDesktopSession(client);
+		// If the setting is enabled and there are active sessions, don't send any push notifications
+		if (onlyPushWhenInactive && _.size(client.attachedClients) > 0) {
+			return;
+		}
 		
-		_.forOwn(client.config.sessions, ({pushSubscription, agent}, token) => {
+		_.forOwn(client.config.sessions, ({pushSubscription}, token) => {
 			if (pushSubscription) {
 				if (onlyToOffline && _.find(client.attachedClients, {token}) !== undefined) {
 					return;
-				}
-
-				// Skip mobile push notifications only if:
-				// 1. The setting is enabled (default: false) AND
-				// 2. There's an active desktop session  AND
-				// 3. This mobile session is not currently active (closed)
-				if (skipMobilePushWhenDesktopActive && hasActiveDesktopSession && this.isMobileDevice(agent)) {
-					const isThisMobileSessionActive = _.find(client.attachedClients, {token}) !== undefined;
-					if (!isThisMobileSessionActive) {
-						return;
-					}
 				}
 
 				this.pushSingle(client, pushSubscription, payload);
@@ -120,50 +111,6 @@ class WebPush {
 		});
 	}
 
-	/**
-	 * Check if a user agent string represents a mobile device
-	 */
-	private isMobileDevice(agent: string): boolean {
-		if (!agent) {
-			return false;
-		}
-
-		const mobileKeywords = [
-			'Android',
-			'iPhone',
-			'iPad',
-			'iPod',
-			'iOS',
-			'iPadOS',
-			'Mobile',
-			'BlackBerry',
-			'Windows Phone',
-			'webOS',
-			'Palm',
-			'Symbian'
-		];
-
-		return mobileKeywords.some(keyword => 
-			agent.toLowerCase().includes(keyword.toLowerCase())
-		);
-	}
-
-	/**
-	 * Check if there are any active desktop sessions for this client
-	 */
-	private hasActiveDesktopSession(client: Client): boolean {
-		return _.some(client.attachedClients, (attachedClient, socketId) => {
-			const sessionToken = attachedClient.token;
-			const session = client.config.sessions[sessionToken];
-			
-			if (!session || !session.agent) {
-				return false;
-			}
-
-			// If the session is active (attached) and not mobile, it's a desktop session
-			return !this.isMobileDevice(session.agent);
-		});
-	}
 }
 
 export default WebPush;

--- a/server/server.ts
+++ b/server/server.ts
@@ -718,16 +718,17 @@ function initializeClient(
 				return;
 			}
 
-			if (
-				typeof newSetting.value === "object" ||
-				typeof newSetting.name !== "string" ||
-				newSetting.name[0] === "_"
-			) {
+			if (typeof newSetting.name !== "string" || newSetting.name[0] === "_") {
+				return;
+			}
+
+			// Allow plain objects for nested settings, but reject arrays and null
+			if (typeof newSetting.value === "object" && !_.isPlainObject(newSetting.value)) {
 				return;
 			}
 
 			// We do not need to do write operations and emit events if nothing changed.
-			if (client.config.clientSettings[newSetting.name] !== newSetting.value) {
+			if (!_.isEqual(client.config.clientSettings[newSetting.name], newSetting.value)) {
 				client.config.clientSettings[newSetting.name] = newSetting.value;
 
 				// Pass the setting to all clients.


### PR DESCRIPTION
# Summary

This PR introduces a new option to not send mobile push notifications if there is already an active session in any other device. When enabled, push notifications will only be sent to mobile devices if there is no active session (socket connection) in any other device.

Example:

1. Lounge is closed on phone AND desktop
Result: I get a **push** notification on phone

You will not get a mobile push notification in any other case.

I believe this contributes to https://github.com/thelounge/thelounge/issues/1441

<img width="909" height="601" alt="image" src="https://github.com/user-attachments/assets/2b6f8df9-f824-4c1f-ad15-e5046a4e5dfc" />

### Notes:

This setting is disabled by default, so users will need to manually enable this setting to notice any changes.