### PR TITLE
Fix mobile viewport

### DIFF
--- a/client/index.html.tpl
+++ b/client/index.html.tpl
@@ -3,7 +3,7 @@
 	<head>
 
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, user-scalable=no">
+	<meta name="viewport" content="width=device-width, user-scalable=no, interactive-widget=resizes-content">
 
 	<link rel="preload" as="script" href="js/loading-error-handlers.js?v=<%- cacheBust %>">
 	<link rel="preload" as="script" href="js/bundle.vendor.js?v=<%- cacheBust %>">


### PR DESCRIPTION
Make content resize again when the keyboard is slid out.

Fixes #4752 (Chromium) and also Firefox's different behaviour of not moving the content at all, making the keyboard overlay the bottom half of the app.