### PR TITLE
sqlite: change to single quotes

### DIFF
--- a/server/plugins/messageStorage/sqlite.ts
+++ b/server/plugins/messageStorage/sqlite.ts
@@ -470,7 +470,7 @@ class SqliteMessageStorage implements SearchableMessageStorage {
 		const escapedSearchTerm = query.searchTerm.replace(/([%_@])/g, "@$1");
 
 		let select =
-			'SELECT msg, type, time, network, channel FROM messages WHERE type = "message" AND json_extract(msg, "$.text") LIKE ? ESCAPE \'@\'';
+			"SELECT msg, type, time, network, channel FROM messages WHERE type = 'message' AND json_extract(msg, '$.text') LIKE ? ESCAPE '@'";
 		const params: any[] = [`%${escapedSearchTerm}%`];
 
 		if (query.networkUuid) {


### PR DESCRIPTION
Apparently sqlite started validating this in certain versions. Crashes on BSDs with:

SQLite version 3.50.4 2025-07-30 19:33:53
sqlite> SELECT msg, type, time, network, channel FROM messages WHERE type = "message"; Parse error: no such column: "message" - should this be a string literal in single-quotes?
  time, network, channel FROM messages WHERE type = "message";
                                      error here ---^