### PR TITLE
fix: escape user-supplied LDAP filter value as per RFC 4515

### DIFF
--- a/server/plugins/auth/ldap.ts
+++ b/server/plugins/auth/ldap.ts
@@ -7,7 +7,7 @@ import type {AuthHandler} from "../auth";
 
 // Escape LDAP filter assertion values per RFC 4515 section 3:
 // https://datatracker.ietf.org/doc/html/rfc4515#section-3
-function escapeLdapFilter(value: string): string {
+export function escapeLdapFilter(value: string): string {
 	return value.replace(/[\\*()\0]/g, (c) => {
 		return "\\" + c.charCodeAt(0).toString(16).padStart(2, "0");
 	});

--- a/server/plugins/auth/ldap.ts
+++ b/server/plugins/auth/ldap.ts
@@ -5,6 +5,14 @@ import log from "../../log";
 import Config from "../../config";
 import type {AuthHandler} from "../auth";
 
+// Escape LDAP filter assertion values per RFC 4515 section 3:
+// https://datatracker.ietf.org/doc/html/rfc4515#section-3
+function escapeLdapFilter(value: string): string {
+	return value.replace(/[\\*()\0]/g, (c) => {
+		return "\\" + c.charCodeAt(0).toString(16).padStart(2, "0");
+	});
+}
+
 function ldapAuthCommon(
 	user: string,
 	bindDN: string,
@@ -60,6 +68,7 @@ function advancedLdapAuth(user: string, password: string, callback: (success: bo
 
 	const config = Config.values;
 	const userDN = user.replace(/([,\\/#+<>;"= ])/g, "\\$1");
+	const userFilterValue = escapeLdapFilter(user);
 
 	const ldapclient = ldap.createClient({
 		url: config.ldap.url,
@@ -69,7 +78,7 @@ function advancedLdapAuth(user: string, password: string, callback: (success: bo
 	const base = config.ldap.searchDN.base;
 	const searchOptions: SearchOptions = {
 		scope: config.ldap.searchDN.scope,
-		filter: `(&(${config.ldap.primaryKey}=${userDN})${config.ldap.searchDN.filter})`,
+		filter: `(&(${config.ldap.primaryKey}=${userFilterValue})${config.ldap.searchDN.filter})`,
 		attributes: ["dn"],
 	};
 

--- a/test/plugins/auth/ldap.ts
+++ b/test/plugins/auth/ldap.ts
@@ -1,5 +1,5 @@
 import log from "../../../server/log";
-import ldapAuth from "../../../server/plugins/auth/ldap";
+import ldapAuth, {escapeLdapFilter} from "../../../server/plugins/auth/ldap";
 import Config from "../../../server/config";
 import ldap from "ldapjs";
 import {expect} from "chai";
@@ -180,5 +180,50 @@ describe("LDAP authentication plugin", function () {
 	describe("Advanced LDAP authentication (DN found by a prior search query)", function () {
 		delete Config.values.ldap.baseDN;
 		testLdapAuth();
+
+		it("should reject filter-injection usernames (RFC 4515)", function (done) {
+			let warning = "";
+			const warnLogStub = sinon
+				.stub(log, "warn")
+				.callsFake(TestUtil.sanitizeLog((str) => (warning += str)));
+
+			// Without proper escaping, "*" becomes a presence wildcard in the
+			// search filter, causing the mock server to return johndoe's DN;
+			// combined with johndoe's password this would bypass the username
+			// check. With RFC 4515 escaping, "*" is sent as "\2a" and matches
+			// no uid, so auth must fail.
+			ldapAuth.auth({} as ClientManager, true as any, "*", correctPassword, function (valid) {
+				expect(valid).to.equal(false);
+				expect(warning).to.contain("LDAP Search did not find anything");
+				warnLogStub.restore();
+				done();
+			});
+		});
+	});
+
+	describe("escapeLdapFilter (RFC 4515)", function () {
+		it("escapes the five required octets", function () {
+			expect(escapeLdapFilter("*")).to.equal("\\2a");
+			expect(escapeLdapFilter("(")).to.equal("\\28");
+			expect(escapeLdapFilter(")")).to.equal("\\29");
+			expect(escapeLdapFilter("\\")).to.equal("\\5c");
+			expect(escapeLdapFilter("\0")).to.equal("\\00");
+		});
+
+		it("leaves ordinary characters untouched", function () {
+			expect(escapeLdapFilter("johndoe")).to.equal("johndoe");
+			expect(escapeLdapFilter("john.doe+tag@example.com")).to.equal(
+				"john.doe+tag@example.com"
+			);
+		});
+
+		it("escapes every occurrence, not just the first", function () {
+			expect(escapeLdapFilter("a*b*c")).to.equal("a\\2ab\\2ac");
+			expect(escapeLdapFilter("()()")).to.equal("\\28\\29\\28\\29");
+		});
+
+		it("neutralizes a classic injection payload", function () {
+			expect(escapeLdapFilter("*)(uid=*")).to.equal("\\2a\\29\\28uid=\\2a");
+		});
 	});
 });


### PR DESCRIPTION
Pointed out by claude and @xPaw 

https://datatracker.ietf.org/doc/html/rfc4515#section-3

Tests written by Claude
