### PR TITLE
fix: hide Account settings tab on public instance, sometimes hide General

### DIFF
--- a/client/components/Settings/Navigation.vue
+++ b/client/components/Settings/Navigation.vue
@@ -3,10 +3,10 @@
 	<aside class="settings-menu">
 		<h2>Settings</h2>
 		<ul role="navigation" aria-label="Settings tabs">
-			<SettingTabItem name="General" class-name="general" to="" />
+			<SettingTabItem v-if="showGeneral" name="General" class-name="general" to="" />
 			<SettingTabItem name="Appearance" class-name="appearance" to="appearance" />
 			<SettingTabItem name="Notifications" class-name="notifications" to="notifications" />
-			<SettingTabItem name="Account" class-name="account" to="account" />
+			<SettingTabItem v-if="!isPublic" name="Account" class-name="account" to="account" />
 		</ul>
 	</aside>
 </template>
@@ -93,11 +93,18 @@
 <script lang="ts">
 import SettingTabItem from "./SettingTabItem.vue";
 import {defineComponent} from "vue";
+import {useStore} from "../../js/store";
 
 export default defineComponent({
 	name: "SettingsTabs",
 	components: {
 		SettingTabItem,
+	},
+	setup() {
+		const store = useStore();
+		const isPublic = store.state.serverConfiguration?.public;
+		const showGeneral = !isPublic || store.state.serverConfiguration?.fileUpload;
+		return {isPublic, showGeneral};
 	},
 });
 </script>

--- a/client/js/router.ts
+++ b/client/js/router.ts
@@ -48,6 +48,16 @@ const router = createRouter({
 					name: "General",
 					path: "",
 					component: GeneralSettings,
+					beforeEnter(_to, _from, next) {
+						const config = store.state.serverConfiguration;
+
+						if (config?.public && !config?.fileUpload) {
+							next({name: "Appearance"});
+							return;
+						}
+
+						next();
+					},
 				},
 				{
 					name: "Appearance",
@@ -59,6 +69,14 @@ const router = createRouter({
 					path: "account",
 					component: AccountSettings,
 					props: true,
+					beforeEnter(_to, _from, next) {
+						if (store.state.serverConfiguration?.public) {
+							next({name: "Appearance"});
+							return;
+						}
+
+						next();
+					},
 				},
 				{
 					name: "Notifications",

--- a/client/js/router.ts
+++ b/client/js/router.ts
@@ -48,16 +48,6 @@ const router = createRouter({
 					name: "General",
 					path: "",
 					component: GeneralSettings,
-					beforeEnter(_to, _from, next) {
-						const config = store.state.serverConfiguration;
-
-						if (config?.public && !config?.fileUpload) {
-							next({name: "Appearance"});
-							return;
-						}
-
-						next();
-					},
 				},
 				{
 					name: "Appearance",
@@ -69,14 +59,6 @@ const router = createRouter({
 					path: "account",
 					component: AccountSettings,
 					props: true,
-					beforeEnter(_to, _from, next) {
-						if (store.state.serverConfiguration?.public) {
-							next({name: "Appearance"});
-							return;
-						}
-
-						next();
-					},
 				},
 				{
 					name: "Notifications",


### PR DESCRIPTION
on public TL instances like the demo, this is what the account and general tabs look like in Firefox:
 
| General | Account |
|--------|--------|
| <img width="600" height="auto" alt="image" src="https://github.com/user-attachments/assets/6cb1b9a2-da93-4412-893a-e70004376705" /> | <img width="600" height="auto" alt="image" src="https://github.com/user-attachments/assets/429f8c1a-4b38-49b4-bb14-b3a935860aa7" /> | 

1. we should just always hide account if mode is public, its useless
2. if file uploads are off, there's nothing to show in General except the native app install, which i figure is fine/not really necessary for public instances (and isn't supported by Firefox, hence the blankness)

