### PR TITLE
router: add `beforeEnter` for `/settings` to avoid rendering empty pages

### DIFF
--- a/client/components/Settings/Navigation.vue
+++ b/client/components/Settings/Navigation.vue
@@ -94,6 +94,7 @@
 import SettingTabItem from "./SettingTabItem.vue";
 import {defineComponent} from "vue";
 import {useStore} from "../../js/store";
+import {showGeneralSettings} from "../../js/helpers/settingsTabs";
 
 export default defineComponent({
 	name: "SettingsTabs",
@@ -103,8 +104,7 @@ export default defineComponent({
 	setup() {
 		const store = useStore();
 		const isPublic = store.state.serverConfiguration?.public;
-		const showGeneral = !isPublic || store.state.serverConfiguration?.fileUpload;
-		return {isPublic, showGeneral};
+		return {isPublic, showGeneral: showGeneralSettings()};
 	},
 });
 </script>

--- a/client/components/Settings/Navigation.vue
+++ b/client/components/Settings/Navigation.vue
@@ -94,7 +94,7 @@
 import SettingTabItem from "./SettingTabItem.vue";
 import {defineComponent} from "vue";
 import {useStore} from "../../js/store";
-import {showGeneralSettings} from "../../js/helpers/settingsTabs";
+import {shouldShowGeneralSettings} from "../../js/helpers/settingsTabs";
 
 export default defineComponent({
 	name: "SettingsTabs",
@@ -104,7 +104,7 @@ export default defineComponent({
 	setup() {
 		const store = useStore();
 		const isPublic = store.state.serverConfiguration?.public;
-		return {isPublic, showGeneral: showGeneralSettings()};
+		return {isPublic, showGeneral: shouldShowGeneralSettings()};
 	},
 });
 </script>

--- a/client/js/helpers/settingsTabs.ts
+++ b/client/js/helpers/settingsTabs.ts
@@ -1,0 +1,6 @@
+import {store} from "../store";
+
+export function showGeneralSettings() {
+	const config = store.state.serverConfiguration;
+	return !config?.public || !!config?.fileUpload;
+}

--- a/client/js/helpers/settingsTabs.ts
+++ b/client/js/helpers/settingsTabs.ts
@@ -1,6 +1,6 @@
 import {store} from "../store";
 
-export function showGeneralSettings() {
+export function shouldShowGeneralSettings() {
 	const config = store.state.serverConfiguration;
 	return !config?.public || !!config?.fileUpload;
 }

--- a/client/js/router.ts
+++ b/client/js/router.ts
@@ -16,6 +16,7 @@ import GeneralSettings from "../components/Settings/General.vue";
 import AccountSettings from "../components/Settings/Account.vue";
 import NotificationSettings from "../components/Settings/Notifications.vue";
 import {ClientChan} from "./types";
+import {showGeneralSettings} from "./helpers/settingsTabs";
 
 const router = createRouter({
 	history: createWebHashHistory(),
@@ -48,6 +49,14 @@ const router = createRouter({
 					name: "General",
 					path: "",
 					component: GeneralSettings,
+					beforeEnter(to, from, next) {
+						if (!showGeneralSettings()) {
+							next({name: "Appearance"});
+							return;
+						}
+
+						next();
+					},
 				},
 				{
 					name: "Appearance",

--- a/client/js/router.ts
+++ b/client/js/router.ts
@@ -16,7 +16,7 @@ import GeneralSettings from "../components/Settings/General.vue";
 import AccountSettings from "../components/Settings/Account.vue";
 import NotificationSettings from "../components/Settings/Notifications.vue";
 import {ClientChan} from "./types";
-import {showGeneralSettings} from "./helpers/settingsTabs";
+import {shouldShowGeneralSettings} from "./helpers/settingsTabs";
 
 const router = createRouter({
 	history: createWebHashHistory(),
@@ -50,7 +50,7 @@ const router = createRouter({
 					path: "",
 					component: GeneralSettings,
 					beforeEnter(to, from, next) {
-						if (!showGeneralSettings()) {
+						if (!shouldShowGeneralSettings()) {
 							next({name: "Appearance"});
 							return;
 						}


### PR DESCRIPTION
https://github.com/thelounge/thelounge/pull/5063 hid the general tab if it had nothing to show, but we removed the route guard. turns out, we need it to avoid taking you to an empty settings page (reproducible on https://demo.thelounge.chat/) 

<img width="1512" height="835" alt="Screenshot 2026-04-18 at 5 16 21 PM" src="https://github.com/user-attachments/assets/ebc4b3ab-d3f3-4bd3-ae31-b276d20db5ea" />
