### PR TITLE
Add minimal self-registration feature

### DIFF
--- a/client/components/Windows/SignIn.vue
+++ b/client/components/Windows/SignIn.vue
@@ -49,6 +49,11 @@
 			<div v-if="errorShown" class="error">Authentication failed.</div>
 
 			<button :disabled="inFlight" type="submit" class="btn">Sign in</button>
+
+			<p v-if="selfRegisterEnabled" class="sign-up-link">
+				Don't have an account?
+				<router-link to="/sign-up">Sign up</router-link>
+			</p>
 		</form>
 	</div>
 </template>
@@ -57,7 +62,8 @@
 import storage from "../../js/localStorage";
 import socket from "../../js/socket";
 import RevealPassword from "../RevealPassword.vue";
-import {defineComponent, onBeforeUnmount, onMounted, ref} from "vue";
+import {computed, defineComponent, onBeforeUnmount, onMounted, ref} from "vue";
+import {useStore} from "../../js/store";
 
 export default defineComponent({
 	name: "SignIn",
@@ -65,11 +71,14 @@ export default defineComponent({
 		RevealPassword,
 	},
 	setup() {
+		const store = useStore();
 		const inFlight = ref(false);
 		const errorShown = ref(false);
 
 		const username = ref(storage.get("user") || "");
 		const password = ref("");
+
+		const selfRegisterEnabled = computed(() => store.state.selfRegister);
 
 		const onAuthFailed = () => {
 			inFlight.value = false;
@@ -109,6 +118,7 @@ export default defineComponent({
 			errorShown,
 			username,
 			password,
+			selfRegisterEnabled,
 			onSubmit,
 		};
 	},

--- a/client/components/Windows/SignUp.vue
+++ b/client/components/Windows/SignUp.vue
@@ -1,0 +1,162 @@
+<template>
+	<div id="sign-in" class="window" role="tabpanel" aria-label="Sign-up">
+		<form class="container" method="post" action="" @submit="onSubmit">
+			<img
+				src="img/logo-vertical-transparent-bg.svg"
+				class="logo"
+				alt="The Lounge"
+				width="256"
+				height="170"
+			/>
+			<img
+				src="img/logo-vertical-transparent-bg-inverted.svg"
+				class="logo-inverted"
+				alt="The Lounge"
+				width="256"
+				height="170"
+			/>
+
+			<label for="signup-username">Username</label>
+			<input
+				id="signup-username"
+				v-model.trim="username"
+				class="input"
+				type="text"
+				name="username"
+				autocapitalize="none"
+				autocorrect="off"
+				autocomplete="username"
+				required
+				autofocus
+			/>
+
+			<div class="password-container">
+				<label for="signup-password">Password</label>
+				<RevealPassword v-slot:default="slotProps">
+					<input
+						id="signup-password"
+						v-model="password"
+						:type="slotProps.isVisible ? 'text' : 'password'"
+						class="input"
+						autocapitalize="none"
+						autocorrect="off"
+						autocomplete="new-password"
+						required
+					/>
+				</RevealPassword>
+			</div>
+
+			<div class="password-container">
+				<label for="signup-password-confirm">Confirm Password</label>
+				<RevealPassword v-slot:default="slotProps">
+					<input
+						id="signup-password-confirm"
+						v-model="passwordConfirm"
+						:type="slotProps.isVisible ? 'text' : 'password'"
+						class="input"
+						autocapitalize="none"
+						autocorrect="off"
+						autocomplete="new-password"
+						required
+					/>
+				</RevealPassword>
+			</div>
+
+			<div v-if="errorShown" class="error">{{ errorMessage }}</div>
+			<div v-if="successShown" class="success">
+				Registration successful! You can now
+				<router-link to="/sign-in">sign in</router-link>.
+			</div>
+
+			<button :disabled="inFlight || successShown" type="submit" class="btn">Sign up</button>
+
+			<p class="sign-in-link">
+				Already have an account?
+				<router-link to="/sign-in">Sign in</router-link>
+			</p>
+		</form>
+	</div>
+</template>
+
+<script lang="ts">
+import socket from "../../js/socket";
+import RevealPassword from "../RevealPassword.vue";
+import {defineComponent, onBeforeUnmount, onMounted, ref} from "vue";
+import {useRouter} from "vue-router";
+
+export default defineComponent({
+	name: "SignUp",
+	components: {
+		RevealPassword,
+	},
+	setup() {
+		const inFlight = ref(false);
+		const errorShown = ref(false);
+		const successShown = ref(false);
+		const errorMessage = ref("");
+
+		const username = ref("");
+		const password = ref("");
+		const passwordConfirm = ref("");
+
+		const onRegisterSuccess = () => {
+			inFlight.value = false;
+			successShown.value = true;
+			errorShown.value = false;
+		};
+
+		const onRegisterFailed = (data: {error: string}) => {
+			inFlight.value = false;
+			errorShown.value = true;
+			errorMessage.value = data.error || "Registration failed.";
+		};
+
+		const onSubmit = (event: Event) => {
+			event.preventDefault();
+
+			if (!username.value || !password.value || !passwordConfirm.value) {
+				return;
+			}
+
+			if (password.value !== passwordConfirm.value) {
+				errorShown.value = true;
+				errorMessage.value = "Passwords do not match.";
+				return;
+			}
+
+			inFlight.value = true;
+			errorShown.value = false;
+			successShown.value = false;
+
+			const values = {
+				user: username.value,
+				password: password.value,
+				password_confirm: passwordConfirm.value,
+			};
+
+			socket.emit("auth:register", values);
+		};
+
+		onMounted(() => {
+			socket.on("auth:register:success", onRegisterSuccess);
+			socket.on("auth:register:failed", onRegisterFailed);
+		});
+
+		onBeforeUnmount(() => {
+			socket.off("auth:register:success", onRegisterSuccess);
+			socket.off("auth:register:failed", onRegisterFailed);
+		});
+
+		return {
+			inFlight,
+			errorShown,
+			successShown,
+			errorMessage,
+			username,
+			password,
+			passwordConfirm,
+			onSubmit,
+		};
+	},
+});
+</script>

--- a/client/js/router.ts
+++ b/client/js/router.ts
@@ -2,6 +2,7 @@ import constants from "./constants";
 
 import {createRouter, createWebHashHistory} from "vue-router";
 import SignIn from "../components/Windows/SignIn.vue";
+import SignUp from "../components/Windows/SignUp.vue";
 import Connect from "../components/Windows/Connect.vue";
 import Settings from "../components/Windows/Settings.vue";
 import Help from "../components/Windows/Help.vue";
@@ -26,6 +27,20 @@ const router = createRouter({
 			component: SignIn,
 			beforeEnter(to, from, next) {
 				// Prevent navigating to sign-in when already signed in
+				if (store.state.appLoaded) {
+					next(false);
+					return;
+				}
+
+				next();
+			},
+		},
+		{
+			name: "SignUp",
+			path: "/sign-up",
+			component: SignUp,
+			beforeEnter(to, from, next) {
+				// Prevent navigating to sign-up when already signed in
 				if (store.state.appLoaded) {
 					next(false);
 					return;
@@ -97,8 +112,8 @@ const router = createRouter({
 
 router.beforeEach((to, from, next) => {
 	// If user is not yet signed in, wait for appLoaded state to change
-	// unless they are trying to open SignIn (which can be triggered in auth.js)
-	if (!store.state.appLoaded && to.name !== "SignIn") {
+	// unless they are trying to open SignIn or SignUp
+	if (!store.state.appLoaded && to.name !== "SignIn" && to.name !== "SignUp") {
 		store.watch(
 			(state) => state.appLoaded,
 			() => next()

--- a/client/js/socket-events/auth.ts
+++ b/client/js/socket-events/auth.ts
@@ -26,14 +26,17 @@ socket.on("auth:failed", async function () {
 	await showSignIn();
 });
 
-socket.on("auth:start", async function (serverHash) {
+socket.on("auth:start", async function (data) {
 	// If we reconnected and serverHash differs, that means the server restarted
 	// And we will reload the page to grab the latest version
-	if (lastServerHash && serverHash !== lastServerHash) {
+	if (lastServerHash && data.serverHash !== lastServerHash) {
 		return reloadPage("Server restarted, reloading…");
 	}
 
-	lastServerHash = serverHash;
+	lastServerHash = data.serverHash;
+
+	// Store selfRegister for use on sign-in page before full config is loaded
+	store.commit("selfRegister", data.selfRegister);
 
 	const user = storage.get("user");
 	const token = storage.get("token");

--- a/client/js/store.ts
+++ b/client/js/store.ts
@@ -48,6 +48,7 @@ export type State = {
 	isAutoCompleting: boolean;
 	isConnected: boolean;
 	networks: ClientNetwork[];
+	selfRegister: boolean;
 	// TODO: type
 	mentions: ClientMention[];
 	hasServiceWorker: boolean;
@@ -91,6 +92,7 @@ const state = (): State => ({
 	isAutoCompleting: false,
 	isConnected: false,
 	networks: [],
+	selfRegister: false,
 	mentions: [],
 	hasServiceWorker: false,
 	pushNotificationState: "unsupported",
@@ -204,6 +206,7 @@ type Mutations = {
 	isAutoCompleting(state: State, isAutoCompleting: State["isAutoCompleting"]): void;
 	isConnected(state: State, payload: State["isConnected"]): void;
 	networks(state: State, networks: State["networks"]): void;
+	selfRegister(state: State, selfRegister: State["selfRegister"]): void;
 	mentions(state: State, mentions: State["mentions"]): void;
 
 	removeNetwork(state: State, networkUuid: string): void;
@@ -253,6 +256,9 @@ const mutations: Mutations = {
 	},
 	networks(state, networks) {
 		state.networks = networks;
+	},
+	selfRegister(state, selfRegister) {
+		state.selfRegister = selfRegister;
 	},
 	mentions(state, mentions) {
 		state.mentions = mentions;

--- a/defaults/config.js
+++ b/defaults/config.js
@@ -18,6 +18,17 @@ module.exports = {
 	// This value is set to `false` by default.
 	public: false,
 
+	// ### `selfRegister`
+	//
+	// When set to `true`, users can create their own accounts via a sign-up form
+	// on the login page. This only applies in private mode (when `public` is
+	// `false`). The server admin is responsible for rate limiting via reverse
+	// proxy (nginx, Apache, Cloudflare, fail2ban, etc.) since The Lounge does
+	// not implement built-in protection against registration abuse.
+	//
+	// This value is set to `false` by default.
+	selfRegister: false,
+
 	// ### `host`
 	//
 	// IP address or hostname for the web server to listen to. For example, set it

--- a/server/client.ts
+++ b/server/client.ts
@@ -195,8 +195,6 @@ class Client {
 		delete client.config.networks;
 
 		if (client.name) {
-			log.info(`User ${colors.bold(client.name)} loaded`);
-
 			// Networks are created instantly, but to reduce server load on startup
 			// We randomize the IRC connections and channel log loading
 			let delay = client.manager.clients.length * 500;

--- a/server/clientManager.ts
+++ b/server/clientManager.ts
@@ -83,6 +83,8 @@ class ClientManager {
 			// Fallback to loading all users
 			users.forEach((name) => this.loadUser(name));
 		}
+
+		log.info(`${colors.bold(String(users.length))} users loaded`);
 	}
 
 	autoloadUsers() {

--- a/server/config.ts
+++ b/server/config.ts
@@ -85,6 +85,7 @@ type StoragePolicy = {
 
 export type ConfigType = {
 	public: boolean;
+	selfRegister: boolean;
 	host: string | undefined;
 	port: number;
 	bind: string | undefined;

--- a/shared/types/config.ts
+++ b/shared/types/config.ts
@@ -5,6 +5,7 @@ export type ConfigTheme = {
 };
 type SharedConfigurationBase = {
 	public: boolean;
+	selfRegister: boolean;
 	useHexIp: boolean;
 	prefetch: boolean;
 	fileUpload: boolean;

--- a/shared/types/socket-events.d.ts
+++ b/shared/types/socket-events.d.ts
@@ -20,9 +20,11 @@ type EventHandler<T> = (data: T) => void;
 type NoPayloadEventHandler = EventHandler<void>;
 
 interface ServerToClientEvents {
-	"auth:start": (serverHash: number) => void;
+	"auth:start": (data: {serverHash: number; selfRegister: boolean}) => void;
 	"auth:failed": NoPayloadEventHandler;
 	"auth:success": NoPayloadEventHandler;
+	"auth:register:success": NoPayloadEventHandler;
+	"auth:register:failed": EventHandler<{error: string}>;
 
 	"upload:auth": (token: string) => void;
 
@@ -112,8 +114,15 @@ type AuthPerformData =
 			hasConfig: boolean;
 	  };
 
+type AuthRegisterData = {
+	user: string;
+	password: string;
+	password_confirm: string;
+};
+
 interface ClientToServerEvents {
 	"auth:perform": EventHandler<AuthPerformData>;
+	"auth:register": EventHandler<AuthRegisterData>;
 
 	changelog: NoPayloadEventHandler;
 


### PR DESCRIPTION
closes #914

adds basic self-registration support in private mode. opt-in via config, disabled by default.

## what it does
- new signup form (username + password + confirm)
- creates user account immediately 
- config flag `selfRegister: false` to enable/disable

## what it doesn't do (intentionally minimal)
- no email verification
- no admin approval workflow
- no built-in rate limiting (handle via reverse proxy)
- no captcha

## why minimal
keeping scope tight to get something merged. discussed approach in #914 avoiding the scope creep that killed #641. security concerns like rate limiting should be handled at the infrastructure level (nginx/cloudflare) similar to how public mode works.

## can be enhanced later with
- email verification system
- admin approval workflow  
- password strength requirements
- rate limiting

## testing
tested locally with:
- successful registration
- duplicate username handling
- password mismatch validation
- config toggle working
- user can sign in after registering

## screenshots
<img width="500" alt="image" src="https://github.com/user-attachments/assets/4591a0dc-bd03-442a-b46e-7a9884171154" />
<img width="500"  alt="image" src="https://github.com/user-attachments/assets/019f8beb-ca67-4b3f-ac46-78bf66163a77" />

<img width="500"  alt="image" src="https://github.com/user-attachments/assets/2f2a0504-9584-4f49-9f05-3fcfc154e4f1" />
<img width="500"  alt="image" src="https://github.com/user-attachments/assets/2f4610be-5774-4f24-ae9a-cf27d6c136fc" />

https://github.com/user-attachments/assets/9e49a196-2f8f-4671-93cb-ca0279322eec


ready for review. happy to iterate on feedback but trying to keep scope focused.