### PR TITLE
Add crossorigin attribute to manifest link so it work with CF tunnels

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -23,7 +23,7 @@
 		<!-- Safari pinned tab icon -->
 		<link rel="mask-icon" href="img/icon-black-transparent-bg.svg" color="#415364" />
 
-		<link rel="manifest" href="thelounge.webmanifest" />
+		<link rel="manifest" href="thelounge.webmanifest" crossorigin="use-credentials" />
 
 		<!-- iPhone 4, iPhone 4s, iPhone 5, iPhone 5c, iPhone 5s, iPhone 6, iPhone 6s, iPhone 7, iPhone 7s, iPhone8 -->
 		<link rel="apple-touch-icon" sizes="120x120" href="img/logo-grey-bg-120x120px.png" />


### PR DESCRIPTION
Reason: https://github.com/cloudflare/cloudflare-docs/blob/production/src/content/docs/cloudflare-one/access-controls/applications/http-apps/authorization-cookie/cors.mdx example: https://github.com/open-webui/open-webui/issues/1538

So with the help of chatgpt i saw 
<img width="675" height="50" alt="image" src="https://github.com/user-attachments/assets/3a501177-54b5-44db-900c-8bb38c3ace4d" />

And it's fixed with this small change:
<img width="1462" height="221" alt="image" src="https://github.com/user-attachments/assets/a30fcbfc-1d75-4bf7-ad89-152da3ce1a85" />
