### PR TITLE
tests/coverage: ignore test/client and test/public, fix running coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build:client": "webpack",
     "build:server": "tsc -p server/tsconfig.json",
     "build": "run-p --aggregate-output build:client build:server",
-    "coverage": "run-s test:* && nyc --nycrc-path=test/.nycrc-report.json report",
+    "coverage": "webpack --mode=development && cross-env NODE_ENV=test TS_NODE_PROJECT='./test/tsconfig.json' nyc --nycrc-path=test/.nycrc-mocha.json mocha --config=test/.mocharc.yml 'test/**/*.ts' && nyc --nycrc-path=test/.nycrc-report.json report",
     "dev": "cross-env NODE_ENV=development ts-node --project server/tsconfig.json server/index.ts start --dev",
     "format:prettier": "prettier --write \"**/*.*\"",
     "generate:config:doc": "ts-node scripts/generate-config-doc.js",

--- a/test/.mocharc.yml
+++ b/test/.mocharc.yml
@@ -2,7 +2,9 @@ color: true
 check-leaks: true
 recursive: true
 reporter: dot
-ignore: "test/client/**"
+ignore:
+  - "test/client/**"
+  - "test/public/**"
 extension: ["ts", "js"]
 node-option:
   - "import=tsx"


### PR DESCRIPTION
we need to ignore webpack's build output / bundles in `public/`

fixes `yarn coverage`

Issue introduced in https://github.com/thelounge/thelounge/commit/a12ddc75