### PR TITLE
Show locked network name in Connect header for private mode too

### DIFF
--- a/client/components/NetworkForm.vue
+++ b/client/components/NetworkForm.vue
@@ -12,7 +12,7 @@
 				<template v-else>
 					Connect
 					<template
-						v-if="config?.lockNetwork && store?.state.serverConfiguration?.public"
+						v-if="config?.lockNetwork"
 					>
 						to {{ defaults.name }}
 					</template>


### PR DESCRIPTION
The Connect header only showed the network name in public mode. Private lockNetwork mode has a fixed network too, so show the name there as well.