### PR TITLE
Fix spurious "insecure connection" warning by treating ::1 as localhost

### DIFF
--- a/server/models/network.ts
+++ b/server/models/network.ts
@@ -524,7 +524,7 @@ class Network {
 			const transport = this.irc.connection.transport;
 
 			if (transport.socket) {
-				const isLocalhost = transport.socket.remoteAddress === "127.0.0.1";
+				const isLocalhost = ["127.0.0.1", "::1"].includes(transport.socket.remoteAddress);
 				const isAuthorized = transport.socket.encrypted && transport.socket.authorized;
 
 				status.connected = transport.isConnected();


### PR DESCRIPTION
On some systems, `localhost` resolves to IPv6 `::1` instead of IPv4 `127.0.0.1`. This was causing The Lounge's "insecure connection" warning to show up spuriously. The warning normally has an exemption for localhost connections, but it wasn't counting `::1` as localhost.

I had trouble getting a dev environment set up, so I couldn't run tests and lint, sorry. Hopefully those still pass.