### PR TITLE
fix: send credentials when using PWA installation behind Cloudflare Access

### DIFF
--- a/client/index.html.tpl
+++ b/client/index.html.tpl
@@ -24,7 +24,7 @@
 	<!-- Safari pinned tab icon -->
 	<link rel="mask-icon" href="img/icon-black-transparent-bg.svg" color="#415364">
 
-	<link rel="manifest" href="thelounge.webmanifest">
+	<link rel="manifest" href="thelounge.webmanifest" crossorigin="use-credentials">
 
 	<!-- iPhone 4, iPhone 4s, iPhone 5, iPhone 5c, iPhone 5s, iPhone 6, iPhone 6s, iPhone 7, iPhone 7s, iPhone8 -->
 	<link rel="apple-touch-icon" sizes="120x120" href="img/logo-grey-bg-120x120px.png">


### PR DESCRIPTION
Add crossorigin="use-credentials" to the manifest link tag so the browser includes authentication cookies when fetching the web manifest. Without this, Cloudflare Access redirect to the credentialless manifest request to a login page, which blocks PWA installation.

https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/crossorigin#use-credentials

Fixes #5032