### PR TITLE
fix: fix inverted boolean check with expand & collapse

### DIFF
--- a/server/server.ts
+++ b/server/server.ts
@@ -606,7 +606,7 @@ function initializeClient(
 	// so there's no need to handle msg:preview:toggle
 	if (!Config.values.public) {
 		socket.on("msg:preview:toggle", (data) => {
-			if (_.isPlainObject(data)) {
+			if (!_.isPlainObject(data)) {
 				return;
 			}
 


### PR DESCRIPTION
Introduced in https://github.com/thelounge/thelounge/commit/551f85ea51e3cacc9fb8a8331866448641781b38?w=1

If you `/expand` (or `/collapse`) and reload, the state is not persisted as its not stored on the server. We didn't notice as the client logic is correct. 


h/t @xPaw and claude for finding