### PR TITLE
feat: Add click-to-scroll mentions with full history browsing

### DIFF
--- a/client/components/Mentions.vue
+++ b/client/components/Mentions.vue
@@ -21,7 +21,10 @@
 				<p v-else>You have no recent mentions.</p>
 			</template>
 			<template v-for="message in resolvedMessages" v-else :key="message.msgId">
-				<div :class="['msg', message.type]">
+				<div
+					:class="['msg', message.type, {'mention-clickable': !!message.channel}]"
+					@click="goToMention(message)"
+				>
 					<div class="mentions-info">
 						<div>
 							<span class="from">
@@ -44,7 +47,7 @@
 								<button
 									class="msg-dismiss"
 									aria-label="Dismiss this mention"
-									@click="dismissMention(message)"
+									@click.stop="dismissMention(message)"
 								></button>
 							</span>
 						</div>
@@ -90,6 +93,15 @@
 .mentions-popup .msg {
 	margin-bottom: 15px;
 	user-select: text;
+}
+
+.mentions-popup .msg.mention-clickable {
+	cursor: pointer;
+}
+
+.mentions-popup .msg.mention-clickable:hover {
+	background-color: var(--highlight-bg-color);
+	border-radius: 5px;
 }
 
 .mentions-popup .msg:last-child {
@@ -152,8 +164,9 @@ import eventbus from "../js/eventbus";
 import localetime from "../js/helpers/localetime";
 import dayjs from "dayjs";
 import relativeTime from "dayjs/plugin/relativeTime";
-import {computed, watch, defineComponent, ref, onMounted, onUnmounted} from "vue";
+import {computed, watch, defineComponent, ref, onMounted, onUnmounted, nextTick} from "vue";
 import {useStore} from "../js/store";
+import {switchToChannel} from "../js/router";
 import {ClientMention} from "../js/types";
 
 dayjs.extend(relativeTime);
@@ -204,6 +217,47 @@ export default defineComponent({
 			socket.emit("mentions:dismiss_all");
 		};
 
+		const scrollToMessage = (msgId: number) => {
+			const el = document.getElementById(`msg-${msgId}`);
+
+			if (el) {
+				el.scrollIntoView({behavior: "smooth", block: "center"});
+			}
+		};
+
+		const goToMention = (message: ClientMention) => {
+			if (!message.channel) {
+				return;
+			}
+
+			isOpen.value = false;
+			switchToChannel(message.channel.channel);
+
+			// Give the channel time to render, then try to scroll
+			setTimeout(() => {
+				const el = document.getElementById(`msg-${message.msgId}`);
+
+				if (el) {
+					el.scrollIntoView({behavior: "smooth", block: "center"});
+				} else {
+					// Message not in loaded buffer, request from server
+					socket.emit("messages:around", {
+						target: message.chanId,
+						msgId: message.msgId,
+					});
+				}
+			}, 200);
+		};
+
+		const onScrollToMention = (msgId: number) => {
+			void nextTick().then(() => {
+				// Small delay to let the DOM update with new messages
+				setTimeout(() => {
+					scrollToMessage(msgId);
+				}, 100);
+			});
+		};
+
 		const containerClick = (event: Event) => {
 			if (event.currentTarget === event.target) {
 				isOpen.value = false;
@@ -226,11 +280,13 @@ export default defineComponent({
 		onMounted(() => {
 			eventbus.on("mentions:toggle", togglePopup);
 			eventbus.on("escapekey", closePopup);
+			eventbus.on("mentions:scrollTo", onScrollToMention);
 		});
 
 		onUnmounted(() => {
 			eventbus.off("mentions:toggle", togglePopup);
 			eventbus.off("escapekey", closePopup);
+			eventbus.off("mentions:scrollTo", onScrollToMention);
 		});
 
 		return {
@@ -240,6 +296,7 @@ export default defineComponent({
 			messageTime,
 			dismissMention,
 			dismissAllMentions,
+			goToMention,
 			containerClick,
 		};
 	},

--- a/client/components/MessageList.vue
+++ b/client/components/MessageList.vue
@@ -64,6 +64,12 @@
 				<span v-if="channel.historyLoading">Loading…</span>
 				<span v-else>Show newer messages</span>
 			</button>
+			<button
+				class="btn"
+				@click="onJumpToLatest"
+			>
+				Jump to latest
+			</button>
 		</div>
 	</div>
 </template>
@@ -191,6 +197,18 @@ export default defineComponent({
 			socket.emit("more:newer", {
 				target: props.channel.id,
 				lastId: lastMessage,
+			});
+		};
+
+		const onJumpToLatest = () => {
+			if (!store.state.isConnected) {
+				return;
+			}
+
+			props.channel.historyLoading = true;
+
+			socket.emit("messages:latest", {
+				target: props.channel.id,
 			});
 		};
 
@@ -487,6 +505,7 @@ export default defineComponent({
 			store,
 			onShowMoreClick,
 			onShowNewerClick,
+			onJumpToLatest,
 			loadMoreButton,
 			loadNewerButton,
 			onCopy,

--- a/client/components/MessageList.vue
+++ b/client/components/MessageList.vue
@@ -54,6 +54,17 @@
 				/>
 			</template>
 		</div>
+		<div v-show="channel.moreNewerAvailable" class="show-more show-newer">
+			<button
+				ref="loadNewerButton"
+				:disabled="channel.historyLoading || !store.state.isConnected"
+				class="btn"
+				@click="onShowNewerClick"
+			>
+				<span v-if="channel.historyLoading">Loading…</span>
+				<span v-else>Show newer messages</span>
+			</button>
+		</div>
 	</div>
 </template>
 
@@ -109,7 +120,9 @@ export default defineComponent({
 
 		const chat = ref<HTMLDivElement | null>(null);
 		const loadMoreButton = ref<HTMLButtonElement | null>(null);
+		const loadNewerButton = ref<HTMLButtonElement | null>(null);
 		const historyObserver = ref<IntersectionObserver | null>(null);
+		const newerObserver = ref<IntersectionObserver | null>(null);
 		const skipNextScrollEvent = ref(false);
 
 		const isWaitingForNextTick = ref(false);
@@ -160,6 +173,37 @@ export default defineComponent({
 			});
 		};
 
+		const onShowNewerClick = () => {
+			if (!store.state.isConnected) {
+				return;
+			}
+
+			const messages = props.channel.messages;
+
+			if (messages.length === 0) {
+				return;
+			}
+
+			const lastMessage = messages[messages.length - 1].id;
+
+			props.channel.historyLoading = true;
+
+			socket.emit("more:newer", {
+				target: props.channel.id,
+				lastId: lastMessage,
+			});
+		};
+
+		const onNewerButtonObserved = (entries: IntersectionObserverEntry[]) => {
+			entries.forEach((entry) => {
+				if (!entry.isIntersecting) {
+					return;
+				}
+
+				onShowNewerClick();
+			});
+		};
+
 		nextTick(() => {
 			if (!chat.value) {
 				return;
@@ -167,6 +211,10 @@ export default defineComponent({
 
 			if (window.IntersectionObserver) {
 				historyObserver.value = new window.IntersectionObserver(onLoadButtonObserved, {
+					root: chat.value,
+				});
+
+				newerObserver.value = new window.IntersectionObserver(onNewerButtonObserved, {
 					root: chat.value,
 				});
 			}
@@ -371,6 +419,10 @@ export default defineComponent({
 				if (historyObserver.value && loadMoreButton.value) {
 					historyObserver.value.observe(loadMoreButton.value);
 				}
+
+				if (newerObserver.value && loadNewerButton.value) {
+					newerObserver.value.observe(loadNewerButton.value);
+				}
 			});
 		});
 
@@ -378,12 +430,17 @@ export default defineComponent({
 			() => props.channel.id,
 			() => {
 				props.channel.scrolledToBottom = true;
+				props.channel.moreNewerAvailable = false;
 
 				// Re-add the intersection observer to trigger the check again on channel switch
-				// Otherwise if last channel had the button visible, switching to a new channel won't trigger the history
 				if (historyObserver.value && loadMoreButton.value) {
 					historyObserver.value.unobserve(loadMoreButton.value);
 					historyObserver.value.observe(loadMoreButton.value);
+				}
+
+				if (newerObserver.value && loadNewerButton.value) {
+					newerObserver.value.unobserve(loadNewerButton.value);
+					newerObserver.value.observe(loadNewerButton.value);
 				}
 			}
 		);
@@ -419,13 +476,19 @@ export default defineComponent({
 			if (historyObserver.value) {
 				historyObserver.value.disconnect();
 			}
+
+			if (newerObserver.value) {
+				newerObserver.value.disconnect();
+			}
 		});
 
 		return {
 			chat,
 			store,
 			onShowMoreClick,
+			onShowNewerClick,
 			loadMoreButton,
+			loadNewerButton,
 			onCopy,
 			condensedMessages,
 			shouldDisplayDateMarker,

--- a/client/js/chan.ts
+++ b/client/js/chan.ts
@@ -24,6 +24,7 @@ export function toClientChan(shared: SharedNetworkChan): ClientChan {
 		users: [],
 		usersOutdated: shared.type === ChanType.CHANNEL ? true : false,
 		moreHistoryAvailable: shared.totalMessages > shared.messages.length,
+		moreNewerAvailable: false,
 		inputHistory: history,
 		messages: sharedMsgToClientMsg(messages),
 	};

--- a/client/js/socket-events/index.ts
+++ b/client/js/socket-events/index.ts
@@ -23,5 +23,7 @@ import "./changelog";
 import "./setting";
 import "./history_clear";
 import "./mentions";
+import "./messages_around";
+import "./more_newer";
 import "./search";
 import "./mute_changed";

--- a/client/js/socket-events/index.ts
+++ b/client/js/socket-events/index.ts
@@ -24,6 +24,7 @@ import "./setting";
 import "./history_clear";
 import "./mentions";
 import "./messages_around";
+import "./messages_latest";
 import "./more_newer";
 import "./search";
 import "./mute_changed";

--- a/client/js/socket-events/messages_around.ts
+++ b/client/js/socket-events/messages_around.ts
@@ -1,0 +1,25 @@
+import socket from "../socket";
+import {store} from "../store";
+import eventbus from "../eventbus";
+
+socket.on("messages:around", (data) => {
+	const channel = store.getters.findChannel(data.chan)?.channel;
+
+	if (!channel) {
+		return;
+	}
+
+	// Replace the channel's messages with the messages around the target
+	channel.messages = data.messages;
+	channel.moreHistoryAvailable = data.moreHistoryBefore;
+	channel.moreNewerAvailable = true;
+	channel.scrolledToBottom = false;
+
+	// Reset unread marker so "New messages" line doesn't appear when browsing via mention
+	if (data.messages.length > 0) {
+		channel.firstUnread = data.messages[data.messages.length - 1].id;
+	}
+
+	// Notify that we should scroll to the target message
+	eventbus.emit("mentions:scrollTo", data.msgId);
+});

--- a/client/js/socket-events/messages_latest.ts
+++ b/client/js/socket-events/messages_latest.ts
@@ -1,0 +1,16 @@
+import socket from "../socket";
+import {store} from "../store";
+
+socket.on("messages:latest", (data) => {
+	const channel = store.getters.findChannel(data.chan)?.channel;
+
+	if (!channel) {
+		return;
+	}
+
+	channel.messages = data.messages;
+	channel.moreHistoryAvailable = data.totalMessages > data.messages.length;
+	channel.moreNewerAvailable = false;
+	channel.scrolledToBottom = true;
+	channel.historyLoading = false;
+});

--- a/client/js/socket-events/more_newer.ts
+++ b/client/js/socket-events/more_newer.ts
@@ -1,0 +1,19 @@
+import socket from "../socket";
+import {store} from "../store";
+
+socket.on("more:newer", (data) => {
+	const channel = store.getters.findChannel(data.chan)?.channel;
+
+	if (!channel) {
+		return;
+	}
+
+	channel.messages.push(...data.messages);
+	channel.moreNewerAvailable = data.moreAfter;
+	channel.historyLoading = false;
+
+	// If we've caught up to the latest messages, switch back to live mode
+	if (!data.moreAfter) {
+		channel.scrolledToBottom = true;
+	}
+});

--- a/client/js/socket-events/msg.ts
+++ b/client/js/socket-events/msg.ts
@@ -66,7 +66,11 @@ socket.on("msg", function (data) {
 		}
 	}
 
-	channel.messages.push(data.msg);
+	// Don't push messages into the buffer while browsing old history via mention jump,
+	// as it causes duplicates/gaps when loading newer messages from the server
+	if (!channel.moreNewerAvailable) {
+		channel.messages.push(data.msg);
+	}
 
 	if (data.msg.self) {
 		channel.firstUnread = data.msg.id;

--- a/client/js/types.d.ts
+++ b/client/js/types.d.ts
@@ -19,6 +19,7 @@ export type ClientMessage = SharedMsg;
 
 type ClientChan = Omit<SharedChan, "messages"> & {
 	moreHistoryAvailable: boolean;
+	moreNewerAvailable: boolean;
 	editTopic: boolean;
 	messages: ClientMessage[];
 

--- a/server/client.ts
+++ b/server/client.ts
@@ -680,6 +680,24 @@ class Client {
 		};
 	}
 
+	messagesLatest(data) {
+		const client = this;
+		const target = client.find(data.target);
+
+		if (!target) {
+			return null;
+		}
+
+		const chan = target.chan;
+		const messages = chan.messages.slice(-100);
+
+		return {
+			chan: chan.id,
+			messages: messages,
+			totalMessages: chan.messages.length,
+		};
+	}
+
 	clearHistory(data) {
 		const client = this;
 		const target = client.find(data.target);

--- a/server/client.ts
+++ b/server/client.ts
@@ -623,6 +623,63 @@ class Client {
 		};
 	}
 
+	messagesAround(data) {
+		const client = this;
+		const target = client.find(data.target);
+
+		if (!target) {
+			return null;
+		}
+
+		const chan = target.chan;
+		const index = chan.messages.findIndex((val) => val.id === data.msgId);
+
+		if (index < 0) {
+			return null;
+		}
+
+		// Get 50 messages before and 50 after the target
+		const startIndex = Math.max(0, index - 50);
+		const endIndex = Math.min(chan.messages.length, index + 51);
+		const messages = chan.messages.slice(startIndex, endIndex);
+
+		return {
+			chan: chan.id,
+			messages: messages,
+			totalMessages: chan.messages.length,
+			moreHistoryBefore: startIndex > 0,
+			msgId: data.msgId,
+		};
+	}
+
+	moreNewer(data) {
+		const client = this;
+		const target = client.find(data.target);
+
+		if (!target) {
+			return null;
+		}
+
+		const chan = target.chan;
+		const index = chan.messages.findIndex((val) => val.id === data.lastId);
+
+		if (index < 0) {
+			return null;
+		}
+
+		// Get up to 100 messages after the given ID
+		const startIndex = index + 1;
+		const endIndex = Math.min(chan.messages.length, startIndex + 100);
+		const messages = chan.messages.slice(startIndex, endIndex);
+
+		return {
+			chan: chan.id,
+			messages: messages,
+			totalMessages: chan.messages.length,
+			moreAfter: endIndex < chan.messages.length,
+		};
+	}
+
 	clearHistory(data) {
 		const client = this;
 		const target = client.find(data.target);

--- a/server/server.ts
+++ b/server/server.ts
@@ -490,6 +490,16 @@ function initializeClient(
 		}
 	});
 
+	socket.on("messages:latest", (data) => {
+		if (_.isPlainObject(data)) {
+			const result = client.messagesLatest(data);
+
+			if (result !== null) {
+				socket.emit("messages:latest", result);
+			}
+		}
+	});
+
 	socket.on("network:new", (data) => {
 		if (_.isPlainObject(data)) {
 			// prevent people from overriding webirc settings

--- a/server/server.ts
+++ b/server/server.ts
@@ -470,6 +470,26 @@ function initializeClient(
 		}
 	});
 
+	socket.on("messages:around", (data) => {
+		if (_.isPlainObject(data)) {
+			const result = client.messagesAround(data);
+
+			if (result !== null) {
+				socket.emit("messages:around", result);
+			}
+		}
+	});
+
+	socket.on("more:newer", (data) => {
+		if (_.isPlainObject(data)) {
+			const result = client.moreNewer(data);
+
+			if (result !== null) {
+				socket.emit("more:newer", result);
+			}
+		}
+	});
+
 	socket.on("network:new", (data) => {
 		if (_.isPlainObject(data)) {
 			// prevent people from overriding webirc settings

--- a/shared/types/socket-events.d.ts
+++ b/shared/types/socket-events.d.ts
@@ -79,6 +79,21 @@ interface ServerToClientEvents {
 
 	more: EventHandler<{chan: number; messages: SharedMsg[]; totalMessages: number}>;
 
+	"messages:around": EventHandler<{
+		chan: number;
+		messages: SharedMsg[];
+		totalMessages: number;
+		moreHistoryBefore: boolean;
+		msgId: number;
+	}>;
+
+	"more:newer": EventHandler<{
+		chan: number;
+		messages: SharedMsg[];
+		totalMessages: number;
+		moreAfter: boolean;
+	}>;
+
 	"msg:preview": EventHandler<{id: number; chan: number; preview: LinkPreview}>;
 	"msg:special": EventHandler<{chan: number; data?: Record<string, any>}>;
 	msg: EventHandler<{msg: SharedMsg; chan: number; highlight?: number; unread?: number}>;
@@ -153,6 +168,10 @@ interface ClientToServerEvents {
 	"mentions:get": NoPayloadEventHandler;
 
 	more: EventHandler<{target: number; lastId: number; condensed: boolean}>;
+
+	"messages:around": EventHandler<{target: number; msgId: number}>;
+
+	"more:newer": EventHandler<{target: number; lastId: number}>;
 
 	"msg:preview:toggle": EventHandler<{
 		target: number;

--- a/shared/types/socket-events.d.ts
+++ b/shared/types/socket-events.d.ts
@@ -94,6 +94,12 @@ interface ServerToClientEvents {
 		moreAfter: boolean;
 	}>;
 
+	"messages:latest": EventHandler<{
+		chan: number;
+		messages: SharedMsg[];
+		totalMessages: number;
+	}>;
+
 	"msg:preview": EventHandler<{id: number; chan: number; preview: LinkPreview}>;
 	"msg:special": EventHandler<{chan: number; data?: Record<string, any>}>;
 	msg: EventHandler<{msg: SharedMsg; chan: number; highlight?: number; unread?: number}>;
@@ -170,6 +176,8 @@ interface ClientToServerEvents {
 	more: EventHandler<{target: number; lastId: number; condensed: boolean}>;
 
 	"messages:around": EventHandler<{target: number; msgId: number}>;
+
+	"messages:latest": EventHandler<{target: number}>;
 
 	"more:newer": EventHandler<{target: number; lastId: number}>;
 


### PR DESCRIPTION
## Click-to-scroll for mentions

Clicking a mention in the mentions popup now navigates to the channel and scrolls to the highlighted message. Works regardless of how old the mention is, if the message isn't in the currently loaded buffer, it fetches messages around it from the server.

### What's new

- **Click any mention** in the popup to jump directly to that message in the channel
- **Old mentions work too**: a new `messages:around` socket event fetches messages from server memory when the message isn't in the client's loaded buffer
- **Bidirectional history browsing**: after jumping to an old mention, you can scroll both up (existing "Show older messages") and down (new "Show newer messages") to browse the full history seamlessly
- **Hover state** on clickable mentions for visual feedback

### Changes

**Client:**
- `Mentions.vue`: click handler navigates to channel, scrolls to message, falls back to server fetch
- `MessageList.vue`: "Show newer messages" button + IntersectionObserver for auto-loading
- `messages_around.ts`: handles server response, replaces message buffer, resets unread marker
- `more_newer.ts`: handles newer message batches, restores live mode when caught up
- `chan.ts` / `types.d.ts`: added `moreNewerAvailable` flag

**Server:**
- `client.ts`: `messagesAround()` returns ~100 messages centered on target ID, `moreNewer()` returns 100 messages after a given ID
- `server.ts`: socket handlers for `messages:around` and `more:newer`
- `socket-events.d.ts`: type definitions for new events