### PR TITLE
changelog: fix handling now non-existent optionalDependencies

### DIFF
--- a/scripts/changelog.js
+++ b/scripts/changelog.js
@@ -595,7 +595,7 @@ ${printList(items)}
 
 const dependencies = Object.keys(packageJson.dependencies);
 const devDependencies = Object.keys(packageJson.devDependencies);
-const optionalDependencies = Object.keys(packageJson.optionalDependencies);
+const optionalDependencies = Object.keys(packageJson.optionalDependencies || {});
 
 // Returns the package.json section in which that package exists, or undefined
 // if that package is not listed there.


### PR DESCRIPTION
#5055 removed the `optionalDependencies` field