### PR TITLE
fix order of messages with identical timestamps

### DIFF
--- a/server/plugins/messageStorage/sqlite.ts
+++ b/server/plugins/messageStorage/sqlite.ts
@@ -381,7 +381,7 @@ class SqliteMessageStorage implements SearchableMessageStorage {
 
 		const rows = this.database
 			.prepare(
-				"SELECT msg, type, time FROM messages WHERE network = ? AND channel = ? ORDER BY time DESC LIMIT ?"
+				"SELECT msg, type, time FROM messages WHERE network = ? AND channel = ? ORDER BY time DESC, id DESC LIMIT ?"
 			)
 			.all(network.uuid, channel.name.toLowerCase(), limit) as {
 			msg: string;
@@ -428,7 +428,7 @@ class SqliteMessageStorage implements SearchableMessageStorage {
 
 		const maxResults = 100;
 
-		select += " ORDER BY time DESC LIMIT ? OFFSET ? ";
+		select += " ORDER BY time DESC, id DESC LIMIT ? OFFSET ? ";
 		params.push(maxResults);
 		params.push(query.offset);
 


### PR DESCRIPTION
When sending a message that is too long, thelounge will split it up into multiple PRIVMSGs. These will be saved to the sqlite database with identical timestamps. Thelounge retrieves messages from the DB using `ORDER BY time DESC`, which under certain circumstances causes these messages to be loaded and displayed in the wrong order. This PR addresses that by also ordering by id (only affects messages with identical timestamps).

Before:
<img width="1050" height="107" alt="image" src="https://github.com/user-attachments/assets/54fac085-a989-48fa-9538-1faecb09aa44" />

After:
<img width="1058" height="114" alt="image" src="https://github.com/user-attachments/assets/0bb99db9-5a5d-481d-b799-87162d0535e8" />
