### PR TITLE
ircv3: start storing/tracking msgid

### DIFF
--- a/server/models/msg.ts
+++ b/server/models/msg.ts
@@ -4,6 +4,7 @@ import {MessageType, LinkPreview, UserInMessage} from "../../shared/types/msg";
 class Msg {
 	from!: UserInMessage;
 	id!: number;
+	msgid?: string;
 	previews!: LinkPreview[];
 	text!: string;
 	type!: MessageType;

--- a/server/plugins/irc-events/message.ts
+++ b/server/plugins/irc-events/message.ts
@@ -22,6 +22,7 @@ type HandleInput = {
 	from_server?: boolean;
 	message: string;
 	group?: string;
+	msgid?: string;
 };
 
 function convertForHandle(type: MessageType, data: MessageEventArgs): HandleInput {
@@ -132,6 +133,7 @@ export default <IrcEventHandler>function (irc, network) {
 			from: from,
 			highlight: highlight,
 			users: [],
+			msgid: data.msgid,
 		});
 
 		if (showInActive) {

--- a/server/types/modules/irc-framework.d.ts
+++ b/server/types/modules/irc-framework.d.ts
@@ -29,6 +29,7 @@ declare module "irc-framework" {
 		hostname: string;
 		ident: string;
 		message: string;
+		msgid?: string;
 		nick: string;
 		reply: (message: string) => void;
 		tags: {[key: string]: string};

--- a/shared/types/msg.ts
+++ b/shared/types/msg.ts
@@ -62,6 +62,7 @@ export type LinkPreview = {
 export type SharedMsg = {
 	from?: UserInMessage;
 	id: number;
+	msgid?: string;
 	previews?: LinkPreview[];
 	text?: string;
 	type?: MessageType;


### PR DESCRIPTION
Many newer ircv3 specs rely on https://ircv3.net/specs/extensions/message-ids

This simply extracts `msgid` from incoming messages so we capture and store it for when we _do_ support those newer features. 