### PR TITLE
Don't crash when a socket detaches during token generation

### DIFF
--- a/server/server.ts
+++ b/server/server.ts
@@ -881,7 +881,18 @@ function initializeClient(
 	} else if (!token) {
 		client.generateToken((newToken) => {
 			token = client.calculateTokenHash(newToken);
-			client.attachedClients[socket.id].token = token;
+
+			// generateToken is asynchronous, so the socket may have disconnected while it
+			// was running, in which case clientDetach has already removed the attached
+			// client. There is nothing left to hand the token to: the session would record
+			// a connection that is gone and sendInitEvent would emit into a closed socket.
+			const attachedClient = client.attachedClients[socket.id];
+
+			if (!attachedClient) {
+				return;
+			}
+
+			attachedClient.token = token;
 
 			client.updateSession(token, getClientIp(socket), socket.request);
 			sendInitEvent(newToken);


### PR DESCRIPTION
generateToken is asynchronous, so clientDetach can delete the attached client before its callback runs. Assigning the token then throws from a threadpool callback, which nothing catches, and the process exits.

Client.open() already guards this (#1995, #2831), this is the same bug at a second site which the guard never got applied to.