### PR TITLE
Make the actual host mask in whois more like the host mask.

### DIFF
--- a/client/components/MessageTypes/whois.vue
+++ b/client/components/MessageTypes/whois.vue
@@ -20,23 +20,31 @@
 			</dd>
 
 			<template v-if="message.whois.actual_hostname">
-				<dt>Actual host:</dt>
+				<dt>Actual host mask:</dt>
 				<dd class="hostmask">
+					<ParsedMessage
+						v-if="message.whois.actual_username"
+						:network="network"
+						:text="message.whois.actual_username + '@' + message.whois.actual_hostname"
+					/>
+					<ParsedMessage
+						v-else
+						:network="network"
+						:text="message.whois.ident + '@' + message.whois.actual_hostname"
+					/>
+				</dd>
+			</template>
+
+			<template v-if="message.whois.actual_ip">
+				<dt>IP address:</dt>
+				<dd>
 					<a
 						:href="'https://ipinfo.io/' + message.whois.actual_ip"
 						target="_blank"
 						rel="noopener"
 						>{{ message.whois.actual_ip }}</a
 					>
-					<i v-if="message.whois.actual_hostname != message.whois.actual_ip">
-						({{ message.whois.actual_hostname }})</i
-					>
 				</dd>
-			</template>
-
-			<template v-if="message.whois.actual_username">
-				<dt>Actual username:</dt>
-				<dd>{{ message.whois.actual_username }}</dd>
 			</template>
 
 			<template v-if="message.whois.real_name">


### PR DESCRIPTION
The current way the real hostname and IP are shown is annoying for opers as when we want to ban a user where the username is significant (e.g. IRCCloud) we can't just copy the user@host mask. Some servers (e.g. Libera.Chat) also just return an actual IP and no actual hostname.

This pull request makes the following changes:

1. Moves the IP address to its own field.
2. Always shows a `user@host` mask when the actual hostname numeric is sent even on IRCds that do not send a real username alongside the hostname in `RPL_WHOISACTUALLY`.
3. Renames the whois field to "Actual host mask" to match the "Host mask" field.

Before (4.5.0):
<img width="920" height="126" alt="Screenshot from 2026-06-23 12-22-02" src="https://github.com/user-attachments/assets/70d5a4b5-1c97-41ed-8ebb-b3a6973fae60" />

After (on a server that sends a real username, e.g. `testnet.inspircd.org`):
<img width="700" height="120" alt="Screenshot from 2026-06-23 12-33-50" src="https://github.com/user-attachments/assets/b68ebb52-64d1-4409-9c14-00920f63bc50" />

After on a server that only sends a real hostname, e.g. `irc.libera.chat`):
<img width="938" height="128" alt="Screenshot from 2026-06-23 12-24-14" src="https://github.com/user-attachments/assets/ef490cfd-8f5d-440f-84b7-026b22a7b09c" />
