### PR TITLE
server: Fix quoting in error message

### DIFF
--- a/server/plugins/inputs/index.ts
+++ b/server/plugins/inputs/index.ts
@@ -108,7 +108,7 @@ const addPluginCommand = (packageInfo: PackageInfo, command: any, obj: any) => {
 		return;
 	} else if (!obj || typeof obj.input !== "function") {
 		log.error(
-			`plugin ${packageInfo.packageName} tried to register command "${command} without a callback"`
+			`plugin ${packageInfo.packageName} tried to register command "${command}" without a callback`
 		);
 		return;
 	}


### PR DESCRIPTION
In the error message about an invalid plugin command, only quote the
command name and not the rest of the error message after the command
name.
