### PR TITLE
workflows: don't run on push and PR for every branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,11 @@ name: Build
 permissions:
   contents: read
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   build:


### PR DESCRIPTION
<img width="1182" height="324" alt="image" src="https://github.com/user-attachments/assets/1ee3021f-76d8-465d-a100-73cae9a0a0de" />

Right now we run identical workflows twice for every PR. instead, we should run on `push` on main and on `pull_request` for everything else. 