### PR TITLE
fix: a11y labels and semantics

### DIFF
--- a/client/components/Channel.vue
+++ b/client/components/Channel.vue
@@ -16,12 +16,12 @@
 			>
 				<span class="parted-channel-icon" />
 			</span>
-			<span class="close-tooltip tooltipped tooltipped-w" aria-label="Leave" aria-hidden="true">
+			<span class="close-tooltip tooltipped tooltipped-w" data-tooltip="Leave">
 				<button class="close" aria-label="Leave" @click.stop="close" />
 			</span>
 		</template>
 		<template v-else>
-			<span class="close-tooltip tooltipped tooltipped-w" aria-label="Close" aria-hidden="true">
+			<span class="close-tooltip tooltipped tooltipped-w" data-tooltip="Close">
 				<button class="close" aria-label="Close" @click.stop="close" />
 			</span>
 		</template>

--- a/client/components/Channel.vue
+++ b/client/components/Channel.vue
@@ -16,12 +16,12 @@
 			>
 				<span class="parted-channel-icon" />
 			</span>
-			<span class="close-tooltip tooltipped tooltipped-w" aria-label="Leave">
+			<span class="close-tooltip tooltipped tooltipped-w" aria-label="Leave" aria-hidden="true">
 				<button class="close" aria-label="Leave" @click.stop="close" />
 			</span>
 		</template>
 		<template v-else>
-			<span class="close-tooltip tooltipped tooltipped-w" aria-label="Close">
+			<span class="close-tooltip tooltipped tooltipped-w" aria-label="Close" aria-hidden="true">
 				<button class="close" aria-label="Close" @click.stop="close" />
 			</span>
 		</template>

--- a/client/components/Chat.vue
+++ b/client/components/Chat.vue
@@ -89,7 +89,7 @@
 					</div>
 				</div>
 				<div v-else class="chat-content">
-					<div
+					<button
 						:class="[
 							'scroll-down tooltipped tooltipped-w tooltipped-no-touch',
 							{'scroll-down-shown': !channel.scrolledToBottom},
@@ -98,7 +98,7 @@
 						@click="messageList?.jumpToBottom()"
 					>
 						<div class="scroll-down-arrow" />
-					</div>
+					</button>
 					<ChatUserList v-if="channel.type === 'channel'" :channel="channel" />
 					<MessageList
 						ref="messageList"

--- a/client/components/ChatInput.vue
+++ b/client/components/ChatInput.vue
@@ -2,6 +2,7 @@
 	<form id="form" method="post" action="" @submit.prevent="onSubmit">
 		<span id="upload-progressbar" />
 		<span id="nick">{{ network.nick }}</span>
+		<label for="input" class="sr-only">Message input</label>
 		<textarea
 			id="input"
 			ref="input"
@@ -10,7 +11,7 @@
 			enterkeyhint="send"
 			:value="channel.pendingMessage"
 			:placeholder="getInputPlaceholder(channel)"
-			:aria-label="getInputPlaceholder(channel)"
+			aria-label="Message input"
 			@input="setPendingMessage"
 			@keypress.enter.exact.prevent="onSubmit"
 			@blur="onBlur"
@@ -41,6 +42,7 @@
 			id="submit-tooltip"
 			class="tooltipped tooltipped-w tooltipped-no-touch"
 			aria-label="Send message"
+			role="presentation"
 		>
 			<button
 				id="submit"

--- a/client/components/ChatInput.vue
+++ b/client/components/ChatInput.vue
@@ -11,7 +11,6 @@
 			enterkeyhint="send"
 			:value="channel.pendingMessage"
 			:placeholder="getInputPlaceholder(channel)"
-			aria-label="Message input"
 			@input="setPendingMessage"
 			@keypress.enter.exact.prevent="onSubmit"
 			@blur="onBlur"

--- a/client/components/ChatInput.vue
+++ b/client/components/ChatInput.vue
@@ -41,8 +41,7 @@
 		<span
 			id="submit-tooltip"
 			class="tooltipped tooltipped-w tooltipped-no-touch"
-			aria-label="Send message"
-			role="presentation"
+			data-tooltip="Send message"
 		>
 			<button
 				id="submit"

--- a/client/components/NetworkList.vue
+++ b/client/components/NetworkList.vue
@@ -17,7 +17,6 @@
 				placeholder="Jump to..."
 				type="search"
 				class="search input mousetrap"
-				aria-label="Search among the channel list"
 				tabindex="-1"
 				@input="setSearchText"
 				@keydown.up="navigateResults($event, -1)"

--- a/client/components/NetworkList.vue
+++ b/client/components/NetworkList.vue
@@ -9,7 +9,9 @@
 	</div>
 	<div v-else ref="networklist" role="navigation" aria-label="Network and Channel list">
 		<div class="jump-to-input">
+			<label for="channel-search-input" class="sr-only">Search among the channel list</label>
 			<input
+				id="channel-search-input"
 				ref="searchInput"
 				:value="searchText"
 				placeholder="Jump to..."

--- a/client/css/style.css
+++ b/client/css/style.css
@@ -1278,9 +1278,6 @@ textarea.input {
 	transform: translateY(16px);
 	transition: transform 0.2s, opacity 0.2s;
 	cursor: pointer;
-	background: none;
-	border: none;
-	padding: 0;
 }
 
 .scroll-down:focus:not(:focus-visible)::before,

--- a/client/css/style.css
+++ b/client/css/style.css
@@ -2,6 +2,12 @@
 @import "fontawesome.css";
 @import "../../node_modules/primer-tooltips/build/build.css";
 
+/* Allow tooltips via data-tooltip instead of aria-label to avoid
+   duplicating accessible names on wrapper + child elements */
+.tooltipped[data-tooltip]::after {
+	content: attr(data-tooltip);
+}
+
 :root {
 	/* Main text color */
 	--body-color: #222;

--- a/client/css/style.css
+++ b/client/css/style.css
@@ -1283,6 +1283,11 @@ textarea.input {
 	padding: 0;
 }
 
+.scroll-down:focus:not(:focus-visible)::before,
+.scroll-down:focus:not(:focus-visible)::after {
+	display: none;
+}
+
 .scroll-down-shown {
 	opacity: 1;
 	transform: none;

--- a/client/css/style.css
+++ b/client/css/style.css
@@ -1272,6 +1272,10 @@ textarea.input {
 	transform: translateY(16px);
 	transition: transform 0.2s, opacity 0.2s;
 	cursor: pointer;
+	background: none;
+	padding: 0;
+	border: none;
+	appearance: none;
 }
 
 .scroll-down-shown {

--- a/client/css/style.css
+++ b/client/css/style.css
@@ -1279,9 +1279,8 @@ textarea.input {
 	transition: transform 0.2s, opacity 0.2s;
 	cursor: pointer;
 	background: none;
-	padding: 0;
 	border: none;
-	appearance: none;
+	padding: 0;
 }
 
 .scroll-down-shown {


### PR DESCRIPTION
Fixes #4862, #4863, #4864, #4865, #4866


instead of using `aria-label`, we can use `data-tooltip`  to avoid duplicating their names in the a11y tree

the scroll down button looks fine:
<img width="670" height="228" alt="image" src="https://github.com/user-attachments/assets/d1b3e7b9-1c0f-477b-a0f8-c7d96684b4f4" />
