### PR TITLE
Attempt to clean up some loose `any` types

### DIFF
--- a/client/js/helpers/ircmessageparser/merge.ts
+++ b/client/js/helpers/ircmessageparser/merge.ts
@@ -72,12 +72,12 @@ function merge(
 
 	// Distribute the style fragments within the text parts
 	return allParts.map((part: Part) => {
-		const fragmentedPart = part as PartWithFragments;
-		fragmentedPart.fragments = styleFragments
-			.filter((fragment) => anyIntersection(fragmentedPart, fragment))
-			.map((fragment) => assign(fragmentedPart, fragment));
-
-		return fragmentedPart;
+		return {
+			...part,
+			fragments: styleFragments
+				.filter((fragment) => anyIntersection(part, fragment))
+				.map((fragment) => assign(part, fragment)),
+		};
 	});
 }
 

--- a/client/js/helpers/ircmessageparser/merge.ts
+++ b/client/js/helpers/ircmessageparser/merge.ts
@@ -71,12 +71,13 @@ function merge(
 	const allParts: MergedParts = [...parts, ...filled].sort(sortParts); // Sort all parts identified based on their position in the original text
 
 	// Distribute the style fragments within the text parts
-	return allParts.map((part: any) => {
-		part.fragments = styleFragments
-			.filter((fragment) => anyIntersection(part, fragment))
-			.map((fragment) => assign(part, fragment));
+	return allParts.map((part: Part) => {
+		const fragmentedPart = part as PartWithFragments;
+		fragmentedPart.fragments = styleFragments
+			.filter((fragment) => anyIntersection(fragmentedPart, fragment))
+			.map((fragment) => assign(fragmentedPart, fragment));
 
-		return part as PartWithFragments;
+		return fragmentedPart;
 	});
 }
 

--- a/client/js/router.ts
+++ b/client/js/router.ts
@@ -1,6 +1,6 @@
 import constants from "./constants";
 
-import {createRouter, createWebHashHistory} from "vue-router";
+import {createRouter, createWebHashHistory, RouteParamsRaw} from "vue-router";
 import SignIn from "../components/Windows/SignIn.vue";
 import Connect from "../components/Windows/Connect.vue";
 import Settings from "../components/Windows/Settings.vue";
@@ -164,7 +164,7 @@ router.afterEach((to) => {
 	}
 });
 
-async function navigate(routeName: string, params: any = {}) {
+async function navigate(routeName: string, params: RouteParamsRaw = {}) {
 	if (router.currentRoute.value.name) {
 		await router.push({name: routeName, params});
 	} else {

--- a/client/js/settings.ts
+++ b/client/js/settings.ts
@@ -162,7 +162,7 @@ export function createState() {
 	return state;
 }
 
-function normalizeConfig(obj: Record<string, typeof defaultConfig[keyof typeof defaultConfig]>) {
+function normalizeConfig(obj: typeof defaultConfig) {
 	const newConfig: Partial<typeof defaultConfig> = {};
 
 	for (const settingName in obj) {

--- a/client/js/settings.ts
+++ b/client/js/settings.ts
@@ -162,7 +162,7 @@ export function createState() {
 	return state;
 }
 
-function normalizeConfig(obj: any) {
+function normalizeConfig(obj: Record<string, typeof defaultConfig[keyof typeof defaultConfig]>) {
 	const newConfig: Partial<typeof defaultConfig> = {};
 
 	for (const settingName in obj) {

--- a/server/client.ts
+++ b/server/client.ts
@@ -460,7 +460,7 @@ class Client {
 
 	input(data: {target: number; text: string}) {
 		const client = this;
-		data.text.split("\n").forEach((line: string) => {
+		data.text.split("\n").forEach((line) => {
 			data.text = line;
 			client.inputLine(data);
 		});

--- a/server/client.ts
+++ b/server/client.ts
@@ -24,6 +24,7 @@ import {SearchQuery, SearchResponse} from "../shared/types/storage";
 import {SharedChan, ChanType} from "../shared/types/chan";
 import {SharedNetwork} from "../shared/types/network";
 import {ServerToClientEvents} from "../shared/types/socket-events";
+import {IncomingMessage} from "http";
 
 const events = [
 	"away",
@@ -63,16 +64,18 @@ type ClientPushSubscription = {
 	};
 };
 
+type AttachedClient = {
+	lastUse: number;
+	ip: string;
+	agent: string;
+	pushSubscription?: ClientPushSubscription;
+};
+
 export type UserConfig = {
 	log: boolean;
 	password: string;
 	sessions: {
-		[token: string]: {
-			lastUse: number;
-			ip: string;
-			agent: string;
-			pushSubscription?: ClientPushSubscription;
-		};
+		[token: string]: AttachedClient;
 	};
 	clientSettings: {
 		[key: string]: any;
@@ -340,7 +343,13 @@ class Client {
 		});
 	}
 
-	connectToNetwork(args: Record<string, any>, isStartup = false) {
+	connectToNetwork(
+		args:
+			| Record<keyof NetworkConfig, NetworkConfig[keyof NetworkConfig]>
+			| NetworkConfig
+			| {host: string; port: number; tls: boolean},
+		isStartup = false
+	) {
 		const client = this;
 
 		// Get channel id for lobby before creating other channels for nicer ids
@@ -405,7 +414,7 @@ class Client {
 		return crypto.createHash("sha512").update(token).digest("hex");
 	}
 
-	updateSession(token: string, ip: string, request: any) {
+	updateSession(token: string, ip: string, request: IncomingMessage) {
 		const client = this;
 		const agent = UAParser(request.headers["user-agent"] || "");
 		let friendlyAgent = "";
@@ -449,15 +458,15 @@ class Client {
 		});
 	}
 
-	input(data) {
+	input(data: {target: number; text: string}) {
 		const client = this;
-		data.text.split("\n").forEach((line) => {
+		data.text.split("\n").forEach((line: string) => {
 			data.text = line;
 			client.inputLine(data);
 		});
 	}
 
-	inputLine(data) {
+	inputLine(data: {target: number; text: string}) {
 		const client = this;
 		const target = client.find(data.target);
 
@@ -573,7 +582,7 @@ class Client {
 		);
 	}
 
-	more(data) {
+	more(data: {target: number; lastId: number; condensed: boolean}) {
 		const client = this;
 		const target = client.find(data.target);
 
@@ -628,7 +637,7 @@ class Client {
 		};
 	}
 
-	clearHistory(data) {
+	clearHistory(data: {target: number}) {
 		const client = this;
 		const target = client.find(data.target);
 
@@ -828,8 +837,11 @@ class Client {
 		}
 	}
 
-	// TODO: type session to this.attachedClients
-	registerPushSubscription(session: any, subscription: PushSubscriptionJSON, noSave = false) {
+	registerPushSubscription(
+		session: AttachedClient,
+		subscription: PushSubscriptionJSON,
+		noSave = false
+	) {
 		if (
 			!_.isPlainObject(subscription) ||
 			typeof subscription.endpoint !== "string" ||
@@ -839,7 +851,7 @@ class Client {
 			typeof subscription.keys.p256dh !== "string" ||
 			typeof subscription.keys.auth !== "string"
 		) {
-			session.pushSubscription = null;
+			session.pushSubscription = undefined;
 			return;
 		}
 

--- a/server/plugins/auth.ts
+++ b/server/plugins/auth.ts
@@ -29,7 +29,7 @@ export type Module = {
 // Always keep 'local' auth plugin at the end of the list; it should always be enabled.
 const plugins = [import("./auth/ldap"), import("./auth/local")];
 
-const toExport = {
+const toExport: Module = {
 	moduleName: "<module with no name>",
 
 	// Must override: implements authentication mechanism
@@ -67,7 +67,7 @@ const toExport = {
 			log.error("None of the auth plugins is enabled");
 		}
 	},
-} as Module;
+};
 
 function unimplemented(funcName: string) {
 	log.debug(

--- a/server/plugins/auth.ts
+++ b/server/plugins/auth.ts
@@ -11,6 +11,20 @@ export type AuthHandler = (
 	callback: (success: boolean) => void
 ) => void;
 
+export type Module = {
+	moduleName: string;
+	auth: (
+		manager: ClientManager | null,
+		client: Client | boolean | undefined,
+		user: string,
+		password: string,
+		callback: (success: boolean) => void
+	) => void;
+	loadUsers: (users?: string[], callbackLoadUser?: (user: string) => void) => boolean;
+	initialized: boolean;
+	initialize: () => Promise<void>;
+};
+
 // The order defines priority: the first available plugin is used.
 // Always keep 'local' auth plugin at the end of the list; it should always be enabled.
 const plugins = [import("./auth/ldap"), import("./auth/local")];
@@ -28,7 +42,7 @@ const toExport = {
 	loadUsers: () => false,
 	// local auth should always be enabled, but check here to verify
 	initialized: false,
-	// TODO: fix typing
+
 	async initialize() {
 		if (toExport.initialized) {
 			return;
@@ -53,7 +67,7 @@ const toExport = {
 			log.error("None of the auth plugins is enabled");
 		}
 	},
-} as any;
+} as Module;
 
 function unimplemented(funcName: string) {
 	log.debug(

--- a/server/plugins/changelog.ts
+++ b/server/plugins/changelog.ts
@@ -60,7 +60,7 @@ async function fetch() {
 
 function updateVersions(response: Response<string>) {
 	let i: number;
-	let release: {tag_name: string; body_html: any; prerelease: boolean; html_url: any};
+	let release: {tag_name: string; body_html: string; prerelease: boolean; html_url: string};
 	let prerelease = false;
 
 	const body = JSON.parse(response.body);

--- a/server/plugins/inputs/connect.ts
+++ b/server/plugins/inputs/connect.ts
@@ -40,7 +40,7 @@ const input: PluginInputHandler = function (network, chan, cmd, args) {
 	}
 
 	const host = args[0];
-	this.connectToNetwork({host, port, tls});
+	this.connectToNetwork({host, port: Number(port), tls});
 
 	return true;
 };

--- a/server/plugins/irc-events/cap.ts
+++ b/server/plugins/irc-events/cap.ts
@@ -20,7 +20,7 @@ export default <IrcEventHandler>function (irc, network) {
 		}
 
 		const isSecure = irc.connection.transport.socket.encrypted;
-		const values = {} as Record<string, string>;
+		const values: Record<string, string> = {};
 
 		data.capabilities.sts.split(",").map((value: string) => {
 			const splitValue = value.split("=", 2);

--- a/server/plugins/irc-events/cap.ts
+++ b/server/plugins/irc-events/cap.ts
@@ -20,11 +20,11 @@ export default <IrcEventHandler>function (irc, network) {
 		}
 
 		const isSecure = irc.connection.transport.socket.encrypted;
-		const values = {} as any;
+		const values = {} as Record<string, string>;
 
-		data.capabilities.sts.split(",").map((value) => {
-			value = value.split("=", 2);
-			values[value[0]] = value[1];
+		data.capabilities.sts.split(",").map((value: string) => {
+			const splitValue = value.split("=", 2);
+			values[splitValue[0]] = splitValue[1];
 		});
 
 		if (isSecure) {

--- a/server/plugins/packages/publicClient.ts
+++ b/server/plugins/packages/publicClient.ts
@@ -18,7 +18,7 @@ export default class PublicClient {
 	 * @param {String} command - IRC command to run, this is in the same format that a client would send to the server (eg: JOIN #test)
 	 * @param {String} targetId - The id of the channel to simulate the command coming from. Replies will go to this channel if appropriate
 	 */
-	runAsUser(command: string, targetId: string) {
+	runAsUser(command: string, targetId: number) {
 		this.client.inputLine({target: targetId, text: command});
 	}
 

--- a/server/plugins/uploader.ts
+++ b/server/plugins/uploader.ts
@@ -9,6 +9,7 @@ import contentDisposition from "content-disposition";
 import type {Socket} from "socket.io";
 import {Request, Response} from "express";
 import NodeBuffer, {Buffer} from "buffer";
+import {Express} from "express-serve-static-core";
 
 // Map of allowed mime types to their respecive default filenames
 // that will be rendered in browser without forcing them to be downloaded
@@ -69,8 +70,9 @@ class Uploader {
 		return setTimeout(() => uploadTokens.delete(token), 60 * 1000);
 	}
 
-	// TODO: type
-	static router(this: void, express: any) {
+	static router(this: void, express: Express) {
+		// TODO: figure out if this is actually an issue
+		// eslint-disable-next-line @typescript-eslint/no-misused-promises
 		express.get("/uploads/:name/:slug*?", Uploader.routeGetFile);
 		express.post("/uploads/new/:token", Uploader.routeUploadFile);
 	}

--- a/server/server.ts
+++ b/server/server.ts
@@ -1089,7 +1089,8 @@ function performAuthentication(this: Socket, data: AuthPerformData) {
 		return;
 	}
 
-	void Auth.initialize().then(() => {
+	// eslint-disable-next-line @typescript-eslint/no-floating-promises
+	Auth.initialize().then(() => {
 		// Perform password checking
 		Auth.auth(manager, client, data.user, data.password, authCallback);
 	});

--- a/server/server.ts
+++ b/server/server.ts
@@ -1089,7 +1089,7 @@ function performAuthentication(this: Socket, data: AuthPerformData) {
 		return;
 	}
 
-	Auth.initialize().then(() => {
+	void Auth.initialize().then(() => {
 		// Perform password checking
 		Auth.auth(manager, client, data.user, data.password, authCallback);
 	});

--- a/shared/linkify.ts
+++ b/shared/linkify.ts
@@ -57,7 +57,8 @@ linkify.add("web+", {
 // See https://github.com/thelounge/thelounge/issues/2525
 //
 // We take the validation logic from linkify and just add our own
-// normalizer.
+// normalizer. This is pretty gross, since it depends on the internal
+// data structure of LinkifyIt.
 linkify.add("//", {
 	validate: (linkify as any).__schemas__["//"].validate,
 	normalize(match) {


### PR DESCRIPTION
As briefly discussed on IRC, I decided to take a swing at cleaning up some usage of explicit `any` in the typescript. I found a few places where the types were relatively straightforward to either manually derive or that they just needed to be imported from a library's types file. Happy to break this into further smaller PRs if desired.

One big weak spot right now in the code related to `any` usage is in `catch` statements, which are kind of all over the map with how they treat the `Error` type. TS best practices appears to be to never assert in the catch definition that a thrown value is an Error (since you can literally `throw` any value in javascript, including `null` and `undefined`), and instead always do explicit `typeof` in the catch body. Standardizing that across the codebase feels like a bigger undertaking that should have more input from the existing contributor core.