### PR TITLE
Always wrap emoji with the emoji class (inside links, channels and styles)

### DIFF
--- a/client/js/helpers/parse.ts
+++ b/client/js/helpers/parse.ts
@@ -35,8 +35,11 @@ type StyledFragment = Fragment & {
 	strikethrough?: boolean;
 };
 
-// Create an HTML `span` with styling information for a given fragment
-function createFragment(fragment: StyledFragment): VNode | string | undefined {
+// Build the class list and inline style shared by styled and emoji fragments
+function fragmentStyle(fragment: StyledFragment): {
+	classes: string[];
+	style?: Record<string, string>;
+} {
 	const classes: string[] = [];
 
 	if (fragment.bold) {
@@ -67,13 +70,29 @@ function createFragment(fragment: StyledFragment): VNode | string | undefined {
 		classes.push("irc-monospace");
 	}
 
+	let style: Record<string, string> | undefined;
+
+	if (fragment.hexColor) {
+		style = {
+			color: `#${fragment.hexColor}`,
+		};
+
+		if (fragment.hexBgColor) {
+			style["background-color"] = `#${fragment.hexBgColor}`;
+		}
+	}
+
+	return {classes, style};
+}
+
+// Create an HTML `span` with styling information for a given fragment
+function createFragment(fragment: StyledFragment): VNode | string | undefined {
+	const {classes, style} = fragmentStyle(fragment);
+
 	const data: {
 		class?: string[];
 		style?: Record<string, string>;
-	} = {
-		class: undefined,
-		style: undefined,
-	};
+	} = {};
 
 	let hasData = false;
 
@@ -82,18 +101,77 @@ function createFragment(fragment: StyledFragment): VNode | string | undefined {
 		data.class = classes;
 	}
 
-	if (fragment.hexColor) {
+	if (style) {
 		hasData = true;
-		data.style = {
-			color: `#${fragment.hexColor}`,
-		};
-
-		if (fragment.hexBgColor) {
-			data.style["background-color"] = `#${fragment.hexBgColor}`;
-		}
+		data.style = style;
 	}
 
 	return hasData ? createElement("span", data, fragment.text) : fragment.text;
+}
+
+// Create an emoji `span` (always carrying the `emoji` class) for a fragment whose
+// text is a single emoji, merging in any surrounding style so that styled emoji
+// produce a single span instead of nested ones.
+function createEmojiFragment(fragment: StyledFragment): VNode {
+	const {classes, style} = fragmentStyle(fragment);
+	const emojiWithoutModifiers = (fragment.text || "").replace(emojiModifiersRegex, "");
+	const title = emojiMap[emojiWithoutModifiers]
+		? `Emoji: ${emojiMap[emojiWithoutModifiers]}`
+		: null;
+
+	const data: {
+		role: string;
+		"aria-label": string | null;
+		title: string | null;
+		class: string[];
+		style?: Record<string, string>;
+	} = {
+		role: "img",
+		"aria-label": title,
+		title: title,
+		class: ["emoji", ...classes],
+	};
+
+	if (style) {
+		data.style = style;
+	}
+
+	return createElement("span", data, fragment.text);
+}
+
+// Split a fragment into emoji and non-emoji runs so that emoji anywhere in the
+// visible text (including inside links, channels and nicks) get the `emoji` class,
+// while attributes such as a link's `href` remain untouched.
+function createFragments(fragment: StyledFragment): (VNode | string | undefined)[] {
+	const text = fragment.text;
+
+	if (!text) {
+		return [createFragment(fragment)];
+	}
+
+	const emojis = findEmoji(text);
+
+	if (emojis.length === 0) {
+		return [createFragment(fragment)];
+	}
+
+	const result: (VNode | string | undefined)[] = [];
+	let position = 0;
+
+	for (const emoji of emojis) {
+		if (emoji.start > position) {
+			result.push(createFragment({...fragment, text: text.slice(position, emoji.start)}));
+		}
+
+		result.push(createEmojiFragment({...fragment, text: text.slice(emoji.start, emoji.end)}));
+		position = emoji.end;
+	}
+
+	if (position < text.length) {
+		result.push(createFragment({...fragment, text: text.slice(position)}));
+	}
+
+	return result;
 }
 
 // Transform an IRC message potentially filled with styling control codes, URLs,
@@ -112,18 +190,15 @@ function parse(text: string, message?: ClientMessage, network?: ClientNetwork) {
 		: ["!", "@", "%", "+"];
 	const channelParts = findChannels(cleanText, channelPrefixes, userModes);
 	const linkParts = findLinks(cleanText);
-	const emojiParts = findEmoji(cleanText);
 	const nameParts = findNames(cleanText, message ? message.users || [] : []);
 
-	const parts = (channelParts as MergedParts)
-		.concat(linkParts)
-		.concat(emojiParts)
-		.concat(nameParts);
+	const parts = (channelParts as MergedParts).concat(linkParts).concat(nameParts);
 
 	// Merge the styling information with the channels / URLs / nicks / text objects and
-	// generate HTML strings with the resulting fragments
+	// generate HTML strings with the resulting fragments. Emoji are wrapped at the
+	// fragment level so they keep the `emoji` class even inside links, channels and nicks.
 	return merge(parts, styleFragments, cleanText).map((textPart) => {
-		const fragments = textPart.fragments.map((fragment) => createFragment(fragment));
+		const fragments = textPart.fragments.flatMap((fragment) => createFragments(fragment));
 
 		// Wrap these potentially styled fragments with links and channel buttons
 		if (textPart.link) {
@@ -181,22 +256,6 @@ function parse(text: string, message?: ClientMessage, network?: ClientNetwork) {
 				{
 					default: () => fragments,
 				}
-			);
-		} else if (textPart.emoji) {
-			const emojiWithoutModifiers = textPart.emoji.replace(emojiModifiersRegex, "");
-			const title = emojiMap[emojiWithoutModifiers]
-				? `Emoji: ${emojiMap[emojiWithoutModifiers]}`
-				: null;
-
-			return createElement(
-				"span",
-				{
-					class: ["emoji"],
-					role: "img",
-					"aria-label": title,
-					title: title,
-				},
-				fragments
 			);
 		} else if (textPart.nick) {
 			return createElement(

--- a/test/client/js/helpers/parse.ts
+++ b/test/client/js/helpers/parse.ts
@@ -470,25 +470,25 @@ describe("IRC formatted message parser", () => {
 			expected: "\u{2695}", // this does not match because emoji-regex expects \uFE0F as per the emoji specification
 		},
 		{
-			// FIXME: These multiple `span`s should be optimized into a single one. See https://github.com/thelounge/thelounge/issues/1783
+			// Emoji combined with a style are merged into a single span. See https://github.com/thelounge/thelounge/issues/1783
 			name: "wrapped in style",
 			input: "Super \x034💚 green!",
 			expected:
-				'Super <span role="img" aria-label="Emoji: green heart" title="Emoji: green heart" class="emoji"><span class="irc-fg4">💚</span></span><span class="irc-fg4"> green!</span>',
+				'Super <span role="img" aria-label="Emoji: green heart" title="Emoji: green heart" class="emoji irc-fg4">💚</span><span class="irc-fg4"> green!</span>',
 		},
 		{
+			// Emoji inside a URL's visible text is wrapped, but the href is left untouched. See https://github.com/thelounge/thelounge/issues/1784
 			name: "wrapped in URLs",
 			input: "https://i.❤️.thelounge.chat",
-			// FIXME: Emoji in text should be `<span class="emoji">❤️</span>`. See https://github.com/thelounge/thelounge/issues/1784
 			expected:
-				'<a href="https://i.❤️.thelounge.chat" dir="auto" target="_blank" rel="noopener">https://i.❤️.thelounge.chat</a>',
+				'<a href="https://i.❤️.thelounge.chat" dir="auto" target="_blank" rel="noopener">https://i.<span role="img" aria-label="Emoji: red heart" title="Emoji: red heart" class="emoji">❤️</span>.thelounge.chat</a>',
 		},
 		{
+			// Emoji inside a channel name is wrapped too. See https://github.com/thelounge/thelounge/issues/1784
 			name: "wrapped in channels",
 			input: "#i❤️thelounge",
-			// FIXME: Emoji in text should be `<span class="emoji">❤️</span>`. See https://github.com/thelounge/thelounge/issues/1784
 			expected:
-				'<span dir="auto" role="button" tabindex="0" class="inline-channel">#i❤️thelounge</span>',
+				'<span dir="auto" role="button" tabindex="0" class="inline-channel">#i<span role="img" aria-label="Emoji: red heart" title="Emoji: red heart" class="emoji">❤️</span>thelounge</span>',
 		},
 	].forEach(({name, input, expected}) => {
 		it(`should find emoji: ${name}`, () => {


### PR DESCRIPTION
## What changed

Emoji were only wrapped in `<span class="emoji">` at the **part** level, so an emoji
that fell inside a link, channel name, or nick lost the `emoji` class and rendered at the
normal font size instead of the enlarged emoji size. Emoji combined with an IRC color also
produced nested spans.

This moves emoji wrapping to the **fragment (text-run) level** in `client/js/helpers/parse.ts`:
each styled fragment is split into emoji and non-emoji runs, and emoji runs are wrapped with
the `emoji` class merged with any surrounding style. As a result:

- Emoji keep the `emoji` class inside links, channels and nicks (**#1784**).
- A link's `href` is unaffected — the emoji span only goes into the visible text.
- Styled emoji collapse from nested spans into a single `<span class="emoji irc-fgN">` (**#1783**).

## Why

`.emoji` bumps emoji to `font-size: 1.4em`. Without the class, emoji inside a channel/link
stayed at `1em` and looked noticeably smaller than emoji elsewhere in the message.

## Before / after

| Before | After |
|:---:|:---:|
| ![Before](https://raw.githubusercontent.com/JamBalaya56562/thelounge/pr5121-assets/emoji1784-before.png) | ![After](https://raw.githubusercontent.com/JamBalaya56562/thelounge/pr5121-assets/emoji1784-after.png) |

| Case | Before | After |
|---|---|---|
| Emoji in a channel `#i❤️thelounge` | `❤️` unwrapped, renders at 1em (small) | `❤️` wrapped in `.emoji`, 1.4em |
| Emoji in a link `https://i.❤️.thelounge.chat` | `❤️` unwrapped in link text | `❤️` wrapped in link text; `href` unchanged |
| Emoji + color `\x034💚` | `<span class="emoji"><span class="irc-fg4">💚</span></span>` | `<span class="emoji irc-fg4">💚</span>` |

<sub>Screenshots are a faithful reproduction rendered with TheLounge's real <code>client/css/style.css</code> and the exact HTML emitted by <code>parse()</code> before/after the fix (not a live IRC capture).</sub>

## Tests / validation

- Updated the three FIXME-marked cases in `test/client/js/helpers/parse.ts` to the corrected
  output for #1784 and #1783.
- Verified the actual rendered HTML of `parse()` (via `ParsedMessage.vue`) for emoji inside
  links, channels, styled text, multiple emoji per link, and standalone emoji.

> Note: the `test/client/js/helpers/**` parser tests are not currently matched by the vitest
> `include` globs (only `*Test.ts` / `test/tests/**` are), so this suite is not run by CI today.
> The expected values are updated to reflect correct behavior regardless. Wiring these tests
> back into CI is a separate change and out of scope here.

Fixes #1784
Fixes #1783
