### PR TITLE
fix /mute not persisting, case-insensitive channel check

### DIFF
--- a/server/plugins/inputs/mute.ts
+++ b/server/plugins/inputs/mute.ts
@@ -15,7 +15,8 @@ function args_to_channels(network: Network, args: string[]) {
 	const targets: Chan[] = [];
 
 	for (const arg of args) {
-		const target = network.channels.find((c) => c.name === arg);
+		const argLower = arg.toLowerCase();
+		const target = network.channels.find((c) => c.name.toLowerCase() === argLower);
 
 		if (target) {
 			targets.push(target);
@@ -43,6 +44,7 @@ const input: PluginInputHandler = function (network, chan, cmd, args) {
 
 	if (args.length === 0) {
 		change_mute_state(client, chan, valueToSet);
+		client.save();
 		return;
 	}
 
@@ -66,6 +68,8 @@ const input: PluginInputHandler = function (network, chan, cmd, args) {
 	for (const target of targets) {
 		change_mute_state(client, target, valueToSet);
 	}
+
+	client.save();
 };
 
 export default {


### PR DESCRIPTION
Found by claude:

```
server/plugins/inputs/mute.ts — /mute slash command never persists. Missing client.save(). Mutes set via the command vanish on restart. The socket handler (server/server.ts:768-797) does save.

server/plugins/inputs/mute.ts:18 — /mute #Foo fails when channel was joined as #foo. Uses case-sensitive c.name === arg; IRC channel names are case-insensitive.
```