### PR TITLE
Match custom highlights as a substring for scripts without word boundaries

### DIFF
--- a/server/client.ts
+++ b/server/client.ts
@@ -544,6 +544,13 @@ class Client {
 	}
 
 	compileCustomHighlights() {
+		// Scripts that do not delimit words with spaces or punctuation (CJK, Thai,
+		// Lao, Khmer, Myanmar, ...). Tokens containing such characters can appear in
+		// the middle of a run of text with no boundary around them, so they are
+		// matched as a plain substring instead of being wrapped in word boundaries.
+		const noWordBoundary =
+			/[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}\p{Script=Thai}\p{Script=Lao}\p{Script=Khmer}\p{Script=Myanmar}]/u;
+
 		function compileHighlightRegex(customHighlightString: string) {
 			if (typeof customHighlightString !== "string") {
 				return null;
@@ -559,12 +566,31 @@ class Client {
 				return null;
 			}
 
-			return new RegExp(
-				`(?:^|[ .,+!?|/:<>(){}'"@&~-])(?:${highlightsTokens.join(
-					"|"
-				)})(?:$|[ .,+!?|/:<>(){}'"-])`,
-				"i"
-			);
+			// Split tokens into those that need word boundaries (e.g. "foo", which
+			// should not match "football") and those that must match anywhere
+			// because their script has no word boundaries (e.g. "天気").
+			const boundaryTokens: string[] = [];
+			const substringTokens: string[] = [];
+
+			for (const token of highlightsTokens) {
+				(noWordBoundary.test(token) ? substringTokens : boundaryTokens).push(token);
+			}
+
+			const alternatives: string[] = [];
+
+			if (boundaryTokens.length > 0) {
+				alternatives.push(
+					`(?:^|[ .,+!?|/:<>(){}'"@&~-])(?:${boundaryTokens.join(
+						"|"
+					)})(?:$|[ .,+!?|/:<>(){}'"-])`
+				);
+			}
+
+			if (substringTokens.length > 0) {
+				alternatives.push(`(?:${substringTokens.join("|")})`);
+			}
+
+			return new RegExp(alternatives.join("|"), "i");
 		}
 
 		this.highlightRegex = compileHighlightRegex(this.config.clientSettings.highlights);

--- a/test/tests/customhighlights.ts
+++ b/test/tests/customhighlights.ts
@@ -38,8 +38,6 @@ describe("Custom highlights", function () {
 			"testfoo bar",
 			"fooö",
 			"wtf@all",
-			"foo고",
-			"test고",
 			"space",
 			"sp:ace",
 		];
@@ -67,6 +65,9 @@ describe("Custom highlights", function () {
 			"test 고",
 			"고!",
 			"www.고.com",
+			"foo고",
+			"test고",
+			"오늘고맙다",
 			"hey @Foo",
 			"hey ~Foo",
 			"hey +Foo",
@@ -84,8 +85,12 @@ describe("Custom highlights", function () {
 		}
 	});
 
-	it("should trim custom highlights in the compiled regex", function () {
-		expect(client.highlightRegex).to.match(/\(\?:foo\|@all\|sp ace\|고\)/);
+	it("should trim highlights and split them by word-boundary support", function () {
+		// Tokens whose script uses word boundaries (Latin, etc.) are wrapped in
+		// delimiter groups; tokens whose script does not (e.g. Hangul) are matched
+		// as a plain substring in a separate alternative.
+		expect(client.highlightRegex!.source).to.include("(?:foo|@all|sp ace)");
+		expect(client.highlightRegex!.source).to.include("(?:고)");
 	});
 
 	it("should NOT compile a regex", function () {
@@ -145,6 +150,79 @@ describe("Custom highlights", function () {
 
 		for (const teststring of teststrings) {
 			expect(teststring).to.not.match(client.highlightExceptionRegex!);
+		}
+	});
+});
+
+describe("Custom highlights with scripts that have no word boundaries", function () {
+	const logInfoStub = sinon.stub(log, "info");
+
+	const client = new Client(
+		{
+			clients: [],
+			getDataToSave() {
+				return {
+					newUser: "",
+					newHash: "",
+				};
+			},
+		} as any,
+		"test",
+		{
+			clientSettings: {
+				highlights: "foo, 天気, 고",
+				highlightExceptions: "고",
+			},
+		} as any
+	);
+	client.connect();
+	logInfoStub.restore();
+
+	it("should match CJK/Hangul highlights anywhere, without word boundaries", function () {
+		const teststrings = [
+			"今日はいい天気ですね", // 天気 embedded, no spaces
+			"天気",
+			"오늘고맙다", // 고 embedded
+			"test고",
+			"foo고",
+		];
+
+		for (const teststring of teststrings) {
+			expect(teststring).to.match(client.highlightRegex!);
+		}
+	});
+
+	it("should still require word boundaries for Latin highlights", function () {
+		// "foo" must not match inside "football"/"foobar" just because CJK tokens
+		// are present in the same highlight list.
+		const teststrings = ["football", "foobar", "testfoo", "barfoo"];
+
+		for (const teststring of teststrings) {
+			expect(teststring).to.not.match(client.highlightRegex!);
+		}
+	});
+
+	it("should highlight Latin tokens that are properly delimited", function () {
+		const teststrings = ["foo", "hey foo!", "<foo>"];
+
+		for (const teststring of teststrings) {
+			expect(teststring).to.match(client.highlightRegex!);
+		}
+	});
+
+	it("should NOT highlight strings without any token", function () {
+		const teststrings = ["bar", "hello world", "test"];
+
+		for (const teststring of teststrings) {
+			expect(teststring).to.not.match(client.highlightRegex!);
+		}
+	});
+
+	it("should apply substring matching to highlight exceptions too", function () {
+		const teststrings = ["오늘고맙다", "test고", "고"];
+
+		for (const teststring of teststrings) {
+			expect(teststring).to.match(client.highlightExceptionRegex!);
 		}
 	});
 });


### PR DESCRIPTION
## What changed

- Custom highlights **and** highlight exceptions now match keywords written in scripts **without word boundaries** — CJK (Han / Hiragana / Katakana / Hangul), Thai, Lao, Khmer, Myanmar — as a **plain substring**, automatically and **per keyword**.
- Latin / ASCII keywords keep the existing **word-boundary** behavior, so `foo` still does **not** match inside `football`.
- **No new setting.** Whether a keyword is matched as a substring is decided by the keyword's own script, so a mixed list like `foo, 天気` does the right thing for each keyword.
- Add regression tests covering CJK substring matching, Latin word-boundary safety, and highlight exceptions.

## Why

Custom highlights currently only match on **word boundaries** — the compiled regex wraps the tokens in explicit delimiter groups (`(?:^|[ .,+!?|/:<>(){}'"@&~-]) … (?:$|[ .,+!?|/:<>(){}'"-])`). Languages that do not delimit words with spaces or punctuation — Japanese and other CJK scripts — can never trigger a custom highlight for a keyword that sits in the middle of a sentence (e.g. `天気` inside `今日はいい天気ですね`).

The first version of this PR added an opt-in `highlightSubstring` setting that turned word boundaries off **globally**. As @deltamualpha [pointed out in review](https://github.com/thelounge/thelounge/pull/5122#issuecomment-4987587037), a global toggle does the wrong thing for a mixed keyword list: with `天気` and `foo`, turning substring matching on would also make `football` highlight — presumably not desired.

This version drops the setting and instead decides **per keyword**: a keyword is matched as a substring only when it contains characters from a script that has no word boundaries. So `天気` matches anywhere, while `foo` still requires boundaries — no configuration to get wrong, and no over-matching for Latin keywords.

## Before / after

| Before (word-boundary only) | After (this PR) |
|:---:|:---:|
| ![Before](https://raw.githubusercontent.com/JamBalaya56562/thelounge/pr5121-assets/hl4164-before.png) | ![After](https://raw.githubusercontent.com/JamBalaya56562/thelounge/pr5121-assets/hl4164-after.png) |

Custom highlight keyword: `天気`

| Message | Before | After |
|---|---|---|
| `今日はいい天気ですね` (keyword embedded, no spaces) | Not highlighted | **Highlighted** |
| `明日の 天気 はどうかな` (keyword with spaces) | Highlighted | Highlighted (no regression) |
| `おはよう、みなさん` (no keyword) | Not highlighted | Not highlighted |

### Latin keywords are unaffected — no over-matching

With a mixed list `foo, 天気`:

| Message | Result |
|---|---|
| `football` | Not highlighted (`foo` still needs a word boundary) |
| `hey foo!` | **Highlighted** |
| `今日はいい天気ですね` | **Highlighted** (`天気` matched as a substring) |

<sub>Screenshots are a faithful reproduction rendered with TheLounge's real <code>client/css/style.css</code> and the actual <code>compileCustomHighlights</code> logic (not a live IRC capture).</sub>

## Validation

- `npx vitest run test/tests/customhighlights.ts` — 11/11 pass (existing word-boundary cases, new CJK substring cases, Latin word-boundary safety, and exception cases).
- eslint / prettier clean on changed files; `tsc -p server/tsconfig.json` clean.

Fixes #4164
