### PR TITLE
uploader: change order mime type translation

### DIFF
--- a/server/plugins/uploader.ts
+++ b/server/plugins/uploader.ts
@@ -11,16 +11,25 @@ import contentDisposition from "content-disposition";
 import type {Socket} from "socket.io";
 import {Request, Response} from "express";
 
-// Map of allowed mime types to their respecive default filenames
-// that will be rendered in browser without forcing them to be downloaded
+// Map of mime types to their more common aliases
+const mimeAliases: {[key: string]: string} = {
+	"audio/vnd.wave": "audio/wav",
+	"audio/x-flac": "audio/flac",
+	"audio/x-m4a": "audio/mp4",
+	"video/quicktime": "video/mp4",
+};
+
+// Map of allowed  mime types to their respecive default filenames
+// that will be rendered in browser without forcing them to be downloaded.
+// Use post alias mime types.
 const inlineContentDispositionTypes = {
 	"application/ogg": "media.ogx",
 	"audio/midi": "audio.midi",
 	"audio/mpeg": "audio.mp3",
 	"audio/ogg": "audio.ogg",
-	"audio/vnd.wave": "audio.wav",
-	"audio/x-flac": "audio.flac",
-	"audio/x-m4a": "audio.m4a",
+	"audio/wav": "audio.wav",
+	"audio/flac": "audio.flac",
+	"audio/mp4": "audio.m4a",
 	"image/bmp": "image.bmp",
 	"image/gif": "image.gif",
 	"image/jpeg": "image.jpg",
@@ -95,6 +104,10 @@ class Uploader {
 			return res.status(404).send("Not found");
 		}
 
+		// Send a more common mime type for audio files
+		// so that browsers can play them correctly
+		detectedMimeType = mimeAliases[detectedMimeType] || detectedMimeType;
+
 		// Force a download in the browser if it's not an allowed type (binary or otherwise unknown)
 		let slug = req.params.slug;
 		const isInline = detectedMimeType in inlineContentDispositionTypes;
@@ -109,18 +122,6 @@ class Uploader {
 				fallback: false,
 				type: disposition,
 			});
-		}
-
-		// Send a more common mime type for audio files
-		// so that browsers can play them correctly
-		if (detectedMimeType === "audio/vnd.wave") {
-			detectedMimeType = "audio/wav";
-		} else if (detectedMimeType === "audio/x-flac") {
-			detectedMimeType = "audio/flac";
-		} else if (detectedMimeType === "audio/x-m4a") {
-			detectedMimeType = "audio/mp4";
-		} else if (detectedMimeType === "video/quicktime") {
-			detectedMimeType = "video/mp4";
 		}
 
 		res.setHeader("Content-Disposition", disposition);


### PR DESCRIPTION
The upload maps some mime types onto more well-known ones. However it does so after the check whether it should set the inline disposition.
We need to do the translation first so that it gets matched against the mime type we actually send.