### PR TITLE
sqlite: add message history index

### DIFF
--- a/server/plugins/messageStorage/sqlite.ts
+++ b/server/plugins/messageStorage/sqlite.ts
@@ -11,8 +11,7 @@ import type {SearchableMessageStorage, DeletionRequest} from "./types";
 import Network from "../../models/network";
 import {SearchQuery, SearchResponse} from "../../../shared/types/storage";
 
-// set vacuum on migrations that free up space
-type Migration = {version: number; stmts: string[]; vacuum?: boolean};
+type Migration = {version: number; stmts: string[]};
 type Rollback = {version: number; rollback_forbidden?: boolean; stmts: string[]};
 
 export const currentSchemaVersion = 1780272000000; // use `new Date().getTime()`
@@ -44,7 +43,6 @@ const schema = [
 export const migrations: Migration[] = [
 	{
 		version: 1672236339873,
-		vacuum: true,
 		stmts: [
 			"CREATE TABLE messages_new (id INTEGER PRIMARY KEY AUTOINCREMENT, network TEXT, channel TEXT, time INTEGER, type TEXT, msg TEXT)",
 			"INSERT INTO messages_new(network, channel, time, type, msg) select network, channel, time, type, msg from messages order by time asc",
@@ -181,7 +179,7 @@ class SqliteMessageStorage implements SearchableMessageStorage {
 			.run(currentSchemaVersion.toString());
 	}
 
-	_run_migrations(dbVersion: number): boolean {
+	_run_migrations(dbVersion: number) {
 		log.info(
 			`sqlite messages schema version is out of date (${dbVersion} < ${currentSchemaVersion}). Running migrations, this may take a while.`
 		);
@@ -193,8 +191,6 @@ class SqliteMessageStorage implements SearchableMessageStorage {
 		}
 
 		this.update_version_in_db();
-
-		return to_execute.some((migration) => migration.vacuum);
 	}
 
 	run_migrations() {
@@ -207,13 +203,12 @@ class SqliteMessageStorage implements SearchableMessageStorage {
 		}
 
 		this.database.exec("BEGIN EXCLUSIVE TRANSACTION");
-		let needsVacuum = false;
 
 		try {
 			if (version === 0) {
 				this.setup_new_db();
 			} else {
-				needsVacuum = this._run_migrations(version);
+				this._run_migrations(version);
 			}
 
 			this.insert_rollback_since(version);
@@ -223,10 +218,7 @@ class SqliteMessageStorage implements SearchableMessageStorage {
 		}
 
 		this.database.exec("COMMIT");
-
-		if (needsVacuum) {
-			this.vacuum();
-		}
+		this.database.exec("VACUUM");
 	}
 
 	// helper method that vacuums the db, meant to be used by migration related cli commands
@@ -283,11 +275,12 @@ class SqliteMessageStorage implements SearchableMessageStorage {
 		this.database.prepare("delete from migrations where migrations.version > ?").run(version);
 	}
 
-	_downgrade_to(version: number): number {
+	// returns whether any rollback statements were executed
+	_downgrade_to(version: number): boolean {
 		const _rollbacks = this.fetch_rollbacks(version);
 
 		if (_rollbacks.length === 0) {
-			return version;
+			return false;
 		}
 
 		const forbidden = _rollbacks.find((item) => item.rollback_forbidden);
@@ -305,7 +298,7 @@ class SqliteMessageStorage implements SearchableMessageStorage {
 		this.delete_migrations_older_than(version);
 		this.update_version_in_db();
 
-		return version;
+		return true;
 	}
 
 	downgrade_to(version: number): number {
@@ -315,17 +308,22 @@ class SqliteMessageStorage implements SearchableMessageStorage {
 
 		this.database.exec("BEGIN EXCLUSIVE TRANSACTION");
 
-		let new_version: number;
+		let rolled_back = false;
 
 		try {
-			new_version = this._downgrade_to(version);
+			rolled_back = this._downgrade_to(version);
 		} catch (err) {
 			this.database.exec("ROLLBACK");
 			throw err;
 		}
 
 		this.database.exec("COMMIT");
-		return new_version;
+
+		if (rolled_back) {
+			this.vacuum();
+		}
+
+		return version;
 	}
 
 	downgrade() {

--- a/server/plugins/messageStorage/sqlite.ts
+++ b/server/plugins/messageStorage/sqlite.ts
@@ -11,10 +11,11 @@ import type {SearchableMessageStorage, DeletionRequest} from "./types";
 import Network from "../../models/network";
 import {SearchQuery, SearchResponse} from "../../../shared/types/storage";
 
-type Migration = {version: number; stmts: string[]};
+// set vacuum on migrations that free up space
+type Migration = {version: number; stmts: string[]; vacuum?: boolean};
 type Rollback = {version: number; rollback_forbidden?: boolean; stmts: string[]};
 
-export const currentSchemaVersion = 1703322560448; // use `new Date().getTime()`
+export const currentSchemaVersion = 1780272000000; // use `new Date().getTime()`
 
 // Desired schema, adapt to the newest version and add migrations to the array below
 const schema = [
@@ -31,9 +32,10 @@ const schema = [
 		step INTEGER NOT NULL,
 		statement TEXT NOT NULL
 	)`,
-	"CREATE INDEX network_channel ON messages (network, channel)",
 	"CREATE INDEX time ON messages (time)",
 	"CREATE INDEX msg_type_idx on messages (type)", // needed for efficient storageCleaner queries
+	// needed for efficient getMessages queries
+	"CREATE INDEX network_channel_time ON messages (network, channel, time)",
 ];
 
 // the migrations will be executed in an exclusive transaction as a whole
@@ -42,6 +44,7 @@ const schema = [
 export const migrations: Migration[] = [
 	{
 		version: 1672236339873,
+		vacuum: true,
 		stmts: [
 			"CREATE TABLE messages_new (id INTEGER PRIMARY KEY AUTOINCREMENT, network TEXT, channel TEXT, time INTEGER, type TEXT, msg TEXT)",
 			"INSERT INTO messages_new(network, channel, time, type, msg) select network, channel, time, type, msg from messages order by time asc",
@@ -71,6 +74,14 @@ export const migrations: Migration[] = [
 		version: 1703322560448,
 		stmts: ["CREATE INDEX msg_type_idx on messages (type)"],
 	},
+	{
+		// replaces network_channel and also covers the sort in getMessages
+		version: 1780272000000,
+		stmts: [
+			"CREATE INDEX IF NOT EXISTS network_channel_time ON messages (network, channel, time)",
+			"DROP INDEX IF EXISTS network_channel",
+		],
+	},
 ];
 
 // down migrations need to restore the state of the prior version.
@@ -88,7 +99,18 @@ export const rollbacks: Rollback[] = [
 		version: 1703322560448,
 		stmts: ["drop INDEX msg_type_idx"],
 	},
+	{
+		version: 1780272000000,
+		stmts: [
+			"DROP INDEX IF EXISTS network_channel_time",
+			"CREATE INDEX IF NOT EXISTS network_channel ON messages (network, channel)",
+		],
+	},
 ];
+
+// exported for tests
+export const getMessagesQuery =
+	"SELECT msg, type, time FROM messages WHERE network = ? AND channel = ? ORDER BY time DESC, id DESC LIMIT ?";
 
 class SqliteMessageStorage implements SearchableMessageStorage {
 	isEnabled: boolean;
@@ -159,9 +181,9 @@ class SqliteMessageStorage implements SearchableMessageStorage {
 			.run(currentSchemaVersion.toString());
 	}
 
-	_run_migrations(dbVersion: number) {
+	_run_migrations(dbVersion: number): boolean {
 		log.info(
-			`sqlite messages schema version is out of date (${dbVersion} < ${currentSchemaVersion}). Running migrations.`
+			`sqlite messages schema version is out of date (${dbVersion} < ${currentSchemaVersion}). Running migrations, this may take a while.`
 		);
 
 		const to_execute = necessaryMigrations(dbVersion);
@@ -171,6 +193,8 @@ class SqliteMessageStorage implements SearchableMessageStorage {
 		}
 
 		this.update_version_in_db();
+
+		return to_execute.some((migration) => migration.vacuum);
 	}
 
 	run_migrations() {
@@ -183,12 +207,13 @@ class SqliteMessageStorage implements SearchableMessageStorage {
 		}
 
 		this.database.exec("BEGIN EXCLUSIVE TRANSACTION");
+		let needsVacuum = false;
 
 		try {
 			if (version === 0) {
 				this.setup_new_db();
 			} else {
-				this._run_migrations(version);
+				needsVacuum = this._run_migrations(version);
 			}
 
 			this.insert_rollback_since(version);
@@ -198,7 +223,10 @@ class SqliteMessageStorage implements SearchableMessageStorage {
 		}
 
 		this.database.exec("COMMIT");
-		this.database.exec("VACUUM");
+
+		if (needsVacuum) {
+			this.vacuum();
+		}
 	}
 
 	// helper method that vacuums the db, meant to be used by migration related cli commands
@@ -380,9 +408,7 @@ class SqliteMessageStorage implements SearchableMessageStorage {
 		const limit = Config.values.maxHistory < 0 ? 100000 : Config.values.maxHistory;
 
 		const rows = this.database
-			.prepare(
-				"SELECT msg, type, time FROM messages WHERE network = ? AND channel = ? ORDER BY time DESC, id DESC LIMIT ?"
-			)
+			.prepare(getMessagesQuery)
 			.all(network.uuid, channel.name.toLowerCase(), limit) as {
 			msg: string;
 			type: string;

--- a/test/plugins/sqlite.ts
+++ b/test/plugins/sqlite.ts
@@ -7,6 +7,7 @@ import {MessageType} from "../../shared/types/msg";
 import Config from "../../server/config";
 import MessageStorage, {
 	currentSchemaVersion,
+	getMessagesQuery,
 	migrations,
 	necessaryMigrations,
 	rollbacks,
@@ -89,6 +90,22 @@ describe("SQLite migrations", function () {
 		}
 
 		db.exec("COMMIT TRANSACTION");
+	});
+
+	it("migrated database serves getMessages from the index", function () {
+		const plan = db
+			.prepare(`EXPLAIN QUERY PLAN ${getMessagesQuery}`)
+			.all("8f650427-79a2-4950-b8af-94088b61b37c", "##linux", 100) as {detail: string}[];
+
+		const details = plan.map((row) => row.detail).join("\n");
+		expect(details).to.include("USING INDEX network_channel_time");
+		expect(details).to.not.include("TEMP B-TREE");
+	});
+
+	it("only vacuums after migrations that reclaim space", function () {
+		// the index migration doesn't free up any space, the table rebuild does
+		expect(necessaryMigrations(1703322560448).some((m) => m.vacuum)).to.be.false;
+		expect(necessaryMigrations(v1_schema_version).some((m) => m.vacuum)).to.be.true;
 	});
 
 	it("has working down-migrations", function () {
@@ -325,6 +342,17 @@ describe("SQLite Message Storage", function () {
 		} finally {
 			Config.values.maxHistory = originalMaxHistory;
 		}
+	});
+
+	it("getMessages uses the index instead of sorting the whole channel", function () {
+		// #5103
+		const plan = store.database
+			.prepare(`EXPLAIN QUERY PLAN ${getMessagesQuery}`)
+			.all("retrieval-order-test-network", "#channel", 10000) as {detail: string}[];
+
+		const details = plan.map((row) => row.detail).join("\n");
+		expect(details).to.include("USING INDEX network_channel_time");
+		expect(details).to.not.include("TEMP B-TREE");
 	});
 
 	it("should search messages", function () {

--- a/test/plugins/sqlite.ts
+++ b/test/plugins/sqlite.ts
@@ -102,12 +102,6 @@ describe("SQLite migrations", function () {
 		expect(details).to.not.include("TEMP B-TREE");
 	});
 
-	it("only vacuums after migrations that reclaim space", function () {
-		// the index migration doesn't free up any space, the table rebuild does
-		expect(necessaryMigrations(1703322560448).some((m) => m.vacuum)).to.be.false;
-		expect(necessaryMigrations(v1_schema_version).some((m) => m.vacuum)).to.be.true;
-	});
-
 	it("has working down-migrations", function () {
 		db.exec("BEGIN EXCLUSIVE TRANSACTION");
 


### PR DESCRIPTION
Fixes #5103

Today, `getMessages()` filters by `(network, channel)` but sorts by `time DESC, id DESC` and no index covers both (and a new one supersedes `network_channel`). This has always been an issue but https://github.com/thelounge/thelounge/pull/5055 made this code synchronous which exposed it.

|  | Before | After |
|--------|--------|--------|
| history load, 5 channels (4.4M rows total, busiest 3M) | 6.9s, event loop blocked | 80ms |
| single channel with 3M messages | 4.6s | 18ms |
| query plan | index scan + temp B-tree sort | index only |

