### PR TITLE
fix: call stack size exceeded

### DIFF
--- a/client/js/socket-events/more.ts
+++ b/client/js/socket-events/more.ts
@@ -22,7 +22,7 @@ socket.on("more", async (data) => {
 	);
 	channel.moreHistoryAvailable =
 		data.totalMessages > channel.messages.length + data.messages.length;
-	channel.messages.unshift(...data.messages);
+	channel.messages = data.messages.concat(channel.messages);
 
 	await nextTick();
 	channel.historyLoading = false;

--- a/server/models/chan.ts
+++ b/server/models/chan.ts
@@ -299,7 +299,7 @@ class Chan {
 					return;
 				}
 
-				this.messages.unshift(...messages);
+				this.messages = messages.concat(this.messages);
 
 				if (!this.firstUnread) {
 					this.firstUnread = messages[messages.length - 1].id;


### PR DESCRIPTION
The spread operator will place the arguments, which can reach the call stack limit if too many messages are being sent. This fix uses `.concat()` to avoid the spread operator.

Fixes #5022

Tested with `maxHistory: 131072`.