### PR TITLE
Show STATUSMSG indication for actions as well

### DIFF
--- a/client/components/Message.vue
+++ b/client/components/Message.vue
@@ -34,6 +34,7 @@
 		<template v-else-if="message.type === 'action'">
 			<span class="from"><span class="only-copy">*&nbsp;</span></span>
 			<span class="content" dir="auto">
+				<StatusmsgMarker :group="message.statusmsgGroup" />
 				<Username
 					:user="message.from"
 					:network="network"
@@ -78,12 +79,7 @@
 					class="msg-shown-in-active tooltipped tooltipped-e"
 					><span></span
 				></span>
-				<span
-					v-if="message.statusmsgGroup"
-					:aria-label="`This message was only shown to users with ${message.statusmsgGroup} mode`"
-					class="msg-statusmsg tooltipped tooltipped-e"
-					><span>{{ message.statusmsgGroup }}</span></span
-				>
+				<StatusmsgMarker :group="message.statusmsgGroup" />
 				<ParsedMessage :network="network" :message="message" />
 				<LinkPreview
 					v-for="preview in message.previews"
@@ -107,6 +103,7 @@ import Username from "./Username.vue";
 import LinkPreview from "./LinkPreview.vue";
 import ParsedMessage from "./ParsedMessage.vue";
 import MessageTypes from "./MessageTypes";
+import StatusmsgMarker from "./StatusmsgMarker.vue";
 
 import type {ClientChan, ClientMessage, ClientNetwork} from "../js/types";
 import {useStore} from "../js/store";
@@ -117,7 +114,10 @@ MessageTypes.Username = Username;
 
 export default defineComponent({
 	name: "Message",
-	components: MessageTypes,
+	components: {
+		...MessageTypes,
+		StatusmsgMarker,
+	},
 	props: {
 		message: {type: Object as PropType<ClientMessage>, required: true},
 		channel: {type: Object as PropType<ClientChan>, required: false},

--- a/client/components/StatusmsgMarker.vue
+++ b/client/components/StatusmsgMarker.vue
@@ -1,0 +1,19 @@
+<template>
+	<span
+		v-if="group"
+		:aria-label="`This message was only shown to users with ${group} mode`"
+		class="msg-statusmsg tooltipped tooltipped-e"
+		><span>{{ group }}</span></span
+	>
+</template>
+
+<script lang="ts">
+import {defineComponent} from "vue";
+
+export default defineComponent({
+	name: "StatusmsgMarker",
+	props: {
+		group: {type: String, required: false, default: undefined},
+	},
+});
+</script>

--- a/server/models/msg.ts
+++ b/server/models/msg.ts
@@ -36,7 +36,7 @@ class Msg {
 	when!: Date;
 	whois!: any;
 	users!: string[];
-	statusmsgGroup!: string;
+	statusmsgGroup?: string;
 	params!: string[];
 
 	constructor(attr?: Partial<Msg>) {


### PR DESCRIPTION
It is possible to send actions (/me et al.) to a STATUSMSG target (+#channel etc), even though thelounge does not currently support sending that. Show the statusmsg indicator on such messages.
