### PR TITLE
ircv3: parse msgid from tags manually

### DIFF
--- a/server/plugins/irc-events/message.ts
+++ b/server/plugins/irc-events/message.ts
@@ -26,7 +26,7 @@ type HandleInput = {
 };
 
 function convertForHandle(type: MessageType, data: MessageEventArgs): HandleInput {
-	return {...data, type: type};
+	return {...data, type: type, msgid: data.tags?.msgid};
 }
 
 export default <IrcEventHandler>function (irc, network) {

--- a/server/types/modules/irc-framework.d.ts
+++ b/server/types/modules/irc-framework.d.ts
@@ -29,7 +29,6 @@ declare module "irc-framework" {
 		hostname: string;
 		ident: string;
 		message: string;
-		msgid?: string;
 		nick: string;
 		reply: (message: string) => void;
 		tags: {[key: string]: string};


### PR DESCRIPTION
follow-up to #5044

irc-framework doesn't have a top-level msgId.. I worked on it a while ago and never shipped it. for now/bar that, we can manually parse it from the message tags