### PR TITLE
Config reload fix for BSD

### DIFF
--- a/server/clientManager.ts
+++ b/server/clientManager.ts
@@ -87,26 +87,61 @@ class ClientManager {
 	}
 
 	autoloadUsers() {
+		const fullReload = _.debounce(
+			() => {
+				const loaded = this.clients.map((c) => c.name);
+				const updatedUsers = this.getUsers();
+
+				if (updatedUsers.length === 0) {
+					log.info(
+						`There are currently no users. Create one with ${colors.bold(
+							"thelounge add <name>"
+						)}.`
+					);
+				}
+
+				// Reload all users. Existing users will only have their passwords reloaded.
+				updatedUsers.forEach((name) => this.loadUser(name));
+
+				// Existing users removed since last time users were loaded
+				_.difference(loaded, updatedUsers).forEach((name) => {
+					const client = _.find(this.clients, {name});
+
+					if (client) {
+						client.quit(true);
+						this.clients = _.without(this.clients, client);
+						log.info(`User ${colors.bold(name)} disconnected and removed.`);
+					}
+				});
+			},
+			1000,
+			{maxWait: 10000}
+		);
 		fs.watch(Config.getUsersPath(), (_eventType, file) => {
-			if (!file || !file.endsWith(".json")) {
-				return;
-			}
+			// If the filename is null, the platform (e.g. BSD) does not report filenames in fs.watch
+			if (file === null) {
+				fullReload();
+			} else {
+				if (!file || !file.endsWith(".json")) {
+					return;
+				}
 
-			const name = file.slice(0, -5);
+				const name = file.slice(0, -5);
 
-			const userPath = Config.getUserConfigPath(name);
+				const userPath = Config.getUserConfigPath(name);
 
-			if (fs.existsSync(userPath)) {
-				this.loadUser(name);
-				return;
-			}
+				if (fs.existsSync(userPath)) {
+					this.loadUser(name);
+					return;
+				}
 
-			const client = _.find(this.clients, {name});
+				const client = _.find(this.clients, {name});
 
-			if (client) {
-				client.quit(true);
-				this.clients = _.without(this.clients, client);
-				log.info(`User ${colors.bold(name)} disconnected and removed.`);
+				if (client) {
+					client.quit(true);
+					this.clients = _.without(this.clients, client);
+					log.info(`User ${colors.bold(name)} disconnected and removed.`);
+				}
 			}
 		});
 	}


### PR DESCRIPTION
Commit c20e9d2 implements user reloading by relying on filename from fs.watch, but this breaks compatibility for BSD because Node.js only reports filenames on Windows, Linux, MacOS, and AIX.

This patch fixes it by doing a full reload again if the filename is null.