### PR TITLE
Fix Unicode nickname matching

### DIFF
--- a/client/js/helpers/ircmessageparser/findNames.ts
+++ b/client/js/helpers/ircmessageparser/findNames.ts
@@ -1,6 +1,6 @@
 import {Part} from "./merge";
 
-const nickRegExp = /([\w[\]\\`^{|}-]+)/g;
+const nickRegExp = /([\p{Letter}\p{Number}_[\]\\`^{|}-]+)/gu;
 
 export type NamePart = Part & {
 	nick: string;

--- a/server/models/network.ts
+++ b/server/models/network.ts
@@ -485,15 +485,15 @@ class Network {
 	setNick(this: Network, nick: string) {
 		this.nick = nick;
 		this.highlightRegex = new RegExp(
-			// Do not match characters and numbers (unless IRC color)
-			"(?:^|[^a-z0-9]|\x03[0-9]{1,2})" +
+			// Do not match letters and numbers (unless IRC color)
+			"(?:^|[^\\p{Letter}\\p{Number}]|\x03[0-9]{1,2})" +
 				// Escape nickname, as it may contain regex stuff
 				_.escapeRegExp(nick) +
-				// Do not match characters and numbers
-				"(?:[^a-z0-9]|$)",
+				// Do not match letters and numbers
+				"(?:[^\\p{Letter}\\p{Number}]|$)",
 
-			// Case insensitive search
-			"i"
+			// Case insensitive Unicode search
+			"iu"
 		);
 
 		if (this.keepNick === nick) {

--- a/server/plugins/irc-events/message.ts
+++ b/server/plugins/irc-events/message.ts
@@ -8,7 +8,8 @@ import {MessageType} from "../../../shared/types/msg";
 import {ChanType} from "../../../shared/types/chan";
 import {MessageEventArgs} from "irc-framework";
 
-const nickRegExp = /(?:\x03[0-9]{1,2}(?:,[0-9]{1,2})?)?([\w[\]\\`^{|}-]+)/g;
+const nickRegExp =
+	/(?:\x03[0-9]{1,2}(?:,[0-9]{1,2})?)?([\p{Letter}\p{Number}_[\]\\`^{|}-]+)/gu;
 
 type HandleInput = {
 	nick: string;

--- a/server/plugins/irc-events/message.ts
+++ b/server/plugins/irc-events/message.ts
@@ -8,8 +8,7 @@ import {MessageType} from "../../../shared/types/msg";
 import {ChanType} from "../../../shared/types/chan";
 import {MessageEventArgs} from "irc-framework";
 
-const nickRegExp =
-	/(?:\x03[0-9]{1,2}(?:,[0-9]{1,2})?)?([\p{Letter}\p{Number}_[\]\\`^{|}-]+)/gu;
+const nickRegExp = /(?:\x03[0-9]{1,2}(?:,[0-9]{1,2})?)?([\p{Letter}\p{Number}_[\]\\`^{|}-]+)/gu;
 
 type HandleInput = {
 	nick: string;

--- a/test/client/js/helpers/ircmessageparser/findNames.ts
+++ b/test/client/js/helpers/ircmessageparser/findNames.ts
@@ -76,4 +76,26 @@ describe("findNames", () => {
 
 		expect(actual).to.deep.equal(expected);
 	});
+
+	it("should not find nicks inside words with Unicode letters (issue #4930)", () => {
+		const actual = findNames("Dzięki D", ["D"]);
+
+		expect(actual).to.deep.equal([
+			{
+				start: 7,
+				end: 8,
+				nick: "D",
+			},
+		]);
+	});
+
+	it("should find Unicode and IRC nickname characters", () => {
+		const actual = findNames("Ądam42 foo_bar [nick]", ["Ądam42", "foo_bar", "[nick]"]);
+
+		expect(actual).to.deep.equal([
+			{start: 0, end: 6, nick: "Ądam42"},
+			{start: 7, end: 14, nick: "foo_bar"},
+			{start: 15, end: 21, nick: "[nick]"},
+		]);
+	});
 });

--- a/test/tests/nickhighlights.ts
+++ b/test/tests/nickhighlights.ts
@@ -58,4 +58,16 @@ describe("Nickname highlights", function () {
 		expect("lounge-bot, hello").to.not.match(network.highlightRegex as any);
 		expect("cool_person, hello").to.match(network.highlightRegex as any);
 	});
+
+	it("should respect Unicode word boundaries (issue #4930)", function () {
+		network.setNick("D");
+
+		expect("dzięki").to.not.match(network.highlightRegex as any);
+		expect("hello D").to.match(network.highlightRegex as any);
+		expect("D: hello").to.match(network.highlightRegex as any);
+
+		network.setNick("Ądam");
+
+		expect("hello ąDAM").to.match(network.highlightRegex as any);
+	});
 });


### PR DESCRIPTION
## What changed

- Match nickname tokens with Unicode letters and numbers while preserving IRC nickname characters.
- Use Unicode-aware word boundaries for nickname highlights.
- Add regression coverage for Polish text, Unicode nicknames, and existing IRC nickname characters.

## Why

The previous regular expressions used ASCII-only character classes. This caused a one-character nickname such as `D` to be detected inside words containing Polish diacritics, for example `dzięki`.

## Before / after

| Before (v4.5.2) | After (this PR) |
|:---:|:---:|
| ![Before](https://raw.githubusercontent.com/JamBalaya56562/thelounge/pr5121-assets/pr5121-before.png) | ![After](https://raw.githubusercontent.com/JamBalaya56562/thelounge/pr5121-assets/pr5121-after.png) |

| Scenario | Before | After |
|---|---|---|
| Nick `Ądam42` appears in a message | Not recognized as a nick — rendered as plain text (no color, not clickable) | Recognized and colored like any other nick |
| `Ćadam` / `adamć` with your nick `adam` | Falsely highlighted as a mention of you | Not highlighted |
| Genuine mention `hey adam` | Highlighted | Highlighted (no regression) |

<sub>Screenshots are a faithful reproduction rendered with TheLounge's real <code>client/css/style.css</code> and the actual old/new regexes (not a live IRC capture).</sub>

## Validation

- Direct Unicode nickname extraction and boundary checks with Node.js 24
- Full Vitest/lint suite not run because repository dependencies were unavailable and dependency installation stalled in the local environment

Fixes #4930
