### PR TITLE
send network name in LockedConfigNetDefaults

### DIFF
--- a/server/server.ts
+++ b/server/server.ts
@@ -933,7 +933,7 @@ function getClientConfiguration(): SharedConfiguration | LockedSharedConfigurati
 
 	// Only send defaults that are visible on the client
 	const defaults: LockedConfigNetDefaults = {
-		..._.omit(Config.values.defaults, ["host", "name", "port", "tls", "rejectUnauthorized"]),
+		..._.omit(Config.values.defaults, ["host", "port", "tls", "rejectUnauthorized"]),
 		...defaultsOverride,
 	};
 

--- a/shared/types/config.ts
+++ b/shared/types/config.ts
@@ -36,7 +36,7 @@ export type ConfigNetDefaults = {
 };
 export type LockedConfigNetDefaults = Omit<
 	ConfigNetDefaults,
-	"host" | "name" | "port" | "tls" | "rejectUnauthorized"
+	"host" | "port" | "tls" | "rejectUnauthorized"
 >;
 
 export type LockedSharedConfiguration = SharedConfigurationBase & {


### PR DESCRIPTION
The commit 3f2697cca6916fba28ccf93c650177fea9cfd443 was confused and removed the name from the settings sent to the client when locknetwork was true.

This was noted as odd as the time and is wrong so revert that bit.

Fixes: https://github.com/thelounge/thelounge/issues/5131